### PR TITLE
Add table client

### DIFF
--- a/docs/module_template.md
+++ b/docs/module_template.md
@@ -76,7 +76,7 @@ modules:
     # Add module-specific helpers here
 
 
-    def run(module, snow_client):
+    def run(module, table_client):
         # Implementation here.
 
         return changed, record, dict(before=a, after=b)
@@ -97,8 +97,9 @@ modules:
         try:
             # HTTP client construction
             snow_client = client.Client(**module.params["instance"])
+            table_client = table.TableClient(snow_client)
 
-            changed, record, diff = run(module, snow_client)
+            changed, record, diff = run(module, table_client)
             module.exit_json(changed=changed, record=record, diff=diff)
         except ServiceNowError as e:
             module.fail_json(msg=str(e))
@@ -117,7 +118,7 @@ not modify the instance state. The documentation part should still follow the
 same structure, but the `run` method and the last part of the `main` method are
 a bit simpler:
 
-    def run(module, snow_client):
+    def run(module, table_client):
         # Implementation here thar produces a list of records. Most of the
         # time, this will be the `result` part of the API response.
 
@@ -139,8 +140,9 @@ a bit simpler:
         try:
             # HTTP client construction
             snow_client = client.Client(**module.params["instance"])
+            table_client = table.TableClient(snow_client)
 
-            records = run(module, client)
+            records = run(module, table_client)
             module.exit_json(changed=False, records=records)
         except ServiceNowError as e:
             module.fail_json(msg=str(e))
@@ -177,7 +179,7 @@ The purpose of the main method is two-fold:
    access to remote services.
 
 2. __Construction of the HTTP client__. Once the validation is over, the
-   `main` method must construct the HTTP client.
+   `main` method must construct the HTTP and/or table client.
 
 Once the `main` method constructs the Ansible module and validates its
 parameters, it needs to create the HTTP client. After that, it
@@ -199,7 +201,7 @@ is to delegate the real work to more specialized functions if required.
 The `run` function receives two parameters:
 
 1. an `AnsibleModule` instance;
-2. a `Client` instance.
+2. a `Client` or `TableClient` instance.
 
 Why do we need a module instance and not just parameters and check mode
 boolean? Most of the time, the answer to that question is "we do not". But

--- a/docs/unit_testing.md
+++ b/docs/unit_testing.md
@@ -49,7 +49,7 @@ general, each test file should have the following structure:
 
 
     class TestRun:
-        def test_run_state_absent(self, create_module, client):
+        def test_run_state_absent(self, create_module, table_client):
             module = create_module(
                 params=dict(
                     instance=dict(host="my.host.name", username="user", password="pass"),
@@ -57,7 +57,7 @@ general, each test file should have the following structure:
                 )
             )
             # Configure the client mock as appropriate
-            client.get.return_value.json = {"result": "data"}
+            table_client.get_record.return_value = {"record": "data"}
 
             changed, response, diff = my_mod.run(module, client)
 
@@ -132,7 +132,7 @@ a look at existing tests.
 
 ## Testing methods that require an HTTP client instance
 
-If we need to mock HTTP client responses or make assertions about the
-client's methods that were called (and their arguments), we can use the
-`client` fixture. The fixture returns a `Mock` instance with the same
-spec as our `Client`'s.
+If we need to mock HTTP client responses or make assertions about the client's
+methods that were called (and their arguments), we can use the `client` and
+`table_client` fixtures. The fixtures return a `Mock` instance with the same
+spec as the client class they substitute.

--- a/plugins/module_utils/client.py
+++ b/plugins/module_utils/client.py
@@ -121,25 +121,25 @@ class Client:
             return resp
         raise UnexpectedAPIResponse(resp.status, resp.data)
 
-    def post(self, path, data):
-        resp = self.request("POST", path, data=data)
+    def post(self, path, data, query=None):
+        resp = self.request("POST", path, data=data, query=query)
         if resp.status == 201:
             return resp
         raise UnexpectedAPIResponse(resp.status, resp.data)
 
-    def patch(self, path, data):
-        resp = self.request("PATCH", path, data=data)
+    def patch(self, path, data, query=None):
+        resp = self.request("PATCH", path, data=data, query=query)
         if resp.status == 200:
             return resp
         raise UnexpectedAPIResponse(resp.status, resp.data)
 
-    def put(self, path, data):
-        resp = self.request("PUT", path, data=data)
+    def put(self, path, data, query=None):
+        resp = self.request("PUT", path, data=data, query=query)
         if resp.status == 200:
             return resp
         raise UnexpectedAPIResponse(resp.status, resp.data)
 
