### PR TITLE
Make sure our code works on Python 2

### DIFF
--- a/plugins/module_utils/client.py
+++ b/plugins/module_utils/client.py
@@ -9,6 +9,7 @@ __metaclass__ = type
 
 import json
 
+from ansible.module_utils.six import PY2
 from ansible.module_utils.six.moves.urllib.error import HTTPError, URLError
 from ansible.module_utils.six.moves.urllib.parse import urlencode, quote
 from ansible.module_utils.urls import Request, basic_auth_header
@@ -106,7 +107,9 @@ class Client:
         except URLError as e:
             raise ServiceNowError(e.reason)
 
-        return Response(raw_resp.status, raw_resp.read(), raw_resp.getheaders())
+        if PY2:
+            return Response(raw_resp.getcode(), raw_resp.read(), raw_resp.info())
+        return Response(raw_resp.status, raw_resp.read(), raw_resp.headers)
 
     def request(self, method, path, query=None, data=None):
         escaped_path = quote(path.rstrip("/"))

--- a/plugins/module_utils/validation.py
+++ b/plugins/module_utils/validation.py
@@ -7,13 +7,15 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+from ansible.module_utils.six import text_type
+
 from .errors import ServiceNowError
 
 
 def _assert_str_or_none(param, val):
-    if not isinstance(val, (str, type(None))):
+    if not isinstance(val, (str, text_type, type(None))):
         raise ServiceNowError(
-            "Expected '{0}' to be str or None, got {1}".format(param, type(val))
+            "Expected '{0}' to be text or None, got {1}".format(param, type(val))
         )
 
 

--- a/tests/unit/plugins/module_utils/test_client.py
+++ b/tests/unit/plugins/module_utils/test_client.py
@@ -76,8 +76,11 @@ class TestClientAuthHeader:
         assert c.auth_header == {"Authorization": b"Basic dXNlcjpwYXNz"}
 
     def test_oauth(self, mocker):
-        resp_mock = mocker.MagicMock(status=200)
+        resp_mock = mocker.MagicMock()
+        resp_mock.status = 200  # Used when testing on Python 3
+        resp_mock.getcode.return_value = 200  # Used when testing on Python 2
         resp_mock.read.return_value = '{"access_token": "token"}'
+
         request_mock = mocker.patch.object(client, "Request").return_value
         request_mock.open.return_value = resp_mock
 
@@ -100,8 +103,11 @@ class TestClientAuthHeader:
             c.auth_header
 
     def test_header_is_cached(self, mocker):
-        raw_resp_mock = mocker.MagicMock(status=200)
+        raw_resp_mock = mocker.MagicMock()
+        raw_resp_mock.status = 200  # Used when testing on Python 3
+        raw_resp_mock.getcode.return_value = 200  # Used when testing on Python 2
         raw_resp_mock.read.return_value = '{"access_token": "token"}'
+
         request_mock = mocker.patch.object(client, "Request").return_value
         request_mock.open.return_value = raw_resp_mock
 

--- a/tests/unit/plugins/module_utils/test_validation.py
+++ b/tests/unit/plugins/module_utils/test_validation.py
@@ -71,5 +71,5 @@ class TestMissingFromParamsAndRemote:
         ],
     )
     def test_invalid_wrong_param_value_type(self, module_params, record):
-        with pytest.raises(errors.ServiceNowError, match="str or None"):
+        with pytest.raises(errors.ServiceNowError, match="text or None"):
             validation.missing_from_params_and_remote(["a"], module_params, record)


### PR DESCRIPTION
When we developed things initially, we missed some compatibility spots (our unit tests cannot catch those, and because we do not have a CI/CD that would run integration tests on Python 2, those errors slipped through the cracks of manual testing).