### PR TITLE
Inventory updates

### DIFF
--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -398,11 +398,9 @@ class InventoryModule(BaseInventoryPlugin):
 
                 self.set_hostvars(host, record, columns)
 
-    def fill_desired_groups(self, table_client, table, named_groups):
-        host_source = self.get_option("ansible_host_source")
-        name_source = self.get_option("inventory_hostname_source")
-        columns = self.get_option("columns")
-
+    def fill_desired_groups(
+        self, table_client, table, host_source, name_source, columns, named_groups
+    ):
         for group_name, group_conditions in named_groups.items():
             self.inventory.add_group(group_name)
 
@@ -459,9 +457,15 @@ class InventoryModule(BaseInventoryPlugin):
         table_client = TableClient(client)
 
         table = self.get_option("table")
+        host_source = self.get_option("ansible_host_source")
+        name_source = self.get_option("inventory_hostname_source")
+        columns = self.get_option("columns")
+
         if named_groups:
             # Creates exactly the specified groups (which might be empty).
             # Leaves nothing ungrouped.
-            self.fill_desired_groups(table_client, table, named_groups)
+            self.fill_desired_groups(
+                table_client, table, host_source, name_source, columns, named_groups
+            )
         else:
             self.fill_auto_groups(table_client, table, group_by)

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -371,10 +371,9 @@ class InventoryModule(BaseInventoryPlugin):
         for k in columns:
             self.inventory.set_variable(host, k, record[k])
 
-    def fill_auto_groups(self, table_client, table, group_by):
-        host_source = self.get_option("ansible_host_source")
-        name_source = self.get_option("inventory_hostname_source")
-        columns = self.get_option("columns")
+    def fill_auto_groups(
+        self, table_client, table, host_source, name_source, columns, group_by
+    ):
         records = table_client.list_records(
             table, query=self.query(group_by, host_source, name_source, columns)
         )
@@ -468,4 +467,6 @@ class InventoryModule(BaseInventoryPlugin):
                 table_client, table, host_source, name_source, columns, named_groups
             )
         else:
-            self.fill_auto_groups(table_client, table, group_by)
+            self.fill_auto_groups(
+                table_client, table, host_source, name_source, columns, group_by
+            )

--- a/tests/integration/targets/inventory/files/group_by.now.yml
+++ b/tests/integration/targets/inventory/files/group_by.now.yml
@@ -1,0 +1,14 @@
+---
+plugin: servicenow.itsm.now
+
+table: cmdb_ci_ec2_instance
+columns:
+  - name
+  - ip_address
+  - vm_inst_id
+
+group_by:
+  environment:
+  guest_os_fullname:
+    includes:
+      - OS1

--- a/tests/integration/targets/inventory/files/named_groups.now.yml
+++ b/tests/integration/targets/inventory/files/named_groups.now.yml
@@ -1,0 +1,13 @@
+---
+plugin: servicenow.itsm.now
+
+table: cmdb_ci_vm_instance
+columns:
+  - state
+
+named_groups:
+  active_OS0_servers:
+    guest_os_fullname:
+      includes: [ OS0 ]
+    state:
+      excludes: [ "off" ]

--- a/tests/integration/targets/inventory/files/trivial.now.yml
+++ b/tests/integration/targets/inventory/files/trivial.now.yml
@@ -1,0 +1,2 @@
+---
+plugin: servicenow.itsm.now