-    def delete(self, path):
-        resp = self.request("DELETE", path)
+    def delete(self, path, query=None):
+        resp = self.request("DELETE", path, query=query)
         if resp.status != 204:
             raise UnexpectedAPIResponse(resp.status, resp.data)

--- a/plugins/module_utils/table.py
+++ b/plugins/module_utils/table.py
@@ -15,52 +15,51 @@ def _path(table, *subpaths):
     return "/".join(("table", table) + subpaths)
 
 
-def _flatten(data):
-    result = {}
-    for k, v in data.items():
-        if isinstance(v, dict) and "link" in v:
-            result[k] = v["value"]
-        else:
-            result[k] = v
-    return result
+def _query(original=None):
+    # Flatten the response (skip embedded links to resources)
+    return dict(original or {}, sysparm_exclude_reference_link="true")
 
 
-def list_records(client, table, query=None):
-    return [_flatten(r) for r in client.get(_path(table), query=query).json["result"]]
+class TableClient:
+    def __init__(self, client):
+        self.client = client
 
+    def list_records(self, table, query=None):
+        return self.client.get(_path(table), query=_query(query)).json["result"]
 
-def get_record(client, table, query, must_exist=False):
-    records = list_records(client, table, query)
+    def get_record(self, table, query, must_exist=False):
+        records = self.list_records(table, query)
 
-    if len(records) > 1:
-        raise errors.ServiceNowError(
-            "{0} {1} records match the {2} query.".format(len(records), table, query)
-        )
+        if len(records) > 1:
+            raise errors.ServiceNowError(
+                "{0} {1} records match the {2} query.".format(
+                    len(records), table, query
+                )
+            )
 
-    if must_exist and not records:
-        raise errors.ServiceNowError(
-            "No {0} records match the {1} query.".format(table, query)
-        )
+        if must_exist and not records:
+            raise errors.ServiceNowError(
+                "No {0} records match the {1} query.".format(table, query)
+            )
 
-    return records[0] if records else None
+        return records[0] if records else None
 
+    def create_record(self, table, payload, check_mode):
+        if check_mode:
+            # Approximate the result using the payload.
+            return payload
 
-def create_record(client, table, payload, check_mode):
-    if check_mode:
-        # Approximate the result using the payload.
-        return payload
-    return _flatten(client.post(_path(table), payload).json["result"])
+        return self.client.post(_path(table), payload, query=_query()).json["result"]
 
+    def update_record(self, table, record, payload, check_mode):
+        if check_mode:
+            # Approximate the result by manually patching the existing state.
+            return dict(record, **payload)
 
-def update_record(client, table, record, payload, check_mode):
-    if check_mode:
-        # Approximate the result by manually patching the existing state.
-        return dict(record, **payload)
-    return _flatten(
-        client.patch(_path(table, record["sys_id"]), payload).json["result"]
-    )
+        return self.client.patch(
+            _path(table, record["sys_id"]), payload, query=_query()
+        ).json["result"]
 
-
-def delete_record(client, table, record, check_mode):
-    if not check_mode:
-        client.delete(_path(table, record["sys_id"]))
+    def delete_record(self, table, record, check_mode):
+        if not check_mode:
+            self.client.delete(_path(table, record["sys_id"]))

--- a/plugins/modules/change_request_info.py
+++ b/plugins/modules/change_request_info.py
@@ -169,10 +169,10 @@ from ansible.module_utils.basic import AnsibleModule
 from ..module_utils import arguments, client, errors, utils, table
 
 
-def run(module, snow_client):
+def run(module, table_client):
     query = utils.filter_dict(module.params, "sys_id", "number")
 
-    return table.list_records(snow_client, "change_request", query)
+    return table_client.list_records("change_request", query)
 
 
 def main():
@@ -185,7 +185,8 @@ def main():
 
     try:
         snow_client = client.Client(**module.params["instance"])
-        records = run(module, snow_client)
+        table_client = table.TableClient(snow_client)
+        records = run(module, table_client)
         module.exit_json(changed=False, records=records)
     except errors.ServiceNowError as e:
         module.fail_json(msg=str(e))

--- a/plugins/modules/incident_info.py
+++ b/plugins/modules/incident_info.py
@@ -156,9 +156,10 @@ from ansible.module_utils.basic import AnsibleModule
 from ..module_utils import arguments, client, errors, table, utils
 
 
