### PR TITLE
Add bulk update CMDB module

### DIFF
--- a/plugins/action/configuration_item_batch.py
+++ b/plugins/action/configuration_item_batch.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2021, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+from ansible.plugins.action import ActionBase
+from ansible.utils.vars import merge_hash
+
+from jinja2 import Environment
+
+
+def validate(name, args, required, typ):
+    """
+    Make sure that required values are not None and that if the value is
+    present, it is of the correct type.
+    """
+    value = args.get(name)
+    messages = []
+    if required and value is None:
+        messages.append("{0} is required argument".format(name))
+    if value is not None and not isinstance(value, typ):
+        messages.append("{0} should be {1}".format(name, typ))
+    return messages
+
+
+class ActionModule(ActionBase):
+    def run(self, _tmp=None, task_vars=None):
+        self._supports_check_mode = True
+        self._supports_async = True
+
+        result = super(ActionModule, self).run(task_vars=task_vars)
+
+        wrap_async = self._task.async_val and not self._connection.has_native_async
+
+        try:
+            err_msgs = self.validate_arguments(self._task.args)
+            if err_msgs:
+                return dict(result, failed=True, msg=" ".join(err_msgs))
+
+            args = dict(
+                self._task.args,
+                dataset=self.build_asset(
+                    self._task.args["map"], self._task.args["dataset"]
+                ),
+                map=dict(),
+            )
+
+            return merge_hash(
+                result,
+                self._execute_module(
+                    module_name="servicenow.itsm.configuration_item_batch",
+                    module_args=args,
+                    task_vars=task_vars,
+                    wrap_async=wrap_async,
+                ),
+            )
+
+        finally:
+            if not wrap_async:
+                self._remove_tmp_path(self._connection._shell.tmpdir)
+
+    @staticmethod
+    def validate_arguments(args):
+        # We only validate arguments that we use. We let the module
+        # validate the rest (like auth data).
+        messages = []
+        messages.extend(validate("dataset", args, required=True, typ=list))
+        messages.extend(validate("map", args, required=True, typ=dict))
+
+        return messages
+
+    @staticmethod
+    def build_asset(mapping, dataset):
+        cmdb_items = [{} for _i in range(len(dataset))]
+        env = Environment()
+
+        for key, template in mapping.items():
+            t = env.from_string("{{" + template + "}}")
+
+            for input, output in zip(dataset, cmdb_items):
+                output[key] = t.render(**input)
+
+        return cmdb_items

