### PR TITLE
Remove redundant "query" variable initialization

### DIFF
--- a/plugins/modules/configuration_item_info.py
+++ b/plugins/modules/configuration_item_info.py
@@ -195,7 +195,6 @@ def sysparms_query(module, table_client, mapper):
 
 
 def run(module, table_client):
-    query = utils.filter_dict(module.params, "sys_id")
     cmdb_table = module.params["sys_class_name"] or "cmdb_ci"
     mapper = utils.PayloadMapper(PAYLOAD_FIELDS_MAPPING, module.warn)
 


### PR DESCRIPTION
##### SUMMARY
Remove a redundant variable initialization as it gets overwritten in every case in the following lines.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Configuration item