### PR TITLE
Fix change_request creation tests to test against the correct result

### DIFF
--- a/tests/integration/targets/change_request/tasks/main.yml
+++ b/tests/integration/targets/change_request/tasks/main.yml
@@ -40,6 +40,10 @@
       servicenow.itsm.change_request: *create-change_request
       register: test_result
 
+    - name: Copy test_result into result
+      set_fact:
+        result: "{{ test_result }}"
+
     - ansible.builtin.assert: *create-change_request-result
 
 


### PR DESCRIPTION
##### SUMMARY
- Fix `change_request` creation integration tests to test against the correct result


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`change_request`

##### ADDITIONAL INFORMATION
- Create test change_request (not the check mode one) results never got tested/checked since the task outputs its state in a different variable called `test_result` for later use. The module now copies that value into the `result` var before the test happens to fix that.