### PR TITLE
Bugfix change_request validation

### DIFF
--- a/changelogs/fragments/change-request-change-on-hold-validation.yaml
+++ b/changelogs/fragments/change-request-change-on-hold-validation.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - change_request - validates on_hold with its respective field instead of a non-existent "on_hold" state when requiring a hold_reason

--- a/changelogs/fragments/change-request-change-on-hold-validation.yaml
+++ b/changelogs/fragments/change-request-change-on-hold-validation.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - change_request - validates on_hold with its respective field instead of a non-existent "on_hold" state when requiring a hold_reason
+  - change_request - validates on_hold with its respective field instead of a non-existent "on_hold" state when requiring a hold_reason (https://github.com/ansible-collections/servicenow.itsm/pull/86).

--- a/plugins/modules/change_request.py
+++ b/plugins/modules/change_request.py
@@ -427,7 +427,7 @@ def main():
             ("state", "authorize", ("assignment_group",)),
             ("state", "scheduled", ("assignment_group",)),
             ("state", "assess", ("assignment_group",)),
-            ("state", "on_hold", ("hold_reason",)),
+            ("on_hold", True, ("hold_reason",)),
         ],
     )
 

--- a/tests/integration/targets/change_request/tasks/main.yml
+++ b/tests/integration/targets/change_request/tasks/main.yml
@@ -86,6 +86,19 @@
           - "'state is scheduled but all of the following are missing: assignment_group' in result.msg"
 
 
+    - name: Attempt to put the change request on hold without specifying the reason
+      servicenow.itsm.change_request:
+        number: "{{ test_result.record.number }}"
+        on_hold: true
+      ignore_errors: true
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'on_hold is True but all of the following are missing: hold_reason'"
+
+
     - name: Update change_request - check mode
       servicenow.itsm.change_request: &update-change_request
         requested_by: admin


### PR DESCRIPTION
##### SUMMARY
- Fix `change_request` `hold_reason` requirement
- Add integration tests for setting `change_request` `on_hold` without a `hold_reason`


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`change_request`

##### ADDITIONAL INFORMATION
- The `change_request` module now validates `on_hold` with its respective field instead of a non-existent `on_hold` `state` when requiring a `hold_reason`
- Added an integration test to cover on-hold management requirements (sets on_hold to true without a reason and checks the module's response)