-def run(module, snow_client):
+def run(module, table_client):
     query = utils.filter_dict(module.params, "sys_id", "number")
-    return table.list_records(snow_client, "incident", query=query)
+
+    return table_client.list_records("incident", query)
 
 
 def main():
@@ -171,7 +172,8 @@ def main():
 
     try:
         snow_client = client.Client(**module.params["instance"])
-        records = run(module, snow_client)
+        table_client = table.TableClient(snow_client)
+        records = run(module, table_client)
         module.exit_json(changed=False, records=records)
     except errors.ServiceNowError as e:
         module.fail_json(msg=str(e))

--- a/plugins/modules/problem_info.py
+++ b/plugins/modules/problem_info.py
@@ -161,10 +161,10 @@ from ansible.module_utils.basic import AnsibleModule
 from ..module_utils import arguments, client, errors, utils, table
 
 
-def run(module, snow_client):
+def run(module, table_client):
     query = utils.filter_dict(module.params, "sys_id", "number")
 
-    return table.list_records(snow_client, "problem", query)
+    return table_client.list_records("problem", query)
 
 
 def main():
@@ -177,7 +177,8 @@ def main():
 
     try:
         snow_client = client.Client(**module.params["instance"])
-        records = run(module, snow_client)
+        table_client = table.TableClient(snow_client)
+        records = run(module, table_client)
         module.exit_json(changed=False, records=records)
     except errors.ServiceNowError as e:
         module.fail_json(msg=str(e))

--- a/tests/unit/plugins/conftest.py
+++ b/tests/unit/plugins/conftest.py
@@ -16,11 +16,17 @@ from ansible.module_utils import basic
 from ansible.module_utils._text import to_bytes
 
 from ansible_collections.servicenow.itsm.plugins.module_utils.client import Client
+from ansible_collections.servicenow.itsm.plugins.module_utils.table import TableClient
 
 
 @pytest.fixture
 def client(mocker):
     return mocker.Mock(spec=Client)
+
+
+@pytest.fixture
+def table_client(mocker):
+    return mocker.Mock(spec=TableClient)
 
 
 @pytest.fixture

--- a/tests/unit/plugins/module_utils/test_client.py
+++ b/tests/unit/plugins/module_utils/test_client.py
@@ -257,6 +257,15 @@ class TestClientGet:
         with pytest.raises(errors.UnexpectedAPIResponse, match="forbidden"):
             c.get("table/incident/1")
 
+    def test_query(self, mocker):
+        c = client.Client("instance.com", "user", "pass")
+        request_mock = mocker.patch.object(c, "request")
+        request_mock.return_value = client.Response(200, '{"incident": 1}', None)
+
+        c.get("table/incident/1", query=dict(a="1"))
+
+        request_mock.assert_called_with("GET", "table/incident/1", query=dict(a="1"))
+
 
 class TestClientPost:
     def test_ok(self, mocker):
@@ -277,6 +286,17 @@ class TestClientPost:
 
         with pytest.raises(errors.UnexpectedAPIResponse, match="bad request"):
             c.post("table/incident", {"some": "data"})
+
+    def test_query(self, mocker):
+        c = client.Client("instance.com", "user", "pass")
+        request_mock = mocker.patch.object(c, "request")
+        request_mock.return_value = client.Response(201, '{"incident": 1}')
+
+        c.post("table/incident", {"some": "data"}, query={"b": "3"})
+
+        request_mock.assert_called_with(
+            "POST", "table/incident", data=dict(some="data"), query=dict(b="3")
+        )
 
 
 class TestClientPatch:
@@ -299,6 +319,17 @@ class TestClientPatch:
         with pytest.raises(errors.UnexpectedAPIResponse, match="bad request"):
             c.patch("table/incident/1", {"some": "data"})
 
+    def test_query(self, mocker):
+        c = client.Client("instance.com", "user", "pass")
+        request_mock = mocker.patch.object(c, "request")
+        request_mock.return_value = client.Response(200, '{"incident": 1}')
+
+        c.patch("table/incident/1", {"some": "data"}, query={"g": "f"})
+
+        request_mock.assert_called_with(
+            "PATCH", "table/incident/1", data=dict(some="data"), query=dict(g="f")
+        )
+
 
 class TestClientPut:
     def test_ok(self, mocker):
@@ -320,6 +351,17 @@ class TestClientPut:
         with pytest.raises(errors.UnexpectedAPIResponse, match="bad request"):
             c.put("table/incident/1", {"some": "data"})
 
