### PR TITLE
Add support for OAuth refresh token logins

### DIFF
--- a/changelogs/fragments/refresh_token.yml
+++ b/changelogs/fragments/refresh_token.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Added support for ``refresh_token`` in login mechanism (https://github.com/ansible-collections/servicenow.itsm/issues/63).

--- a/docs/servicenow.itsm.change_request_info_module.rst
+++ b/docs/servicenow.itsm.change_request_info_module.rst
@@ -89,6 +89,28 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>grant_type</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.1.0</div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>password</b>&nbsp;&larr;</div></li>
+                                    <li>refresh_token</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Grant type used for OAuth authentication.</div>
+                        <div>If not set, the value of the <code>SN_GRANT_TYPE</code> environment variable will be used.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>host</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -111,7 +133,6 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
-                         / <span style="color: red">required</span>
                     </div>
                 </td>
                 <td>
@@ -119,6 +140,26 @@ Parameters
                 <td>
                         <div>Password used for authentication.</div>
                         <div>If not set, the value of the <code>SN_PASSWORD</code> environment variable will be used.</div>
+                        <div>Required when using basic authentication or when <em>grant_type=password</em>.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>refresh_token</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.1.0</div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Refresh token used for OAuth authentication.</div>
+                        <div>If not set, the value of the <code>SN_REFRESH_TOKEN</code> environment variable will be used.</div>
+                        <div>Required when <em>grant_type=refresh_token</em>.</div>
                 </td>
             </tr>
             <tr>
@@ -146,7 +187,6 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
-                         / <span style="color: red">required</span>
                     </div>
                 </td>
                 <td>
@@ -154,6 +194,7 @@ Parameters
                 <td>
                         <div>Username used for authentication.</div>
                         <div>If not set, the value of the <code>SN_USERNAME</code> environment variable will be used.</div>
+                        <div>Required when using basic authentication or when <em>grant_type=password</em>.</div>
                 </td>
             </tr>
 
@@ -205,7 +246,7 @@ See Also
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: Retrieve all change requests
       servicenow.itsm.change_request_info:

--- a/docs/servicenow.itsm.change_request_module.rst
+++ b/docs/servicenow.itsm.change_request_module.rst
@@ -219,6 +219,28 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>grant_type</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.1.0</div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>password</b>&nbsp;&larr;</div></li>
+                                    <li>refresh_token</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Grant type used for OAuth authentication.</div>
+                        <div>If not set, the value of the <code>SN_GRANT_TYPE</code> environment variable will be used.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>host</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -241,7 +263,6 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
-                         / <span style="color: red">required</span>
                     </div>
                 </td>
                 <td>
@@ -249,6 +270,26 @@ Parameters
                 <td>
                         <div>Password used for authentication.</div>
                         <div>If not set, the value of the <code>SN_PASSWORD</code> environment variable will be used.</div>
+                        <div>Required when using basic authentication or when <em>grant_type=password</em>.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>refresh_token</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.1.0</div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Refresh token used for OAuth authentication.</div>
+                        <div>If not set, the value of the <code>SN_REFRESH_TOKEN</code> environment variable will be used.</div>
+                        <div>Required when <em>grant_type=refresh_token</em>.</div>
                 </td>
             </tr>
             <tr>
@@ -276,7 +317,6 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
-                         / <span style="color: red">required</span>
                     </div>
                 </td>
                 <td>
@@ -284,6 +324,7 @@ Parameters
                 <td>
                         <div>Username used for authentication.</div>
                         <div>If not set, the value of the <code>SN_USERNAME</code> environment variable will be used.</div>
+                        <div>Required when using basic authentication or when <em>grant_type=password</em>.</div>
                 </td>
             </tr>
 
@@ -525,7 +566,7 @@ See Also
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: Create change request
       servicenow.itsm.change_request:

--- a/docs/servicenow.itsm.configuration_item_info_module.rst
+++ b/docs/servicenow.itsm.configuration_item_info_module.rst
@@ -89,6 +89,28 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>grant_type</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.1.0</div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>password</b>&nbsp;&larr;</div></li>
+                                    <li>refresh_token</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Grant type used for OAuth authentication.</div>
+                        <div>If not set, the value of the <code>SN_GRANT_TYPE</code> environment variable will be used.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>host</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -111,7 +133,6 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
-                         / <span style="color: red">required</span>
                     </div>
                 </td>
                 <td>
@@ -119,6 +140,26 @@ Parameters
                 <td>
                         <div>Password used for authentication.</div>
                         <div>If not set, the value of the <code>SN_PASSWORD</code> environment variable will be used.</div>
+                        <div>Required when using basic authentication or when <em>grant_type=password</em>.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>refresh_token</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.1.0</div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Refresh token used for OAuth authentication.</div>
+                        <div>If not set, the value of the <code>SN_REFRESH_TOKEN</code> environment variable will be used.</div>
+                        <div>Required when <em>grant_type=refresh_token</em>.</div>
                 </td>
             </tr>
             <tr>
@@ -146,7 +187,6 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
-                         / <span style="color: red">required</span>
                     </div>
                 </td>
                 <td>
@@ -154,6 +194,7 @@ Parameters
                 <td>
                         <div>Username used for authentication.</div>
                         <div>If not set, the value of the <code>SN_USERNAME</code> environment variable will be used.</div>
+                        <div>Required when using basic authentication or when <em>grant_type=password</em>.</div>
                 </td>
             </tr>
 
@@ -207,7 +248,7 @@ See Also
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: Retrieve all configuration items
       servicenow.itsm.configuration_item_info:

--- a/docs/servicenow.itsm.configuration_item_module.rst
+++ b/docs/servicenow.itsm.configuration_item_module.rst
@@ -183,6 +183,28 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>grant_type</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.1.0</div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>password</b>&nbsp;&larr;</div></li>
+                                    <li>refresh_token</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Grant type used for OAuth authentication.</div>
+                        <div>If not set, the value of the <code>SN_GRANT_TYPE</code> environment variable will be used.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>host</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -205,7 +227,6 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
-                         / <span style="color: red">required</span>
                     </div>
                 </td>
                 <td>
@@ -213,6 +234,26 @@ Parameters
                 <td>
                         <div>Password used for authentication.</div>
                         <div>If not set, the value of the <code>SN_PASSWORD</code> environment variable will be used.</div>
+                        <div>Required when using basic authentication or when <em>grant_type=password</em>.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>refresh_token</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.1.0</div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Refresh token used for OAuth authentication.</div>
+                        <div>If not set, the value of the <code>SN_REFRESH_TOKEN</code> environment variable will be used.</div>
+                        <div>Required when <em>grant_type=refresh_token</em>.</div>
                 </td>
             </tr>
             <tr>
@@ -240,7 +281,6 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
-                         / <span style="color: red">required</span>
                     </div>
                 </td>
                 <td>
@@ -248,6 +288,7 @@ Parameters
                 <td>
                         <div>Username used for authentication.</div>
                         <div>If not set, the value of the <code>SN_USERNAME</code> environment variable will be used.</div>
+                        <div>Required when using basic authentication or when <em>grant_type=password</em>.</div>
                 </td>
             </tr>
 
@@ -438,7 +479,7 @@ See Also
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: Create a configuration item
       servicenow.itsm.configuration_item:

--- a/docs/servicenow.itsm.incident_info_module.rst
+++ b/docs/servicenow.itsm.incident_info_module.rst
@@ -89,6 +89,28 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>grant_type</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.1.0</div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>password</b>&nbsp;&larr;</div></li>
+                                    <li>refresh_token</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Grant type used for OAuth authentication.</div>
+                        <div>If not set, the value of the <code>SN_GRANT_TYPE</code> environment variable will be used.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>host</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -111,7 +133,6 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
-                         / <span style="color: red">required</span>
                     </div>
                 </td>
                 <td>
@@ -119,6 +140,26 @@ Parameters
                 <td>
                         <div>Password used for authentication.</div>
                         <div>If not set, the value of the <code>SN_PASSWORD</code> environment variable will be used.</div>
+                        <div>Required when using basic authentication or when <em>grant_type=password</em>.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>refresh_token</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.1.0</div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Refresh token used for OAuth authentication.</div>
+                        <div>If not set, the value of the <code>SN_REFRESH_TOKEN</code> environment variable will be used.</div>
+                        <div>Required when <em>grant_type=refresh_token</em>.</div>
                 </td>
             </tr>
             <tr>
@@ -146,7 +187,6 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
-                         / <span style="color: red">required</span>
                     </div>
                 </td>
                 <td>
@@ -154,6 +194,7 @@ Parameters
                 <td>
                         <div>Username used for authentication.</div>
                         <div>If not set, the value of the <code>SN_USERNAME</code> environment variable will be used.</div>
+                        <div>Required when using basic authentication or when <em>grant_type=password</em>.</div>
                 </td>
             </tr>
 
@@ -205,7 +246,7 @@ See Also
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: Retrieve all incidents
       servicenow.itsm.incident_info:

--- a/docs/servicenow.itsm.incident_module.rst
+++ b/docs/servicenow.itsm.incident_module.rst
@@ -202,6 +202,28 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>grant_type</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.1.0</div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>password</b>&nbsp;&larr;</div></li>
+                                    <li>refresh_token</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Grant type used for OAuth authentication.</div>
+                        <div>If not set, the value of the <code>SN_GRANT_TYPE</code> environment variable will be used.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>host</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -224,7 +246,6 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
-                         / <span style="color: red">required</span>
                     </div>
                 </td>
                 <td>
@@ -232,6 +253,26 @@ Parameters
                 <td>
                         <div>Password used for authentication.</div>
                         <div>If not set, the value of the <code>SN_PASSWORD</code> environment variable will be used.</div>
+                        <div>Required when using basic authentication or when <em>grant_type=password</em>.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>refresh_token</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.1.0</div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Refresh token used for OAuth authentication.</div>
+                        <div>If not set, the value of the <code>SN_REFRESH_TOKEN</code> environment variable will be used.</div>
+                        <div>Required when <em>grant_type=refresh_token</em>.</div>
                 </td>
             </tr>
             <tr>
@@ -259,7 +300,6 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
-                         / <span style="color: red">required</span>
                     </div>
                 </td>
                 <td>
@@ -267,6 +307,7 @@ Parameters
                 <td>
                         <div>Username used for authentication.</div>
                         <div>If not set, the value of the <code>SN_USERNAME</code> environment variable will be used.</div>
+                        <div>Required when using basic authentication or when <em>grant_type=password</em>.</div>
                 </td>
             </tr>
 
@@ -387,7 +428,7 @@ Parameters
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: Create incident
       servicenow.itsm.incident:

--- a/docs/servicenow.itsm.problem_info_module.rst
+++ b/docs/servicenow.itsm.problem_info_module.rst
@@ -89,6 +89,28 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>grant_type</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.1.0</div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>password</b>&nbsp;&larr;</div></li>
+                                    <li>refresh_token</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Grant type used for OAuth authentication.</div>
+                        <div>If not set, the value of the <code>SN_GRANT_TYPE</code> environment variable will be used.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>host</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -111,7 +133,6 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
-                         / <span style="color: red">required</span>
                     </div>
                 </td>
                 <td>
@@ -119,6 +140,26 @@ Parameters
                 <td>
                         <div>Password used for authentication.</div>
                         <div>If not set, the value of the <code>SN_PASSWORD</code> environment variable will be used.</div>
+                        <div>Required when using basic authentication or when <em>grant_type=password</em>.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>refresh_token</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.1.0</div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Refresh token used for OAuth authentication.</div>
+                        <div>If not set, the value of the <code>SN_REFRESH_TOKEN</code> environment variable will be used.</div>
+                        <div>Required when <em>grant_type=refresh_token</em>.</div>
                 </td>
             </tr>
             <tr>
@@ -146,7 +187,6 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
-                         / <span style="color: red">required</span>
                     </div>
                 </td>
                 <td>
@@ -154,6 +194,7 @@ Parameters
                 <td>
                         <div>Username used for authentication.</div>
                         <div>If not set, the value of the <code>SN_USERNAME</code> environment variable will be used.</div>
+                        <div>Required when using basic authentication or when <em>grant_type=password</em>.</div>
                 </td>
             </tr>
 
@@ -205,7 +246,7 @@ See Also
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: Retrieve all problems
       servicenow.itsm.problem_info:

--- a/docs/servicenow.itsm.problem_module.rst
+++ b/docs/servicenow.itsm.problem_module.rst
@@ -207,6 +207,28 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>grant_type</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.1.0</div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>password</b>&nbsp;&larr;</div></li>
+                                    <li>refresh_token</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Grant type used for OAuth authentication.</div>
+                        <div>If not set, the value of the <code>SN_GRANT_TYPE</code> environment variable will be used.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>host</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -229,7 +251,6 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
-                         / <span style="color: red">required</span>
                     </div>
                 </td>
                 <td>
@@ -237,6 +258,26 @@ Parameters
                 <td>
                         <div>Password used for authentication.</div>
                         <div>If not set, the value of the <code>SN_PASSWORD</code> environment variable will be used.</div>
+                        <div>Required when using basic authentication or when <em>grant_type=password</em>.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>refresh_token</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.1.0</div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Refresh token used for OAuth authentication.</div>
+                        <div>If not set, the value of the <code>SN_REFRESH_TOKEN</code> environment variable will be used.</div>
+                        <div>Required when <em>grant_type=refresh_token</em>.</div>
                 </td>
             </tr>
             <tr>
@@ -264,7 +305,6 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
-                         / <span style="color: red">required</span>
                     </div>
                 </td>
                 <td>
@@ -272,6 +312,7 @@ Parameters
                 <td>
                         <div>Username used for authentication.</div>
                         <div>If not set, the value of the <code>SN_USERNAME</code> environment variable will be used.</div>
+                        <div>Required when using basic authentication or when <em>grant_type=password</em>.</div>
                 </td>
             </tr>
 
@@ -421,7 +462,7 @@ See Also
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: Create a problem
       servicenow.itsm.problem:

--- a/docs/servicenow.itsm.servicenow.itsm.now_inventory.rst
+++ b/docs/servicenow.itsm.servicenow.itsm.now_inventory.rst
@@ -470,7 +470,7 @@ Parameters
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     # A trivial example that creates a host from every record of the
     # ServiceNow cmdb_ci_server table. The ip_address column is used for

--- a/plugins/doc_fragments/instance.py
+++ b/plugins/doc_fragments/instance.py
@@ -28,25 +28,23 @@ options:
           - Username used for authentication.
           - If not set, the value of the C(SN_USERNAME) environment
             variable will be used.
-          - Required when using basic authentication
-            or when I(grant_type=password).
+          - Required when using basic authentication or when I(grant_type=password).
         type: str
       password:
         description:
           - Password used for authentication.
           - If not set, the value of the C(SN_PASSWORD) environment
             variable will be used.
-          - Required when using basic authentication
-            or when I(grant_type=password).
+          - Required when using basic authentication or when I(grant_type=password).
         type: str
       grant_type:
         description:
           - Grant type used for OAuth authentication.
-          - If not set, the value of the C(SN_GRANT_TYPE) environment
-            variable will be used.
-        choices: ['password', 'refresh_token']
+          - If not set, the value of the C(SN_GRANT_TYPE) environment variable will be used.
+        choices: [ 'password', 'refresh_token' ]
         default: password
         type: str
+        version_added: '1.1.0'
       client_id:
         description:
           - ID of the client application used for OAuth authentication.
@@ -68,6 +66,7 @@ options:
             variable will be used.
           - Required when I(grant_type=refresh_token).
         type: str
+        version_added: '1.1.0'
       timeout:
         description:
           - Timeout in seconds for the connection with the ServiceNow instance.

--- a/plugins/doc_fragments/instance.py
+++ b/plugins/doc_fragments/instance.py
@@ -28,14 +28,24 @@ options:
           - Username used for authentication.
           - If not set, the value of the C(SN_USERNAME) environment
             variable will be used.
-        required: true
+          - Required when using basic authentication
+            or when I(grant_type=password).
         type: str
       password:
         description:
           - Password used for authentication.
           - If not set, the value of the C(SN_PASSWORD) environment
             variable will be used.
-        required: true
+          - Required when using basic authentication
+            or when I(grant_type=password).
+        type: str
+      grant_type:
+        description:
+          - Grant type used for OAuth authentication.
+          - If not set, the value of the C(SN_GRANT_TYPE) environment
+            variable will be used.
+        choices: ['password', 'refresh_token']
+        default: password
         type: str
       client_id:
         description:
@@ -50,6 +60,13 @@ options:
           - If not set, the value of the C(SN_CLIENT_SECRET) environment
             variable will be used.
           - If provided, it requires I(client_id).
+        type: str
+      refresh_token:
+        description:
+          - Refresh token used for OAuth authentication.
+          - If not set, the value of the C(SN_REFRESH_TOKEN) environment
+            variable will be used.
+          - Required when I(grant_type=refresh_token).
         type: str
       timeout:
         description:

--- a/plugins/module_utils/arguments.py
+++ b/plugins/module_utils/arguments.py
@@ -61,8 +61,12 @@ SHARED_SPECS = dict(
             ("client_id", "client_secret"),
             ("username", "password")
         ],
-        required_one_of=[("username", "refresh_token")],
-        mutually_exclusive=[("username", "refresh_token")],
+        required_one_of=[
+            ("username", "refresh_token")
+        ],
+        mutually_exclusive=[
+            ("username", "refresh_token")
+        ],
         required_if=[
             ("grant_type", "password", ("username", "password")),
             ("grant_type", "refresh_token", ("refresh_token",))

--- a/plugins/module_utils/arguments.py
+++ b/plugins/module_utils/arguments.py
@@ -22,14 +22,21 @@ SHARED_SPECS = dict(
             ),
             username=dict(
                 type="str",
-                required=True,
                 fallback=(env_fallback, ["SN_USERNAME"]),
             ),
             password=dict(
                 type="str",
-                required=True,
                 no_log=True,
                 fallback=(env_fallback, ["SN_PASSWORD"]),
+            ),
+            grant_type=dict(
+                type="str",
+                choices=[
+                    "password",
+                    "refresh_token"
+                ],
+                default="password",
+                fallback=(env_fallback, ["SN_GRANT_TYPE"]),
             ),
             client_id=dict(
                 type="str",
@@ -40,12 +47,26 @@ SHARED_SPECS = dict(
                 no_log=True,
                 fallback=(env_fallback, ["SN_CLIENT_SECRET"]),
             ),
+            refresh_token=dict(
+                type="str",
+                no_log=True,
+                fallback=(env_fallback, ["SN_REFRESH_TOKEN"]),
+            ),
             timeout=dict(
                 type="float",
                 fallback=(env_fallback, ["SN_TIMEOUT"]),
             ),
         ),
-        required_together=[("client_id", "client_secret")],
+        required_together=[
+            ("client_id", "client_secret"),
+            ("username", "password")
+            ],
+        required_one_of=[("username", "refresh_token")],
+        mutually_exclusive=[("username", "refresh_token")],
+        required_if=[
+            ("grant_type", "password", ("username", "password")),
+            ("grant_type", "refresh_token", ("refresh_token",))
+            ]
     ),
     sys_id=dict(type="str"),
     number=dict(type="str"),

--- a/plugins/module_utils/arguments.py
+++ b/plugins/module_utils/arguments.py
@@ -60,13 +60,13 @@ SHARED_SPECS = dict(
         required_together=[
             ("client_id", "client_secret"),
             ("username", "password")
-            ],
+        ],
         required_one_of=[("username", "refresh_token")],
         mutually_exclusive=[("username", "refresh_token")],
         required_if=[
             ("grant_type", "password", ("username", "password")),
             ("grant_type", "refresh_token", ("refresh_token",))
-            ]
+        ]
     ),
     sys_id=dict(type="str"),
     number=dict(type="str"),

