### PR TITLE
Add a specification for the change_request_task module

### DIFF
--- a/plugins/modules/change_request_task.py
+++ b/plugins/modules/change_request_task.py
@@ -33,7 +33,7 @@ seealso:
   - module: servicenow.itsm.change_request_task_info
 
 options:
-  cmdb_ci:
+  configuration_item:
     description:
       - The configuration item (CI) or service that the change task applies to.
     type: str
@@ -70,7 +70,7 @@ options:
         is not in the C(pending), C(canceled), or C(closed).
       - Provide an On hold reason if a change task is placed on hold.
     type: bool
-  on_hold_reason:
+  hold_reason:
     description:
       - Reason why change task is on hold.
       - Required if change task's I(on_hold) value will be C(true).

--- a/plugins/modules/change_request_task.py
+++ b/plugins/modules/change_request_task.py
@@ -108,6 +108,13 @@ options:
       - The change task must have this parameter set prior to
         transitioning to the C(closed) state.
     type: str
+  other:
+    description:
+      - Optional remaining parameters.
+      - For more information on optional parameters, refer to the ServiceNow
+        change task documentation at
+        U(https://docs.servicenow.com/bundle/paris-it-service-management/page/product/change-management/task/create-a-change-task.html).
+    type: dict
 """
 
 EXAMPLES = """
@@ -130,6 +137,8 @@ EXAMPLES = """
     hold_reason: "Waiting for a report from the hardware team"
     planned_start_date: 2021-07-15 08:00:00
     planned_end_date: 2021-07-21 16:00:00
+    other:
+      approval: approved
   
 - name: Change state of the change task
   servicenow.itsm.change_request_task:

--- a/plugins/modules/change_request_task.py
+++ b/plugins/modules/change_request_task.py
@@ -37,6 +37,16 @@ options:
     description:
       - The configuration item (CI) or service that the change task applies to.
     type: str
+  change_request_id:
+    description:
+      - I(sys_id) of the change request this task belongs to.
+      - Mutually exclusive with I(change_request_number).
+    type: str
+  change_request_number:
+    description:
+      - I(number) of the change request this task belongs to.
+      - Mutually exclusive with I(change_request_id).
+    type: str
   type:
     description:
       - The type of change task.
@@ -46,7 +56,7 @@ options:
   state:
     description:
       - The state of the change request task.
-    choices: [ pending, open, in_progress, closed, canceled ]
+    choices: [ pending, open, in_progress, closed, canceled, absent ]
     type: str
   assigned_to:
     description:
@@ -85,31 +95,72 @@ options:
       - If the task I(type) is C(implementation), the I(planned_start_date) and I(planned_end_date) values 
       must fall within the planned start and end dates specified in the I(change_request).
     type: datetime
-  
+  close_code:
+    description:
+      - Provide information on how the change task was resolved.
+      - The change task must have this parameter set prior to
+        transitioning to the C(closed) state.
+    choices: [ successful, successful_issues, unsuccessful ]
+    type: str
+  close_notes:
+    description:
+      - Resolution notes added by the user who closed the change task.
+      - The change task must have this parameter set prior to
+        transitioning to the C(closed) state.
+    type: str
 """
 
-# TODO Check whether datetime type exists
-# TODO Check for more potentially useful fields
-
 EXAMPLES = """
-- name: Create change request
-  servicenow.itsm.change_request:
+- name: Create a change task
+  servicenow.itsm.change_request_task:
     instance:
       host: https://instance_id.service-now.com
       username: user
       password: pass
 
-    type: standard
-    state: new
-    requested_by: some.user
-    short_description: Install new Cisco
-    description: Please install new Cat. 6500 in Data center 01
-    priority: moderate
-    risk: low
-    impact: low
+    configuration_item: Rogue Squadron Launcher
+    change_request_number: CHG0000001
+    type: planning
+    state: open
+    assigned_to: fred.luddy
+    assignment_group: robot.embedded
+    short_description: Implement collision avoidance
+    description: "Implement collision avoidance based on the newly installed TOF sensor arrays."
+    on_hold: true
+    hold_reason: "Waiting for a report from the hardware team"
+    planned_start_date: 2021-07-15 08:00:00
+    planned_end_date: 2021-07-21 16:00:00
+  
+- name: Change state of the change task
+  servicenow.itsm.change_request_task:
+    instance:
+      host: https://instance_id.service-now.com
+      username: user
+      password: pass
 
-    other:
-      expected_start: 2021-02-12
+    state: in_progress
+    on_hold: false
+    number: CTASK0000001
+
+- name: Close a change task
+  servicenow.itsm.change_request_task:
+    instance:
+      host: https://instance_id.service-now.com
+      username: user
+      password: pass
+
+    state: closed
+    close_code: "successful"
+    close_notes: "Closed"
+    number: CTASK0000001
+
+- name: Delete a change task
+  servicenow.itsm.change_request_task:
+    instance:
+      host: https://instance_id.service-now.com
+      username: user
+      password: pass
+
+    state: absent
+    number: CTASK0000001
 """
-
-# TODO Add actual examples

--- a/plugins/modules/change_request_task.py
+++ b/plugins/modules/change_request_task.py
@@ -13,6 +13,9 @@ module: change_request_task
 
 author:
   - Matej Pevec (@mysteriouswolf)
+  - Manca Bizjak (@mancabizjak)
+  - Miha Dolinar (@mdolin)
+  - Tadej Borovsak (@tadeboro)
 
 short_description: Manage ServiceNow change request tasks
 

--- a/plugins/modules/change_request_task.py
+++ b/plugins/modules/change_request_task.py
@@ -1,0 +1,112 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2021, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+module: change_request_task
+
+author:
+  - Matej Pevec (@mysteriouswolf)
+
+short_description: Manage ServiceNow change request tasks
+
+description:
+  - Create, delete or update a ServiceNow change request tasks.
+  - For more information, refer to the ServiceNow change management documentation at
+    U(https://docs.servicenow.com/bundle/paris-it-service-management/page/product/change-management/concept/c_ITILChangeManagement.html).
+version_added: 1.0.0
+extends_documentation_fragment:
+  - servicenow.itsm.instance
+  - servicenow.itsm.sys_id
+  - servicenow.itsm.number
+
+seealso:
+  - module: servicenow.itsm.change_request_task_info
+
+options:
+  cmdb_ci:
+    description:
+      - The configuration item (CI) or service that the change task applies to.
+    type: str
+  type:
+    description:
+      - The type of change task.
+      - Default workflow generates tasks in I(type) C(review)
+    choices: [ planning, implementation, testing, review ]
+    type: str
+  state:
+    description:
+      - The state of the change request task.
+    choices: [ pending, open, in_progress, closed, canceled ]
+    type: str
+  assigned_to:
+    description:
+      - The user that the change task is assigned to.
+    type: str
+  assignment_group:
+    description:
+      - The group that the change task is assigned to.
+    type: str
+  short_description:
+    description:
+      - A summary of the task.
+    type: str
+  description:
+    description:
+      - A detailed description of the task.
+    type: str
+  on_hold:
+    description:
+      - A change task can be put on hold when I(state)
+        is not in the C(pending), C(canceled), or C(closed).
+      - Provide an On hold reason if a change task is placed on hold.
+    type: bool
+  on_hold_reason:
+    description:
+      - Reason why change task is on hold.
+      - Required if change task's I(on_hold) value will be C(true).
+    type: str
+  planned_start_date:
+    description:
+      - The date you plan to begin working on the task.
+    type: datetime
+  planned_end_date:
+    description:
+      - The date the change task is planned to be completed.
+      - If the task I(type) is C(implementation), the I(planned_start_date) and I(planned_end_date) values 
+      must fall within the planned start and end dates specified in the I(change_request).
+    type: datetime
+  
+"""
+
+# TODO Check whether datetime type exists
+# TODO Check for more potentially useful fields
+
+EXAMPLES = """
+- name: Create change request
+  servicenow.itsm.change_request:
+    instance:
+      host: https://instance_id.service-now.com
+      username: user
+      password: pass
+
+    type: standard
+    state: new
+    requested_by: some.user
+    short_description: Install new Cisco
+    description: Please install new Cat. 6500 in Data center 01
+    priority: moderate
+    risk: low
+    impact: low
+
+    other:
+      expected_start: 2021-02-12
+"""
+
+# TODO Add actual examples

--- a/plugins/modules/change_request_task_info.py
+++ b/plugins/modules/change_request_task_info.py
@@ -45,7 +45,7 @@ EXAMPLES = r"""
 
 - name: Retrieve change request tasks by number
   servicenow.itsm.change_request_task_info:
-    number: TASK0000001
+    number: CTASK0000001
   register: result
 
 - name: Retrieve change request tasks that contain SAP in their short description
@@ -66,7 +66,7 @@ EXAMPLES = r"""
 RETURN = r"""
 records:
   description:
-    - A list of change request records.
+    - A list of change task records.
   returned: success
   type: list
   sample:

--- a/plugins/modules/change_request_task_info.py
+++ b/plugins/modules/change_request_task_info.py
@@ -1,0 +1,71 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2021, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+DOCUMENTATION = r"""
+module: change_request_task_info
+
+author:
+  - Matej Pevec (@mysteriouswolf)
+  
+short_description: List ServiceNow change request tasks
+description:
+  - Retrieve information about ServiceNow change request tasks.
+  - For more information, refer to the ServiceNow change management documentation at
+    U(https://docs.servicenow.com/bundle/paris-it-service-management/page/product/change-management/concept/c_ITILChangeManagement.html).
+version_added: 1.0.0
+extends_documentation_fragment:
+  - servicenow.itsm.instance
+  - servicenow.itsm.sys_id.info
+  - servicenow.itsm.number.info
+  - servicenow.itsm.query
+seealso:
+  - module: servicenow.itsm.change_request_task
+"""
+
+EXAMPLES = r"""
+- name: Retrieve all change request tasks
+  servicenow.itsm.change_request_task_info:
+  register: result
+
+- name: Retrieve a specific change request task by its sys_id
+  servicenow.itsm.change_request_task_info:
+    sys_id: 471bfbc7a9fe198101e77a3e10e5d47f
+  register: result
+
+- name: Retrieve change request tasks by number
+  servicenow.itsm.change_request_task_info:
+    number: TASK0000001
+  register: result
+
+- name: Retrieve change request tasks that contain SAP in their short description
+  servicenow.itsm.change_request_task_info:
+    query:
+      - short_description: LIKE SAP
+  register: result
+
+- name: Retrieve new change requests assigned to abel.tuter or bertie.luby
+  servicenow.itsm.change_request_task_info:
+    query:
+      - state: = new
+        assigned_to: = abel.tuter
+      - state: = new
+        assigned_to: = bertie.luby
+"""
+
+RETURN = r"""
+records:
+  description:
+    - A list of change request records.
+  returned: success
+  type: list
+  sample:
+    - TBD
+"""

--- a/plugins/modules/change_request_task_info.py
+++ b/plugins/modules/change_request_task_info.py
@@ -14,6 +14,9 @@ module: change_request_task_info
 
 author:
   - Matej Pevec (@mysteriouswolf)
+  - Manca Bizjak (@mancabizjak)
+  - Miha Dolinar (@mdolin)
+  - Tadej Borovsak (@tadeboro)
   
 short_description: List ServiceNow change request tasks
 description:


### PR DESCRIPTION
##### SUMMARY
Adds a specification for the change_request_task module with usage examples.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
- change_request_task and change_request_task_info

##### ADDITIONAL INFORMATION
The specification allows users to modify all [standard parameters](https://docs.servicenow.com/bundle/quebec-it-service-management/page/product/change-management/task/create-a-change-task.html) defined in the ServiceNow docs, as well as properties required to create and close tasks.