### PR TITLE
Update broken assertion in one of the unit tests

### DIFF
--- a/tests/unit/plugins/action/test_configuration_item_batch.py
+++ b/tests/unit/plugins/action/test_configuration_item_batch.py
@@ -38,7 +38,9 @@ class TestValidate:
 
     def test_invalid_type(self):
         result = configuration_item_batch.validate("a", dict(a=3), True, str)
-        assert result == ["a should be <class 'str'>"] or ["a should be <type 'str'>"]
+        assert result == ["a should be <class 'str'>"] or result == [
+            "a should be <type 'str'>"
+        ]
 
 
 class TestValidateArguments:


### PR DESCRIPTION
When we initially added tests for the batch module, we got one of the assert conditions wrong. This small PR fixes that issue and make sure our test actually performs a check.