--- a/tests/integration/targets/inventory/playbooks/group_by.yml
+++ b/tests/integration/targets/inventory/playbooks/group_by.yml
@@ -1,0 +1,43 @@
+---
+- name: Test automatic grouping
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - block:
+        - name: Create imaginary VMs
+          servicenow.itsm.configuration_item:
+            name: my-vm-{{ item }}
+            sys_class_name: cmdb_ci_ec2_instance
+            ip_address: 10.1.0.{{ item }}
+            environment: "{{ (item % 2 == 0) | ansible.builtin.ternary('development', 'production') }}"
+            other:
+              guest_os_fullname: "{{ (item < 105) | ansible.builtin.ternary('OS0', 'OS1') }}"
+          loop: "{{ range(100, 110) }}"
+          register: vms
+
+        - name: Reload inventory
+          ansible.builtin.meta: refresh_inventory
+
+        - ansible.builtin.debug:
+            var: groups
+
+        - ansible.builtin.assert:
+            that:
+              - groups | length == 5
+              - "'Production' in groups"
+              - "groups['Production'] | length == 3"
+              - "'Development' in groups"
+              - "groups['Development'] | length == 2"
+              - "'OS1' in groups"
+              - "groups['OS1'] | length == 5"
+              - "'OS0' not in groups"
+
+      always:
+        - name: Delete VMs
+          servicenow.itsm.configuration_item:
+            state: absent
+            sys_id: "{{ item.record.sys_id }}"
+          loop: "{{ vms.results }}"
+          loop_control:
+            label: "{{ item.record.name }}"

--- a/tests/integration/targets/inventory/playbooks/named_groups.yml
+++ b/tests/integration/targets/inventory/playbooks/named_groups.yml
@@ -1,0 +1,42 @@
+---
+- name: Test named groups
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - block:
+        - name: Create imaginary VMs
+          servicenow.itsm.configuration_item:
+            name: my-vm-{{ item }}
+            sys_class_name: cmdb_ci_vm_instance
+            ip_address: 10.1.0.{{ item }}
+            other:
+              state: "{{ (item % 4 == 0) | ansible.builtin.ternary('on', 'off') }}"
+              guest_os_fullname: "{{ (item < 105) | ansible.builtin.ternary('OS0', 'OS1') }}"
+          loop: "{{ range(100, 110) }}"
+          register: vms
+
+        - name: Reload inventory
+          ansible.builtin.meta: refresh_inventory
+
+        - ansible.builtin.debug:
+            var: groups
+
+        - ansible.builtin.assert:
+            that:
+              - groups | length == 3
+              - "'active_OS0_servers' in groups"
+              - groups["active_OS0_servers"] | length == 2
+              - hostvars["my-vm-100"].state == "On"
+              - hostvars["my-vm-100"].ansible_host == "10.1.0.100"
+              - hostvars["my-vm-104"].state == "On"
+              - hostvars["my-vm-104"].ansible_host == "10.1.0.104"
+
+      always:
+        - name: Delete VMs
+          servicenow.itsm.configuration_item:
+            state: absent
+            sys_id: "{{ item.record.sys_id }}"
+          loop: "{{ vms.results }}"
+          loop_control:
+            label: "{{ item.record.name }}"

--- a/tests/integration/targets/inventory/playbooks/trivial.yml
+++ b/tests/integration/targets/inventory/playbooks/trivial.yml
@@ -1,0 +1,11 @@
+---
+- name: Make sure we get back all and ungrouped groups by default
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - ansible.builtin.assert:
+        that:
+          - groups | length == 2
+          - "'all' in groups"
+          - "'ungrouped' in groups"

