### PR TITLE
Expose API error responses to playbook users

### DIFF
--- a/plugins/module_utils/client.py
+++ b/plugins/module_utils/client.py
@@ -97,7 +97,7 @@ class Client:
                 )
             # Other HTTP error codes do not necessarily mean errors.
             # This is for the caller to decide.
-            return Response(e.code, e.reason)
+            return Response(e.code, e.read(), e.headers)
         except URLError as e:
             raise ServiceNowError(e.reason)
 


### PR DESCRIPTION
ServiceNow's API often returns valuable information in its error responses that can help users resolve issues and report bugs.

Up until now, we discarded this information and relied on status codes, which has obvious downsides. Changes in this commit rectify the situation and improve the ergonomics of the issue resolution process.