### PR TITLE
Handle and warn about unknown values for enumerated payload fields

### DIFF
--- a/plugins/modules/change_request.py
+++ b/plugins/modules/change_request.py
@@ -216,7 +216,7 @@ DIRECT_PAYLOAD_FIELDS = (
 
 
 def ensure_absent(module, table_client):
-    mapper = utils.PayloadMapper(PAYLOAD_FIELDS_MAPPING)
+    mapper = utils.PayloadMapper(PAYLOAD_FIELDS_MAPPING, module.warn)
     query = utils.filter_dict(module.params, "sys_id", "number")
     change = table_client.get_record("change_request", query)
 
@@ -243,7 +243,7 @@ def validate_params(params, change_request=None):
 
 
 def ensure_present(module, table_client):
-    mapper = utils.PayloadMapper(PAYLOAD_FIELDS_MAPPING)
+    mapper = utils.PayloadMapper(PAYLOAD_FIELDS_MAPPING, module.warn)
     query = utils.filter_dict(module.params, "sys_id", "number")
     payload = build_payload(module, table_client)
 

--- a/plugins/modules/change_request_info.py
+++ b/plugins/modules/change_request_info.py
@@ -166,7 +166,7 @@ from ..module_utils.change_request import PAYLOAD_FIELDS_MAPPING
 
 def run(module, table_client):
     query = utils.filter_dict(module.params, "sys_id", "number")
-    mapper = utils.PayloadMapper(PAYLOAD_FIELDS_MAPPING)
+    mapper = utils.PayloadMapper(PAYLOAD_FIELDS_MAPPING, module.warn)
 
     return [
         mapper.to_ansible(record)

--- a/plugins/modules/configuration_item.py
+++ b/plugins/modules/configuration_item.py
@@ -253,7 +253,7 @@ DIRECT_PAYLOAD_FIELDS = (
 
 
 def ensure_absent(module, table_client):
-    mapper = utils.PayloadMapper(PAYLOAD_FIELDS_MAPPING)
+    mapper = utils.PayloadMapper(PAYLOAD_FIELDS_MAPPING, module.warn)
     query = utils.filter_dict(module.params, "sys_id")
     configuration_item = table_client.get_record("cmdb_ci", query)
 
@@ -283,7 +283,7 @@ def build_payload(module, table_client):
 
 
 def ensure_present(module, table_client):
-    mapper = utils.PayloadMapper(PAYLOAD_FIELDS_MAPPING)
+    mapper = utils.PayloadMapper(PAYLOAD_FIELDS_MAPPING, module.warn)
     query = utils.filter_dict(module.params, "sys_id")
     payload = build_payload(module, table_client)
 

--- a/plugins/modules/configuration_item_info.py
+++ b/plugins/modules/configuration_item_info.py
@@ -156,7 +156,7 @@ from ..module_utils.configuration_item import PAYLOAD_FIELDS_MAPPING
 def run(module, table_client):
     query = utils.filter_dict(module.params, "sys_id")
     cmdb_table = module.params["sys_class_name"] or "cmdb_ci"
-    mapper = utils.PayloadMapper(PAYLOAD_FIELDS_MAPPING)
+    mapper = utils.PayloadMapper(PAYLOAD_FIELDS_MAPPING, module.warn)
 
     return [
         mapper.to_ansible(record)

--- a/plugins/modules/incident.py
+++ b/plugins/modules/incident.py
@@ -159,7 +159,7 @@ DIRECT_PAYLOAD_FIELDS = (
 
 
 def ensure_absent(module, table_client):
-    mapper = utils.PayloadMapper(PAYLOAD_FIELDS_MAPPING)
+    mapper = utils.PayloadMapper(PAYLOAD_FIELDS_MAPPING, module.warn)
     query = utils.filter_dict(module.params, "sys_id", "number")
     incident = table_client.get_record("incident", query)
 
@@ -197,7 +197,7 @@ def validate_params(params, incident=None):
 
 
 def ensure_present(module, table_client):
-    mapper = utils.PayloadMapper(PAYLOAD_FIELDS_MAPPING)
+    mapper = utils.PayloadMapper(PAYLOAD_FIELDS_MAPPING, module.warn)
     query = utils.filter_dict(module.params, "sys_id", "number")
     payload = build_payload(module, table_client)
 

--- a/plugins/modules/incident_info.py
+++ b/plugins/modules/incident_info.py
@@ -152,7 +152,7 @@ from ..module_utils.incident import PAYLOAD_FIELDS_MAPPING
 
 def run(module, table_client):
     query = utils.filter_dict(module.params, "sys_id", "number")
-    mapper = utils.PayloadMapper(PAYLOAD_FIELDS_MAPPING)
+    mapper = utils.PayloadMapper(PAYLOAD_FIELDS_MAPPING, module.warn)
 
     return [
         mapper.to_ansible(record)

--- a/plugins/modules/problem.py
+++ b/plugins/modules/problem.py
@@ -287,7 +287,7 @@ DIRECT_PAYLOAD_FIELDS = (
 
 
 def ensure_absent(module, table_client):
-    mapper = utils.PayloadMapper(PAYLOAD_FIELDS_MAPPING)
+    mapper = utils.PayloadMapper(PAYLOAD_FIELDS_MAPPING, module.warn)
     query = utils.filter_dict(module.params, "sys_id", "number")
     problem = table_client.get_record("problem", query)
 
@@ -370,7 +370,7 @@ def validate_params(params, problem=None):
 
 
 def ensure_present(module, table_client):
-    mapper = utils.PayloadMapper(PAYLOAD_FIELDS_MAPPING)
+    mapper = utils.PayloadMapper(PAYLOAD_FIELDS_MAPPING, module.warn)
     query = utils.filter_dict(module.params, "sys_id", "number")
     payload = build_payload(module, table_client)
 

--- a/plugins/modules/problem_info.py
+++ b/plugins/modules/problem_info.py
@@ -157,7 +157,7 @@ from ..module_utils.problem import PAYLOAD_FIELDS_MAPPING
 
 def run(module, table_client):
     query = utils.filter_dict(module.params, "sys_id", "number")
-    mapper = utils.PayloadMapper(PAYLOAD_FIELDS_MAPPING)
+    mapper = utils.PayloadMapper(PAYLOAD_FIELDS_MAPPING, module.warn)
 
     return [
         mapper.to_ansible(record)

--- a/tests/unit/plugins/module_utils/test_utils.py
+++ b/tests/unit/plugins/module_utils/test_utils.py
@@ -61,10 +61,38 @@ class TestPayloadMapper:
 
         assert dict(a=4, b=6, c=7) == mapper.to_ansible(dict(a=3, b=5, c=7))
 
+    def test_to_ansible_unknown_value_is_included(self):
+        mapper = utils.PayloadMapper(dict(a=[(1, "a1")]))
+
+        assert dict(a=2) == mapper.to_ansible(dict(a=2))
+
+    def test_to_ansible_unknown_value_handler_is_invoked(self, mocker):
+        mock_handler = mocker.Mock()
+        mapper = utils.PayloadMapper(dict(a=[(1, "a1")]), mock_handler.warn)
+        mapper.to_ansible(dict(a="a2"))
+
+        mock_handler.warn.assert_called_once_with(
+            "Encountered unknown value a2 while mapping field a."
+        )
+
     def test_to_snow(self):
         mapper = utils.PayloadMapper(dict(a=[(1, 2), (3, 4)], b=[(5, 6)]))
 
         assert dict(a=1, b=5, c=7) == mapper.to_snow(dict(a=2, b=6, c=7))
+
+    def test_to_snow_unknown_value_is_included(self):
+        mapper = utils.PayloadMapper(dict(a=[(1, "a1")]))
+
+        assert dict(a="a2") == mapper.to_snow(dict(a="a2"))
+
+    def test_to_snow_unknown_value_handler_is_invoked(self, mocker):
+        mock_handler = mocker.Mock()
+        mapper = utils.PayloadMapper(dict(a=[(1, "a1")]), mock_handler.warn)
+        mapper.to_snow(dict(a=2))
+
+        mock_handler.warn.assert_called_once_with(
+            "Encountered unknown value 2 while mapping field a."
+        )
 
     @pytest.mark.parametrize(
         "data", [dict(), dict(a=1), dict(a=1, b=2), dict(c=3), dict(a=2, c=5)]


### PR DESCRIPTION
Fixes #41.

Until now, our modules crashed when encountering unknown values for enumerated payload fields that are mapped between ServiceNow values and their canonical representations. 

In this PR, we fix this by ensuring that:

* Unknown values are included in their original form;
* Users are warned about specific values that our modules consider unknown via `module.warn`.

Example of a warning:

```
TASK [configuration_item : Retrieve a record with unknown install_status value] **********************************************************************************************************************************************************
[WARNING]: Encountered unknown value 999 while mapping field install_status.
ok: [testhost]
```