--- a/tests/integration/targets/inventory/runme.sh
+++ b/tests/integration/targets/inventory/runme.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+set -eu
+
+# To reduce the amount of warnings coming from the inventory plugins
+# enabled by default, we whitelist our plugin only
+export ANSIBLE_INVENTORY_ENABLED=servicenow.itsm.now
+
+# When running script-based integration targets, `ansible-test integration`
+# does not make these variables available. We will need to pass them
+# explicitly, as extra vars to `ansible-playbook` command.
+readonly vars_file=../../integration_config.yml
+
+# The exports below allow the inventory plugin access to authentication data
+# from the environment.
+
+eval "$(cat <<EOF | python
+import yaml
+with open("$vars_file") as fd:
+    data = yaml.safe_load(fd)
+print("export SN_HOST='{}'".format(data["sn_host"]))
+print("export SN_USERNAME='{}'".format(data["sn_username"]))
+print("export SN_PASSWORD='{}'".format(data["sn_password"]))
+print("export SN_CLIENT_ID='{}'".format(data["sn_client_id"]))
+print("export SN_CLIENT_SECRET='{}'".format(data["sn_client_secret"]))
+EOF
+)"
+
+env | grep SN_
+
+# Each inventory source `files/{name}.now.yml` represents a separate context
+# for testing. The tests for each inventory source are in the
+# `playbooks/{name}.yml` playbook.
+
+set -x
+
+for inventory_config in files/*.now.yml
+do
+  ansible-playbook \
+    -i "$inventory_config" \
+    -e "@$vars_file" \
+    "playbooks/$(basename "$inventory_config" .now.yml).yml"
+done

--- a/tests/unit/plugins/inventory/test_now.py
+++ b/tests/unit/plugins/inventory/test_now.py
@@ -113,3 +113,58 @@ class TestInventoryModuleValidateGroupingConditions:
                     col=dict(includes=[4, 5], excludes=["test"]),
                 ),
             )
+
+
+class TestInventoryModuleAddHost:
+    def test_valid(self, inventory_plugin):
+        host = inventory_plugin.add_host(
+            dict(host_source="1.2.3.4", name_source="dummy_host", sys_id="123"),
+            "table_name",
+            "host_source",
+            "name_source",
+        )
+
+        assert host == "dummy_host"
+        hostvars = inventory_plugin.inventory.get_host("dummy_host").vars
+        assert hostvars["ansible_host"] == "1.2.3.4"
+
+    def test_valid_empty_host(self, inventory_plugin):
+        host = inventory_plugin.add_host(
+            dict(host_source="", name_source="dummy_host", sys_id="123"),
+            "table_name",
+            "host_source",
+            "name_source",
+        )
+
+        assert host == "dummy_host"
+        hostvars = inventory_plugin.inventory.get_host("dummy_host").vars
+        assert "ansible_host" not in hostvars
+
+    def test_valid_empty_name(self, inventory_plugin):
+        host = inventory_plugin.add_host(
+            dict(host_source="1.2.3.4", name_source="", sys_id="123"),
+            "table_name",
+            "host_source",
+            "name_source",
+        )
+
+        assert host is None
+        assert inventory_plugin.inventory.get_host("dummy_host") is None
+
+    def test_invalid_host(self, inventory_plugin):
+        with pytest.raises(AnsibleParserError, match="invalid_host"):
+            inventory_plugin.add_host(
+                dict(host_source="1.2.3.4", name_source="dummy_host", sys_id="123"),
+                "table_name",
+                "invalid_host",
+                "name_source",
+            )
+
+    def test_invalid_name(self, inventory_plugin):
+        with pytest.raises(AnsibleParserError, match="invalid_name"):
+            inventory_plugin.add_host(
+                dict(host_source="1.2.3.4", name_source="dummy_host", sys_id="123"),
+                "table_name",
+                "host_source",
+                "invalid_name",
+            )

--- a/tests/unit/plugins/inventory/test_now.py
+++ b/tests/unit/plugins/inventory/test_now.py
@@ -168,3 +168,27 @@ class TestInventoryModuleAddHost:
                 "host_source",
                 "invalid_name",
             )
+
+
+class TestInventoryModuleSetHostvars:
+    def test_valid(self, inventory_plugin):
+        inventory_plugin.inventory.add_host("dummy_host")
+
+        inventory_plugin.set_hostvars(
+            "dummy_host",
+            dict(sys_id="123", platform="demo", unused="column"),
+            ("sys_id", "platform"),
+        )
+
+        hostvars = inventory_plugin.inventory.get_host("dummy_host").vars
+        assert hostvars["sys_id"] == "123"
+        assert hostvars["platform"] == "demo"
+        assert "unused" not in hostvars
+
+    def test_invalid_column(self, inventory_plugin):
+        with pytest.raises(AnsibleParserError, match="bad_column"):
+            inventory_plugin.set_hostvars(
+                "dummy_host",
+                dict(sys_id="123", platform="demo", unused="column"),
+                ("sys_id", "platform", "bad_column"),
+            )

--- a/tests/unit/plugins/inventory/test_now.py
+++ b/tests/unit/plugins/inventory/test_now.py
@@ -192,3 +192,16 @@ class TestInventoryModuleSetHostvars:
                 dict(sys_id="123", platform="demo", unused="column"),
                 ("sys_id", "platform", "bad_column"),
             )
+
+
+class TestInventoryModuleQuery:
+    def test_construction(self, inventory_plugin):
+        result = inventory_plugin.query(
+            dict(cname=dict(includes="b")), "host", "name", ("col1", "col2")
+        )
+
+        assert set(result["sysparm_fields"].split(",")) == set(
+            ("col1", "col2", "host", "name", "sys_id", "cname")
+        )
+        assert result["sysparm_display_value"] is True
+        assert result["sysparm_query"] == "cname=b"

--- a/tests/unit/plugins/inventory/test_now.py
+++ b/tests/unit/plugins/inventory/test_now.py
@@ -11,11 +11,22 @@ import sys
 
 import pytest
 
+from ansible.errors import AnsibleParserError
+from ansible.inventory.data import InventoryData
+from ansible.module_utils.common.text.converters import to_text
+
 from ansible_collections.servicenow.itsm.plugins.inventory import now
 
 pytestmark = pytest.mark.skipif(
     sys.version_info < (2, 7), reason="requires python2.7 or higher"
 )
+
+
+@pytest.fixture
+def inventory_plugin():
+    plugin = now.InventoryModule()
+    plugin.inventory = InventoryData()
+    return plugin
 
 
 class TestSysparmQueryFromConditions:
@@ -44,3 +55,61 @@ class TestSysparmQueryFromConditions:
         # We do not care about the order, we just want to make sure
         # that there is "and" between conditions for both fields.
         assert sysparm_query in ("a=a1^ORa=a2^b!=b1^b!=b2", "b!=b1^b!=b2^a=a1^ORa=a2")
+
+
+class TestInventoryModuleVerifyFile:
+    @pytest.mark.parametrize(
+        "name,valid",
+        [("sample.now.yaml", True), ("sample.now.yml", True), ("invalid.yaml", False)],
+    )
+    def test_file_name(self, inventory_plugin, tmp_path, name, valid):
+        config = tmp_path / name
+        config.write_text(to_text("plugin: servicenow.itsm.now"))
+
+        assert inventory_plugin.verify_file(to_text(config)) is valid
+
+
+class TestInventoryModuleValidateGroupingConditions:
+    def test_valid_named_groups(self, inventory_plugin):
+        inventory_plugin.validate_grouping_conditions(
+            dict(
+                group1=dict(
+                    col1=dict(includes=[1, 2, 3]),
+                    col2=dict(excludes=[4, 5, 6]),
+                ),
+                group2=dict(
+                    col3=dict(excludes=["a", "b"]),
+                    col4=dict(includes=["c", "d"]),
+                ),
+            ),
+            dict(),
+        )
+
+    def test_invalid_named_groups(self, inventory_plugin):
+        with pytest.raises(AnsibleParserError, match="mutually exclusive"):
+            inventory_plugin.validate_grouping_conditions(
+                dict(
+                    group=dict(
+                        col=dict(includes=[1], excludes=[2]),
+                    ),
+                ),
+                dict(),
+            )
+
+    def test_valid_group_by(self, inventory_plugin):
+        inventory_plugin.validate_grouping_conditions(
+            dict(),
+            dict(
+                col1=dict(includes=[1, 2, 3]),
+                col2=dict(excludes=[4, 5, 6]),
+            ),
+        )
+
+    def test_invalid_group_by(self, inventory_plugin):
+        with pytest.raises(AnsibleParserError, match="mutually exclusive"):
+            inventory_plugin.validate_grouping_conditions(
+                dict(),
+                dict(
+                    col=dict(includes=[4, 5], excludes=["test"]),
+                ),
+            )


### PR DESCRIPTION
The main purpose of this PR is to rename the `group` configuration option into `named_groups` to avoid clashing with the constructed inventory that is part of Ansible and may be added to the plugin in the future.

The remaining commits just refactor inventory code a bit and add unit tests for the functionality.