### PR TITLE
incident: Update closed example

### DIFF
--- a/plugins/modules/incident.py
+++ b/plugins/modules/incident.py
@@ -127,6 +127,8 @@ EXAMPLES = r"""
 
     state: closed
     number: INC0000001
+    close_code: "Solved (Permanently)"
+    close_notes: "Closed"
 
 - name: Delete incident
   servicenow.itsm.incident:


### PR DESCRIPTION
##### SUMMARY

* While closing incident user need to provide
  `close_notes` and `close_code`

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
plugins/modules/incident.py