--- a/plugins/module_utils/client.py
+++ b/plugins/module_utils/client.py
@@ -40,13 +40,16 @@ class Response:
 
 class Client:
     def __init__(
-        self, host, username, password, client_id=None, client_secret=None, timeout=None
+        self, host, username=None, password=None, grant_type=None,
+        refresh_token=None, client_id=None, client_secret=None, timeout=None
     ):
         self.host = host
         self.username = username
         self.password = password
+        self.grant_type = grant_type
         self.client_id = client_id
         self.client_secret = client_secret
+        self.refresh_token = refresh_token
         self.timeout = timeout
 
         self._auth_header = None
@@ -67,15 +70,26 @@ class Client:
         return dict(Authorization=basic_auth_header(self.username, self.password))
 
     def _login_oauth(self):
-        auth_data = urlencode(
-            dict(
-                grant_type="password",
-                username=self.username,
-                password=self.password,
-                client_id=self.client_id,
-                client_secret=self.client_secret,
+        if self.grant_type == 'refresh_token':
+            auth_data = urlencode(
+                dict(
+                    grant_type=self.grant_type,
+                    refresh_token=self.refresh_token,
+                    client_id=self.client_id,
+                    client_secret=self.client_secret,
+                )
             )
-        )
+        # Only other possible value for grant_type is "password"
+        else:
+            auth_data = urlencode(
+                dict(
+                    grant_type=self.grant_type,
+                    username=self.username,
+                    password=self.password,
+                    client_id=self.client_id,
+                    client_secret=self.client_secret,
+                )
+            )
         resp = self._request(
             "POST",
             "{0}/oauth_token.do".format(self.host),

--- a/tests/integration/targets/api_authentication/tasks/main.yml
+++ b/tests/integration/targets/api_authentication/tasks/main.yml
@@ -25,7 +25,7 @@
           - result is failed
           - "'Failed to authenticate with the instance' in result.msg"
 
-    - name: OAuth authentication success
+    - name: OAuth authentication success with password
       servicenow.itsm.incident_info:
       environment:
         SN_USERNAME: "{{ sn_username }}"
@@ -58,6 +58,47 @@
         SN_PASSWORD: bad-password
         SN_CLIENT_ID: "{{ sn_client_id }}"
         SN_CLIENT_SECRET: "{{ sn_client_id }}"
+      register: result
+      ignore_errors: true
+    - assert:
+        that:
+          - result is failed
+          - "'Failed to authenticate with the instance' in result.msg"
+
+    - name: Get a refresh token to test with
+      ansible.builtin.uri:
+        url: "{{ sn_host }}/oauth_token.do"
+        method: POST
+        body_format: form-urlencoded
+        body:
+          grant_type: password
+          username: "{{ sn_username }}"
+          password: "{{ sn_password }}"
+          client_id: "{{ sn_client_id }}"
+          client_secret: "{{ sn_client_secret }}"
+      register: result
+    - ansible.builtin.set_fact:
+        sn_refresh_token: "{{ result.json.refresh_token }}"
+
+    - name: OAuth authentication success with refresh_token
+      servicenow.itsm.incident_info:
+      environment:
+        SN_GRANT_TYPE: refresh_token
+        SN_REFRESH_TOKEN: "{{ sn_refresh_token }}"
+        SN_CLIENT_ID: "{{ sn_client_id }}"
+        SN_CLIENT_SECRET: "{{ sn_client_secret }}"
+      register: result
+    - ansible.builtin.assert:
+        that:
+          - result is success
+
+    - name: OAuth authentication failure with bad refresh token
+      servicenow.itsm.incident_info:
+      environment:
+        SN_GRANT_TYPE: refresh_token
+        SN_REFRESH_TOKEN: bad-token
+        SN_CLIENT_ID: "{{ sn_client_id }}"
+        SN_CLIENT_SECRET: "{{ sn_client_secret }}"
       register: result
       ignore_errors: true
     - assert:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #63 

This introduces two new parameters, `grant_type` and `refresh_token`, in order to support additional OAuth login cases as described in the above issue.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_utils

##### ADDITIONAL INFORMATION
One issue I had while writing this is that to maintain backwards compatibility, `grant_type` has to default to `password`. This could be written more cleanly in a backwards-incompatible release.