### PR TITLE
Add user lookup utility function

### DIFF
--- a/plugins/module_utils/table.py
+++ b/plugins/module_utils/table.py
@@ -63,3 +63,8 @@ class TableClient:
     def delete_record(self, table, record, check_mode):
         if not check_mode:
             self.client.delete(_path(table, record["sys_id"]))
+
+
+def find_user(table_client, user_id):
+    # TODO: Maybe add a lookup-by-email option too?
+    return table_client.get_record("sys_user", dict(user_name=user_id), must_exist=True)

--- a/tests/unit/plugins/module_utils/test_table.py
+++ b/tests/unit/plugins/module_utils/test_table.py
@@ -149,3 +149,12 @@ class TestTableDeleteRecord:
         t.delete_record("my_table", dict(sys_id="id"), True)
 
         client.delete.assert_not_called()
+
+
+class TestFindUser:
+    def test_user_name_lookup(self, table_client):
+        table_client.get_record.return_value = dict(sys_id="1234", user_name="test")
+
+        user = table.find_user(table_client, "test")
+
+        assert dict(sys_id="1234", user_name="test") == user


### PR DESCRIPTION
Right now, we only try to retrieve users by their `user_name` field, but there is nothing preventing us from expanding the list of lookup fields in the future.