### PR TITLE
Add payload mapper

### DIFF
--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -26,3 +26,39 @@ def is_superset(superset, candidate):
             return False
 
     return True
+
+
+class PayloadMapper:
+    def __init__(self, mapping):
+        # Convert
+        #   dict(a=[("s1", "a1"), ("s2", "a2")], b=[("s3", "a3")])
+        # to
+        #   _to_ansible == dict(a=dict(s1="a1", s2="a2"), b=dict(s3="a3"))
+        #   _to_snow == dict(a=dict(a1="s1", a2="s2"), b=dict(a3="s3"))
+        #
+        # This allows efficient transformation of our internal values to ServiceNow
+        # equivalents.
+
+        self._to_ansible = {}
+        self._to_snow = {}
+
+        for key, value_map in mapping.items():
+            self._to_ansible[key] = dict(value_map)
+            self._to_snow[key] = dict(
+                (ansible_val, snow_val) for snow_val, ansible_val in value_map
+            )
+
+    def _transform(self, mapping, data):
+        result = {}
+        for k, v in data.items():
+            if k in mapping:
+                result[k] = mapping[k][v]
+            else:
+                result[k] = v
+        return result
+
+    def to_ansible(self, snow_data):
+        return self._transform(self._to_ansible, snow_data)
+
+    def to_snow(self, ansible_data):
+        return self._transform(self._to_snow, ansible_data)

--- a/tests/unit/plugins/module_utils/test_utils.py
+++ b/tests/unit/plugins/module_utils/test_utils.py
@@ -54,3 +54,23 @@ class TestIsSupertset:
     )
     def test_not_a_superset(self, superset, candidate):
         assert utils.is_superset(superset, candidate) is False
+
+
+class TestPayloadMapper:
+    def test_to_ansible(self):
+        mapper = utils.PayloadMapper(dict(a=[(1, 2), (3, 4)], b=[(5, 6)]))
+
+        assert dict(a=4, b=6, c=7) == mapper.to_ansible(dict(a=3, b=5, c=7))
+
+    def test_to_snow(self):
+        mapper = utils.PayloadMapper(dict(a=[(1, 2), (3, 4)], b=[(5, 6)]))
+
+        assert dict(a=1, b=5, c=7) == mapper.to_snow(dict(a=2, b=6, c=7))
+
+    @pytest.mark.parametrize(
+        "data", [dict(), dict(a=1), dict(a=1, b=2), dict(c=3), dict(a=2, c=5)]
+    )
+    def test_to_ansible_is_inverse_of_to_snow(self, data):
+        mapper = utils.PayloadMapper(dict(a=[(1, "a1"), (2, "a2")], b=[(2, "b2")]))
+
+        assert data == mapper.to_snow(mapper.to_ansible(data))


### PR DESCRIPTION
Because certain values that ServiceNow API returns are far from human-readable. In order to get around this problem, we created a two-way mapping helper that we can use to transform module parameters into ServiceNow API payloads and back.

~Depends on #14~