--- a/plugins/modules/configuration_item_batch.py
+++ b/plugins/modules/configuration_item_batch.py
@@ -1,0 +1,163 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2021, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+module: configuration_item_batch
+
+author:
+  - Manca Bizjak (@mancabizjak)
+  - Miha Dolinar (@mdolin)
+  - Tadej Borovsak (@tadeboro)
+
+short_description: Manage ServiceNow configuration items
+
+description:
+  - Create, delete or update a ServiceNow configuration item.
+  - For more information, refer to the ServiceNow configuration management documentation at
+    U(https://docs.servicenow.com/bundle/paris-servicenow-platform/page/product/configuration-management/reference/cmdb-table-property-descriptions.html).
+version_added: 2.0.0
+extends_documentation_fragment:
+  - servicenow.itsm.instance
+
+seealso:
+  - module: servicenow.itsm.configuration_item
+  - module: servicenow.itsm.configuration_item_info
+
+options:
+  sys_class_name:
+    description:
+      - Table name (configuration item type) that we would like to manipulate.
+    required: true
+    type: str
+  id_column_set:
+    description:
+      - Columns that should be used to identify an existing record that we need to update.
+    required: true
+    type: list
+    elements: str
+  dataset:
+    description:
+      - List of dictionaries that will be used as a data source.
+      - Each item in a list represents one CMDB item.
+    required: true
+    type: list
+    elements: dict
+  map:
+    description:
+      - Transformation instructions on how to convert input data to CMDB items.
+      - Keys represent the CMDB item column names and the values are Jinja expressions
+        that extract the value from the source data.
+      - Data is returned as string because ServiceNow API expect this
+    required: true
+    type: dict
+"""
+
+EXAMPLES = r"""
+- name: Update CMDB with some data
+  servicenow.itsm.configuration_item_batch:
+    sys_class_name: cmdb_ci_ec2_instance
+    id_column_set: vm_inst_id
+    dataset:
+      - instance_id: 12345
+        public_ip_address: 1.2.3.4
+        tags:
+          Name: my_name
+      - instance_id: 54321
+        public_ip_address: 4.3.2.1
+        tags:
+          Name: other_name
+    map:
+      vm_inst_id: instance_id
+      ip_address: public_ip_adress
+      name: tags.Name
+
+- name: Identify CMDB item using combination of two columns
+  servicenow.itsm.configuration_item_batch:
+    sys_class_name: cmdb_ci_server
+    id_column_set:
+      - name
+      - ip_address
+    dataset: "{{ input_data }}"
+    map:
+      name: tags.Name
+      ip_address: private_ip_address
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ..module_utils import arguments, client, errors, table, utils
+
+
+def update(module, table_client):
+    changed = False
+    cmdb_table = module.params["sys_class_name"]
+    id_column_set = module.params["id_column_set"]
+
+    for desired in module.params["dataset"]:
+        query = dict((c, desired[c]) for c in id_column_set)
+        current = table_client.get_record(cmdb_table, query)
+
+        if not current:
+            table_client.create_record(cmdb_table, desired, module.check_mode)
+            changed = True
+            continue
+
+        if utils.is_superset(current, desired):
+            continue
+
+        table_client.update_record(cmdb_table, current, desired, module.check_mode)
+        changed = True
+
+    return changed
+
+
+def main():
+    module_args = dict(
+        arguments.get_spec("instance"),
+        sys_class_name=dict(
+            type="str",
+            required=True,
+        ),
+        id_column_set=dict(
+            type="list",
+            elements="str",
+            required=True,
+        ),
+        dataset=dict(
+            type="list",
+            elements="dict",
+            required=True,
+        ),
+        map=dict(
+            type="dict",
+            required=True,
+        ),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    if not module.params["id_column_set"]:
+        module.fail_json(msg="id_column_set should not be empty")
+
+    try:
+        snow_client = client.Client(**module.params["instance"])
+        table_client = table.TableClient(snow_client)
+        changed = update(module, table_client)
+        module.exit_json(changed=changed)
+    except errors.ServiceNowError as e:
+        module.fail_json(msg=str(e))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/configuration_item_batch/tasks/main.yml
+++ b/tests/integration/targets/configuration_item_batch/tasks/main.yml
@@ -1,0 +1,258 @@
+---
+- environment:
+    SN_HOST: "{{ sn_host }}"
+    SN_USERNAME: "{{ sn_username }}"
+    SN_PASSWORD: "{{ sn_password }}"
+
+  block:
+    - name: Register instance in ServiceNow
+      servicenow.itsm.configuration_item:
+        name: Demo EC2 instance
+        sys_class_name: cmdb_ci_ec2_instance
+        ip_address: 1.1.1.1
+        other:
+          vm_inst_id: 10
+      register: ci
+
+    - ansible.builtin.assert:
+        that:
+          - ci is changed
+          - ci.record.ip_address == "1.1.1.1"
+          - ci.record.vm_inst_id == "10"
+
+
+    - name: Update existing CMDB
+      configuration_item_batch: &update_cmdb
+        sys_class_name: cmdb_ci_ec2_instance
+        id_column_set: vm_inst_id
+        dataset:
+          - instance_id: 10
+            public_ip_address: 10.10.10.10
+            tags:
+              Name: instance_10
+        map:
+          vm_inst_id: instance_id
+          ip_address: public_ip_address
+          name: tags.Name
+      check_mode: true
+      register: ci
+
+    - ansible.builtin.assert:
+        that:
+          - ci is changed
+
+
+    - name: Configuration item info
+      configuration_item_info:
+        sys_class_name: cmdb_ci_ec2_instance
+        query:
+          - vm_inst_id: = 10
+      register: ci
+
+    - ansible.builtin.assert:
+        that:
+          - ci.records[0].ip_address == "1.1.1.1"
+          - ci.records[0].vm_inst_id == "10"
+
+
+    - name: Update existing CMDB
+      configuration_item_batch: *update_cmdb
+      register: ci
+
+    - ansible.builtin.assert:
+        that:
+          - ci is changed
+
+
+    - name: Configuration item info
+      configuration_item_info:
+        sys_class_name: cmdb_ci_ec2_instance
+        query:
+          - vm_inst_id: = 10
+      register: ci
+
+    - ansible.builtin.assert:
+        that:
+          - ci.records[0].ip_address == "10.10.10.10"
+          - ci.records[0].name == "instance_10"
+
+
+    - name: Delete a configuration item
+      servicenow.itsm.configuration_item:
+        sys_id: "{{ ci.records[0].sys_id }}"
+        state: absent
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result is changed
+
+
+    - name: Update CMDB with data from AWS
+      configuration_item_batch: &state_check_params
+        sys_class_name: cmdb_ci_ec2_instance
+        id_column_set: vm_inst_id
+        dataset:
+          - instance_id: 11
+            public_ip_address: 1.2.3.4
+            tags:
+              Name: my_name
+          - instance_id: 12
+            public_ip_address: 4.3.2.1
+            tags:
+              Name: other_name
+        map:
+          vm_inst_id: instance_id
+          ip_address: public_ip_address
+          name: tags.Name
+      register: ci
+
+    - ansible.builtin.assert:
+        that:
+          - ci is changed
+
+
+    - name: Configuration item info
+      configuration_item_info:
+        sys_class_name: cmdb_ci_ec2_instance
+        query:
+          - vm_inst_id: = 11
+      register: ci
+
+    - ansible.builtin.assert:
+        that:
+          - ci.records[0].ip_address == "1.2.3.4"
+          - ci.records[0].name == "my_name"
+
+
+    - name: Configuration item info
+      configuration_item_info:
+        sys_class_name: cmdb_ci_ec2_instance
+        query:
+          - vm_inst_id: = 12
+      register: ci
+
+    - ansible.builtin.assert:
+        that:
+          - ci.records[0].ip_address == "4.3.2.1"
+          - ci.records[0].name == "other_name"
+
+
+    - name: Update CMDB with same data
+      configuration_item_batch: *state_check_params
+      register: ci
+
+    - ansible.builtin.assert:
+        that:
+          - ci is not changed
+
+
+    - name: Configuration item info
+      configuration_item_info:
+        sys_class_name: cmdb_ci_ec2_instance
+        query:
+          - vm_inst_id: = 11
+      register: ci
+
+    - ansible.builtin.assert:
+        that:
+          - ci.records[0].ip_address == "1.2.3.4"
+          - ci.records[0].name == "my_name"
+
+
+    - name: Configuration item info
+      configuration_item_info:
+        sys_class_name: cmdb_ci_ec2_instance
+        query:
+          - vm_inst_id: = 12
+      register: ci
+
+    - ansible.builtin.assert:
+        that:
+          - ci.records[0].ip_address == "4.3.2.1"
+          - ci.records[0].name == "other_name"
+
+
+    - name: Update CMDB with different data
+      configuration_item_batch:
+        sys_class_name: cmdb_ci_ec2_instance
+        id_column_set: vm_inst_id
+        dataset:
+          - instance_id: 11
+            public_ip_address: 1.1.1.1
+            tags:
+              Name: my_name
+          - instance_id: 12
+            public_ip_address: 2.2.2.2
+            tags:
+              Name: other_name
+        map:
+          vm_inst_id: instance_id | string
+          ip_address: public_ip_address
+          name: tags.Name
+      register: ci
+
+    - ansible.builtin.assert:
+        that:
+          - ci is changed
+
+
+    - name: Configuration item info
+      configuration_item_info:
+        sys_class_name: cmdb_ci_ec2_instance
+        query:
+          - vm_inst_id: = 11
+      register: ci
+
+    - ansible.builtin.assert:
+        that:
+          - ci.records[0].ip_address == "1.1.1.1"
+          - ci.records[0].name == "my_name"
+
+
+    - name: Delete a configuration item
+      servicenow.itsm.configuration_item:
+        sys_id: "{{ ci.records[0].sys_id }}"
+        state: absent
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result is changed
+
+
+    - name: Configuration item info
+      configuration_item_info:
+        sys_class_name: cmdb_ci_ec2_instance
+        query:
+          - vm_inst_id: = 12
+      register: ci
+
+    - ansible.builtin.assert:
+        that:
+          - ci.records[0].ip_address == "2.2.2.2"
+          - ci.records[0].name == "other_name"
+
+
+    - name: Delete a configuration item
+      servicenow.itsm.configuration_item:
+        sys_id: "{{ ci.records[0].sys_id }}"
+        state: absent
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result is changed
+
+
+    - name: Configuration item info
+      configuration_item_info:
+        sys_class_name: cmdb_ci_ec2_instance
+        query:
+          - vm_inst_id: = 11
+          - vm_inst_id: = 12
+      register: ci
+
+    - ansible.builtin.assert:
+        that:
+          - ci.records | length == 0

--- a/tests/unit/plugins/action/test_configuration_item_batch.py
+++ b/tests/unit/plugins/action/test_configuration_item_batch.py
@@ -1,0 +1,201 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import pytest
+
+from ansible.playbook.task import Task
+
+from ansible_collections.servicenow.itsm.plugins.action import configuration_item_batch
+
+
+class TestValidate:
+    @pytest.mark.parametrize(
+        "name,args,required,typ",
+        [
+            # Required values must match the selected type.
+            ("a", dict(a=3), True, int),
+            ("a", dict(a=3.3), True, float),
+            ("a", dict(a="b"), True, str),
+            ("a", dict(a=[]), True, list),
+            ("a", dict(a={}), True, dict),
+            # Optional values are not checked for type-correctness if they are
+            # missing.
+            ("a", dict(), False, int),
+            ("a", dict(), False, float),
+            ("a", dict(), False, str),
+            ("a", dict(), False, list),
+            ("a", dict(), False, dict),
+        ],
+    )
+    def test_valid_values(self, name, args, required, typ):
+        result = configuration_item_batch.validate(name, args, required, typ)
+        assert result == []
+
+    def test_missing_required(self):
+        result = configuration_item_batch.validate("a", {}, True, str)
+        assert result == ["a is required argument"]
+
+    def test_invalid_type(self):
+        result = configuration_item_batch.validate("a", dict(a=3), True, str)
+        assert result == ["a should be <class 'str'>"] or ["a should be <type 'str'>"]
+
+
+class TestValidateArguments:
+    def test_valid_all_args(self):
+        assert [] == configuration_item_batch.ActionModule.validate_arguments(
+            dict(dataset=[{}], map={})
+        )
+
+    def test_invalid_dataset(self):
+        result = configuration_item_batch.ActionModule.validate_arguments(
+            dict(dataset={}, map={})
+        )
+
+        assert len(result) == 1
+        assert "dataset" in result[0]
+
+    def test_invalid_map(self):
+        result = configuration_item_batch.ActionModule.validate_arguments(
+            dict(dataset=[{}], map=[])
+        )
+
+        assert len(result) == 1
+        assert "map" in result[0]
+
+
+class TestBuildAssetArgs:
+    def test_mapping_with_one_dataset(self):
+        result = configuration_item_batch.ActionModule.build_asset(
+            dict(
+                vm_inst_id="instance_id",
+                ip_address="public_ip_address",
+                name="tags.Name",
+            ),
+            [
+                dict(
+                    instance_id=12345,
+                    public_ip_address="1.2.3.4",
+                    tags=dict(
+                        Name="my_name",
+                    ),
+                ),
+            ],
+        )
+
+        assert result == [
+            dict(
+                vm_inst_id="12345",
+                ip_address="1.2.3.4",
+                name="my_name",
+            )
+        ]
+
+    def test_mapping_with_two_datasets(self):
+        result = configuration_item_batch.ActionModule.build_asset(
+            dict(
+                vm_inst_id="instance_id",
+                ip_address="public_ip_address",
+                name="tags.Name",
+            ),
+            [
+                dict(
+                    instance_id=12345,
+                    public_ip_address="1.2.3.4",
+                    tags=dict(
+                        Name="my_name",
+                    ),
+                ),
+                dict(
+                    instance_id=54321,
+                    public_ip_address="4.3.2.1",
+                    tags=dict(
+                        Name="other_name",
+                    ),
+                ),
+            ],
+        )
+
+        assert result == [
+            dict(
+                vm_inst_id="12345",
+                ip_address="1.2.3.4",
+                name="my_name",
+            ),
+            dict(
+                vm_inst_id="54321",
+                ip_address="4.3.2.1",
+                name="other_name",
+            ),
+        ]
+
+    def test_mapping_string_conversion(self):
+        result = configuration_item_batch.ActionModule.build_asset(
+            dict(vm_inst_id="instance_id | string"), [dict(instance_id=12345)]
+        )
+
+        assert result == [dict(vm_inst_id="12345")]
+
+    def test_mapping_float_conversion(self):
+        result = configuration_item_batch.ActionModule.build_asset(
+            dict(vm_inst_id="instance_id | float"), [dict(instance_id=123.45)]
+        )
+
+        assert result == [dict(vm_inst_id="123.45")]
+
+    def test_mapping_int_conversion(self):
+        result = configuration_item_batch.ActionModule.build_asset(
+            dict(vm_inst_id="instance_id | int"), [dict(instance_id=12345)]
+        )
+
+        assert result == [dict(vm_inst_id="12345")]
+
+
+class TestRun:
+    def test_success(self, mocker):
+        task = mocker.MagicMock(
+            Task,
+            async_val=0,
+            args=dict(
+                dataset=[dict(public_ip_address="1.2.3.4")],
+                map=dict(ip_address="public_ip_address"),
+            ),
+        )
+        action = configuration_item_batch.ActionModule(
+            task,
+            mocker.MagicMock(),
+            mocker.MagicMock(),
+            loader=None,
+            templar=None,
+            shared_loader_obj=None,
+        )
+        action._execute_module = mocker.MagicMock(
+            return_value=dict(ip_address="1.2.3.4")
+        )
+
+        result = action.run()
+
+        assert result == dict(ip_address="1.2.3.4")
+
+    def test_fail(self, mocker):
+        task = mocker.MagicMock(
+            Task,
+            async_val=0,
+            args=dict(dataset=[dict(public_ip_address="1.2.3.4")]),
+        )
+        action = configuration_item_batch.ActionModule(
+            task,
+            mocker.MagicMock(),
+            mocker.MagicMock(),
+            loader=None,
+            templar=None,
+            shared_loader_obj=None,
+        )
+        action._execute_module = mocker.MagicMock(
+            return_value=dict(ip_address="1.2.3.4")
+        )
+
+        result = action.run()
+
+        assert result["failed"] is True
+        assert result["msg"] == "map is required argument"

--- a/tests/unit/plugins/modules/test_configuration_item_batch.py
+++ b/tests/unit/plugins/modules/test_configuration_item_batch.py
@@ -1,0 +1,85 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+
+import pytest
+
+
+from ansible_collections.servicenow.itsm.plugins.modules import configuration_item_batch
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires python2.7 or higher"
+)
+
+
+class TestUpdate:
+    def test_update_create_record(self, create_module, table_client):
+        module = create_module(
+            params=dict(
+                instance=dict(
+                    host="https://my.host.name", username="user", password="pass"
+                ),
+                sys_class_name="cmdb_ci_ec2_instance",
+                id_column_set=["vm_inst_id"],
+                dataset=[
+                    dict(vm_inst_id="12345", ip_address="1.2.3.4", name="my_name")
+                ],
+            )
+        )
+        table_client.get_record.return_value = None
+
+        result = configuration_item_batch.update(module, table_client)
+
+        table_client.create_record.assert_called_once()
+        table_client.update_record.assert_not_called()
+        assert result is True
+
+    def test_update_is_superset(self, create_module, table_client):
+        module = create_module(
+            params=dict(
+                instance=dict(
+                    host="https://my.host.name", username="user", password="pass"
+                ),
+                sys_class_name="cmdb_ci_ec2_instance",
+                id_column_set=["vm_inst_id"],
+                dataset=[
+                    dict(vm_inst_id="12345", ip_address="1.2.3.4", name="my_name")
+                ],
+            )
+        )
+
+        table_client.get_record.return_value = dict(
+            ip_address="1.2.3.4", name="my_name", vm_inst_id="12345"
+        )
+
+        result = configuration_item_batch.update(module, table_client)
+
+        table_client.create_record.assert_not_called()
+        table_client.update_record.assert_not_called()
+        assert result is False
+
+    def test_update_update_record(self, create_module, table_client):
+        module = create_module(
+            params=dict(
+                instance=dict(
+                    host="https://my.host.name", username="user", password="pass"
+                ),
+                sys_class_name="cmdb_ci_ec2_instance",
+                id_column_set=["vm_inst_id"],
+                dataset=[
+                    dict(vm_inst_id="12345", ip_address="1.2.3.4", name="my_name")
+                ],
+            )
+        )
+
+        table_client.get_record.return_value = dict(
+            ip_address="1.1.1.1", name="my_name", vm_inst_id="12345"
+        )
+
+        result = configuration_item_batch.update(module, table_client)
+
+        table_client.create_record.assert_not_called()
+        table_client.update_record.assert_called_once()
+        assert result is True


### PR DESCRIPTION
This module allows updating a large number of CMDB entries.

The module is split up into two components: the action plugin that takes care of the mapping and the module which iterates over transformed data and updates the ServiceNow CMDB entries.

Fixes https://github.com/ansible-collections/servicenow.itsm/issues/88