### PR TITLE
Update on query module utils for unary operators

### DIFF
--- a/tests/integration/targets/change_request/tasks/main.yml
+++ b/tests/integration/targets/change_request/tasks/main.yml
@@ -378,3 +378,27 @@
     - ansible.builtin.assert:
         that:
           - "'Oracle' in result.records[0].short_description"
+
+
+    - name: Test unary operator with argument detection
+      servicenow.itsm.change_request_info:
+        query:
+         - short_description: ISEMPTY SAP
+      ignore_errors: true
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'Operator ISEMPTY does not take any arguments' in result.msg"
+
+
+    - name: Test sysparm query unary operator - short_description
+      servicenow.itsm.change_request_info:
+        query:
+         - short_description: ISNOTEMPTY
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result.records[0].short_description != ""

--- a/tests/integration/targets/configuration_item/tasks/main.yml
+++ b/tests/integration/targets/configuration_item/tasks/main.yml
@@ -267,3 +267,27 @@
     - ansible.builtin.assert:
         that:
           - "'lnux101' in result.records[0].name"
+
+
+    - name: Test unary operator with argument detection
+      servicenow.itsm.configuration_item_info:
+        query:
+         - short_description: ISEMPTY SAP
+      ignore_errors: true
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'Operator ISEMPTY does not take any arguments' in result.msg"
+
+
+    - name: Test sysparm query unary operator - short_description
+      servicenow.itsm.configuration_item_info:
+        query:
+         - short_description: ISNOTEMPTY
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result.records[0].short_description != ""

--- a/tests/integration/targets/incident/tasks/main.yml
+++ b/tests/integration/targets/incident/tasks/main.yml
@@ -267,3 +267,27 @@
     - ansible.builtin.assert:
         that:
           - "'SAP' in result.records[0].short_description"
+
+
+    - name: Test unary operator with argument detection
+      servicenow.itsm.incident_info:
+        query:
+         - short_description: ISEMPTY SAP
+      ignore_errors: true
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'Operator ISEMPTY does not take any arguments' in result.msg"
+
+
+    - name: Test sysparm query unary operator - short_description
+      servicenow.itsm.incident_info:
+        query:
+         - short_description: ISNOTEMPTY
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result.records[0].short_description != ""

--- a/tests/integration/targets/problem/tasks/main.yml
+++ b/tests/integration/targets/problem/tasks/main.yml
@@ -366,3 +366,27 @@
     - ansible.builtin.assert:
         that:
           - "'email' in result.records[0].subcategory"
+
+
+    - name: Test unary operator with argument detection
+      servicenow.itsm.problem_info:
+        query:
+         - short_description: ISEMPTY SAP
+      ignore_errors: true
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'Operator ISEMPTY does not take any arguments' in result.msg"
+
+
+    - name: Test sysparm query unary operator - short_description
+      servicenow.itsm.problem_info:
+        query:
+         - short_description: ISNOTEMPTY
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result.records[0].short_description != ""

--- a/tests/unit/plugins/module_utils/test_query.py
+++ b/tests/unit/plugins/module_utils/test_query.py
@@ -24,6 +24,11 @@ class TestGetOperatorAndValue:
 
         assert result == ("=", "new")
 
+    def test_unary_operator(self):
+        result = query.get_operator_and_value("ISEMPTY")
+
+        assert result == ("ISEMPTY", "")
+
     def test_invalid_operator(self):
         result = query.get_operator_and_value("== new")
 
@@ -83,6 +88,15 @@ class TestParseQuery:
         )
 
         assert result == ([], ["Invalid condition '== new' for column 'state'."])
+
+    def test_error_parse_unary_query(self):
+        result = query.parse_query(
+            [
+                {"state": "ISEMPTY new"},
+            ]
+        )
+
+        assert result == ([], ["Operator ISEMPTY does not take any arguments"])
 
 
 class TestSerializeQuery:


### PR DESCRIPTION
Update on query module utils for unary operators
as they do not take any arguments.

https://docs.servicenow.com/bundle/quebec-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html