### PR TITLE
Add timeout parameter to instance configuration

### DIFF
--- a/plugins/doc_fragments/instance.py
+++ b/plugins/doc_fragments/instance.py
@@ -51,4 +51,10 @@ options:
             variable will be used.
           - If provided, it requires I(client_id).
         type: str
+      timeout:
+        description:
+          - Timeout in seconds for the connection with the ServiceNow instance.
+          - If not set, the value of the C(SN_TIMEOUT) environment
+            variable will be used.
+        type: float
 """

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -77,6 +77,12 @@ options:
         env:
           - name: SN_CLIENT_SECRET
         type: str
+      timeout:
+        description:
+          - Timeout in seconds for the connection with the ServiceNow instance.
+        env:
+          - name: SN_TIMEOUT
+        type: float
   table:
     description: The ServiceNow table to use as the inventory source.
     type: str
@@ -428,6 +434,7 @@ class InventoryModule(BaseInventoryPlugin):
             password=os.getenv("SN_PASSWORD"),
             client_id=os.getenv("SN_CLIENT_ID"),
             client_secret=os.getenv("SN_SECRET_ID"),
+            timeout=os.getenv("SN_TIMEOUT"),
         )
 
     def _get_instance(self):

--- a/plugins/module_utils/arguments.py
+++ b/plugins/module_utils/arguments.py
@@ -40,6 +40,10 @@ SHARED_SPECS = dict(
                 no_log=True,
                 fallback=(env_fallback, ["SN_CLIENT_SECRET"]),
             ),
+            timeout=dict(
+                type="float",
+                fallback=(env_fallback, ["SN_TIMEOUT"]),
+            ),
         ),
         required_together=[("client_id", "client_secret")],
     ),

--- a/plugins/module_utils/client.py
+++ b/plugins/module_utils/client.py
@@ -38,12 +38,15 @@ class Response:
 
 
 class Client:
-    def __init__(self, host, username, password, client_id=None, client_secret=None):
+    def __init__(
+        self, host, username, password, client_id=None, client_secret=None, timeout=None
+    ):
         self.host = host
         self.username = username
         self.password = password
         self.client_id = client_id
         self.client_secret = client_secret
+        self.timeout = timeout
 
         self._auth_header = None
         self._client = Request()
@@ -86,7 +89,9 @@ class Client:
 
     def _request(self, method, path, data=None, headers=None):
         try:
-            raw_resp = self._client.open(method, path, data=data, headers=headers)
+            raw_resp = self._client.open(
+                method, path, data=data, headers=headers, timeout=self.timeout
+            )
         except HTTPError as e:
             # Wrong username/password, or expired access token
             if e.code == 401:

--- a/tests/integration/targets/misc/tasks/main.yml
+++ b/tests/integration/targets/misc/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+- environment:
+    SN_HOST: "{{ sn_host }}"
+    SN_USERNAME: "{{ sn_username }}"
+    SN_PASSWORD: "{{ sn_password }}"
+
+  block:
+    - name: Make sure timeout setting is enforced
+      servicenow.itsm.incident_info:
+        instance:
+          timeout: 0.01
+      register: result
+      ignore_errors: true
+    - ansible.builtin.assert: &timeout-assertions
+        that:
+          - result is failed
+          - "'timed out' in result.msg"
+
+    - name: Make sure timeout setting is enforced (env var)
+      servicenow.itsm.incident_info:
+      environment:
+        SN_TIMEOUT: 0.01
+      register: result
+      ignore_errors: true
+    - ansible.builtin.assert: *timeout-assertions


### PR DESCRIPTION
We add a new `timeout` parameter to the shared `instance` configuration.

This new parameter is exposed to all the modules in the collection, and to the inventory plugin. For consistency with other instance parameters, we allow setting the parameter either directly, or via the environment variable, `SN_TIMEOUT`.
