### PR TITLE
Set version to 1.2.0

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: servicenow
 name: itsm
-version: 1.1.0
+version: 1.2.0
 readme: README.md
 authors:
   - XLAB Steampunk <steampunk@xlab.si>

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -40,7 +40,7 @@ extends_documentation_fragment:
   - ansible.builtin.constructed
   - servicenow.itsm.query
 notes:
-  - Query feature and constructed groups is added in version 2.0.0.
+  - Query feature and constructed groups eere added in version 1.2.0.
 options:
   plugin:
     description:

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -40,7 +40,7 @@ extends_documentation_fragment:
   - ansible.builtin.constructed
   - servicenow.itsm.query
 notes:
-  - Query feature and constructed groups eere added in version 1.2.0.
+  - Query feature and constructed groups were added in version 1.2.0.
 options:
   plugin:
     description:

--- a/plugins/modules/configuration_item_batch.py
+++ b/plugins/modules/configuration_item_batch.py
@@ -23,7 +23,7 @@ description:
   - Create, delete or update a ServiceNow configuration item.
   - For more information, refer to the ServiceNow configuration management documentation at
     U(https://docs.servicenow.com/bundle/paris-servicenow-platform/page/product/configuration-management/reference/cmdb-table-property-descriptions.html).
-version_added: 2.0.0
+version_added: 1.2.0
 extends_documentation_fragment:
   - servicenow.itsm.instance
 


### PR DESCRIPTION
Since we did not break the backward compatibility, we do not have to bump the major version in the upcoming release as we originally planned.