### PR TITLE
Updated examples for grouping with os and install_status

### DIFF
--- a/docs/servicenow.itsm.servicenow.itsm.now_inventory.rst
+++ b/docs/servicenow.itsm.servicenow.itsm.now_inventory.rst
@@ -517,8 +517,8 @@ Examples
     #  |  |--INSIGHT-NY-03
     #  |--@ungrouped:
     
-    #Extended filtering on group hosts can be done, however not all options are added using real names, an example are grouping by install_status and OS. 
-    #A filter would look the following way: `install_status=1^os=Linux Red Hat`
+    # Extended filtering on group hosts can be done, however not all options are added using real names, an example are grouping by install_status and OS. 
+    # A filter would look the following way in sysparm_query: `install_status=1^os=Linux Red Hat`
     # 1 = Installed
     plugin: servicenow.itsm.now
     group_by:

--- a/docs/servicenow.itsm.servicenow.itsm.now_inventory.rst
+++ b/docs/servicenow.itsm.servicenow.itsm.now_inventory.rst
@@ -529,7 +529,7 @@ Examples
         includes:
           - Linux Red Hat
           
- # `ansible-inventory -i inventory.now.yaml --graph` output:
+    # `ansible-inventory -i inventory.now.yaml --graph` output:
     # @all:
     #  |--@Installed:
     #  |  |--DatabaseServer1

--- a/docs/servicenow.itsm.servicenow.itsm.now_inventory.rst
+++ b/docs/servicenow.itsm.servicenow.itsm.now_inventory.rst
@@ -516,7 +516,29 @@ Examples
     #  |  |--FileServerFloor2
     #  |  |--INSIGHT-NY-03
     #  |--@ungrouped:
-
+    
+    #Extended filtering on group hosts can be done, however not all options are added using real names, an example are grouping by install_status and OS. 
+    #A filter would look the following way: `install_status=1^os=Linux Red Hat`
+    # 1 = Installed
+    plugin: servicenow.itsm.now
+    group_by:
+      install_status:
+        includes:
+          - 1 
+      os:
+        includes:
+          - Linux Red Hat
+          
+ # `ansible-inventory -i inventory.now.yaml --graph` output:
+    # @all:
+    #  |--@Installed:
+    #  |  |--DatabaseServer1
+    #  |  |--DatabaseServer2
+    #  |--@Linux_Red_Hat:
+    #  |  |--DatabaseServer1
+    #  |  |--DatabaseServer2
+    #  |--@ungrouped:
+  
 
     # Group hosts into named groups, according to the specified criteria.
     # Below example creates a single group containing hosts that match


### PR DESCRIPTION
Updated install_status example to show example where naming can not be used and numbers has to be used instead.

##### SUMMARY
Documentation update to allow for more examples where naming can not be used, and real variables has to b e used. 

##### ISSUE TYPE
- Docs Pull Request


