### PR TITLE
Deprecate duplicated inventory options

### DIFF
--- a/changelogs/fragments/deprecate_non_constructed_inventory_features.yaml
+++ b/changelogs/fragments/deprecate_non_constructed_inventory_features.yaml
@@ -1,0 +1,3 @@
+deprecated_features:
+  - now inventory plugin - deprecate non constructed features
+    (https://github.com/ansible-collections/servicenow.itsm/pull/97).


### PR DESCRIPTION
With the introduction of the constructed features to the inventory plugin, a lot of existing functionality is not needed anymore since it can be replaced by the constructed features.

This commit marks options that control the obsolete functionality as deprecated. The inventory plugin will also print a warning if it detects deprecated features being used since Ansible has some issues printing deprecation notices from plugins that are lazy-loaded.