+    def test_query(self, mocker):
+        c = client.Client("instance.com", "user", "pass")
+        request_mock = mocker.patch.object(c, "request")
+        request_mock.return_value = client.Response(200, '{"incident": 1}')
+
+        c.put("table/incident/1", {"some": "data"}, query={"j": "i"})
+
+        request_mock.assert_called_with(
+            "PUT", "table/incident/1", data=dict(some="data"), query=dict(j="i")
+        )
+
 
 class TestClientDelete:
     def test_ok(self, mocker):
@@ -336,3 +378,12 @@ class TestClientDelete:
 
         with pytest.raises(errors.UnexpectedAPIResponse, match="not found"):
             c.delete("table/resource/1")
+
+    def test_query(self, mocker):
+        c = client.Client("instance.com", "user", "pass")
+        request_mock = mocker.patch.object(c, "request")
+        request_mock.return_value = client.Response(204, {})
+
+        c.delete("table/resource/1", query=dict(x="y"))
+
+        request_mock.assert_called_with("DELETE", "table/resource/1", query=dict(x="y"))

--- a/tests/unit/plugins/modules/test_change_request_info.py
+++ b/tests/unit/plugins/modules/test_change_request_info.py
@@ -46,7 +46,7 @@ class TestMain:
 
 
 class TestRun:
-    def test_run(self, create_module, client):
+    def test_run(self, create_module, table_client):
         module = create_module(
             params=dict(
                 instance=dict(host="my.host.name", username="user", password="pass"),
@@ -54,11 +54,11 @@ class TestRun:
                 number="n",
             )
         )
-        client.get.return_value.json = {"result": [dict(p=1), dict(q=2), dict(r=3)]}
+        table_client.list_records.return_value = [dict(p=1), dict(q=2), dict(r=3)]
 
-        change_requests = change_request_info.run(module, client)
+        change_requests = change_request_info.run(module, table_client)
 
-        client.get.assert_called_once_with(
-            "table/change_request", query=dict(number="n")
+        table_client.list_records.assert_called_once_with(
+            "change_request", dict(number="n")
         )
         assert change_requests == [dict(p=1), dict(q=2), dict(r=3)]

--- a/tests/unit/plugins/modules/test_incident_info.py
+++ b/tests/unit/plugins/modules/test_incident_info.py
@@ -46,7 +46,7 @@ class TestMain:
 
 
 class TestRun:
-    def test_run(self, create_module, client):
+    def test_run(self, create_module, table_client):
         module = create_module(
             params=dict(
                 instance=dict(host="my.host.name", username="user", password="pass"),
@@ -54,11 +54,11 @@ class TestRun:
                 number="INC001",
             )
         )
-        client.get.return_value.json = {"result": [dict(p=1), dict(q=2), dict(r=3)]}
+        table_client.list_records.return_value = [dict(p=1), dict(q=2), dict(r=3)]
 
-        records = incident_info.run(module, client)
+        records = incident_info.run(module, table_client)
 
-        client.get.assert_called_once_with(
-            "table/incident", query=dict(number="INC001")
+        table_client.list_records.assert_called_once_with(
+            "incident", dict(number="INC001")
         )
         assert records == [dict(p=1), dict(q=2), dict(r=3)]

--- a/tests/unit/plugins/modules/test_problem_info.py
+++ b/tests/unit/plugins/modules/test_problem_info.py
@@ -46,7 +46,7 @@ class TestMain:
 
 
 class TestRun:
-    def test_run(self, create_module, client):
+    def test_run(self, create_module, table_client):
         module = create_module(
             params=dict(
                 instance=dict(host="my.host.name", username="user", password="pass"),
@@ -54,9 +54,9 @@ class TestRun:
                 number="n",
             )
         )
-        client.get.return_value.json = {"result": [dict(p=1), dict(q=2), dict(r=3)]}
+        table_client.list_records.return_value = [dict(p=1), dict(q=2), dict(r=3)]
 
-        problems = problem_info.run(module, client)
+        problems = problem_info.run(module, table_client)
 
-        client.get.assert_called_once_with("table/problem", query=dict(number="n"))
+        table_client.list_records.assert_called_once_with("problem", dict(number="n"))
         assert problems == [dict(p=1), dict(q=2), dict(r=3)]


### PR DESCRIPTION
Table client adds another abstraction layer between the module's code and ServiceNow API. It serves the same purpose as the table helper functions we used before, but it better encapsulates the behavior, which makes testing things a lot easier.