### PR TITLE
Remove assumed /api/now base path from the HTTP client

### DIFF
--- a/changelogs/fragments/client-change-base-path.yaml
+++ b/changelogs/fragments/client-change-base-path.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- client - Changed the base URL path of the HTTP client for all requests from `/api/now` to `/`

--- a/plugins/module_utils/attachment.py
+++ b/plugins/module_utils/attachment.py
@@ -15,7 +15,14 @@ from . import errors
 
 
 def _path(*subpaths):
-    return "/".join(("api", "now", "attachment",) + subpaths)
+    return "/".join(
+        (
+            "api",
+            "now",
+            "attachment",
+        )
+        + subpaths
+    )
 
 
 class AttachmentClient:

--- a/plugins/module_utils/attachment.py
+++ b/plugins/module_utils/attachment.py
@@ -15,7 +15,7 @@ from . import errors
 
 
 def _path(*subpaths):
-    return "/".join(("attachment",) + subpaths)
+    return "/".join(("api", "now", "attachment",) + subpaths)
 
 
 class AttachmentClient:

--- a/plugins/module_utils/client.py
+++ b/plugins/module_utils/client.py
@@ -150,8 +150,10 @@ class Client:
                 "Cannot have JSON and binary payload in a single request."
             )
 
-        escaped_path = quote(path.rstrip("/"))
-        url = "{0}/api/now/{1}".format(self.host, escaped_path)
+        escaped_path = quote(path.strip("/"))
+        if escaped_path:
+            escaped_path = "/" + escaped_path
+        url = "{0}{1}".format(self.host, escaped_path)
         if query:
             url = "{0}?{1}".format(url, urlencode(query))
         headers = dict(headers or DEFAULT_HEADERS, **self.auth_header)

--- a/plugins/module_utils/table.py
+++ b/plugins/module_utils/table.py
@@ -11,7 +11,7 @@ from . import errors
 
 
 def _path(table, *subpaths):
-    return "/".join(("table", table) + subpaths)
+    return "/".join(("api", "now") + ("table", table) + subpaths)
 
 
 def _query(original=None):

--- a/tests/unit/plugins/module_utils/test_attachment.py
+++ b/tests/unit/plugins/module_utils/test_attachment.py
@@ -11,7 +11,6 @@ import sys
 
 import pytest
 
-
 from ansible_collections.servicenow.itsm.plugins.module_utils import errors, attachment
 from ansible_collections.servicenow.itsm.plugins.module_utils.client import Response
 
@@ -237,7 +236,7 @@ class TestAttachmentListRecords:
 
         assert [] == records
         client.get.assert_called_once_with(
-            "attachment",
+            "api/now/attachment",
             query=dict(
                 sysparm_limit=10000,
                 sysparm_offset=0,
@@ -263,7 +262,7 @@ class TestAttachmentListRecords:
         a.list_records(dict(a="b"))
 
         client.get.assert_called_once_with(
-            "attachment",
+            "api/now/attachment",
             query=dict(
                 a="b",
                 sysparm_limit=10000,
@@ -287,11 +286,11 @@ class TestAttachmentListRecords:
         assert [dict(a=3, b="sys_id"), dict(a=2, b="sys_ie")] == records
         assert 2 == len(client.get.mock_calls)
         client.get.assert_any_call(
-            "attachment",
+            "api/now/attachment",
             query=dict(sysparm_limit=1, sysparm_offset=0),
         )
         client.get.assert_any_call(
-            "attachment",
+            "api/now/attachment",
             query=dict(sysparm_limit=1, sysparm_offset=1),
         )
 
@@ -313,7 +312,7 @@ class TestAttachmentCreateRecord:
         assert dict(a=3, b="sys_id") == record
         client.request.assert_called_with(
             "POST",
-            "attachment/file",
+            "api/now/attachment/file",
             query={"some": "property"},
             headers={"Accept": "application/json", "Content-type": "text/plain"},
             bytes="file_content",
@@ -361,7 +360,7 @@ class TestAttachmentUploadRecord:
         assert dict(a=3, b="sys_id") == record
         client.request.assert_called_with(
             "POST",
-            "attachment/file",
+            "api/now/attachment/file",
             query={
                 "table_name": "table",
                 "table_sys_id": "1234",
@@ -439,7 +438,7 @@ class TestAttachmentUploadRecords:
         assert 2 == client.request.call_count
         client.request.assert_any_call(
             "POST",
-            "attachment/file",
+            "api/now/attachment/file",
             query={
                 "table_name": "table",
                 "table_sys_id": "1234",
@@ -452,7 +451,7 @@ class TestAttachmentUploadRecords:
         )
         client.request.assert_any_call(
             "POST",
-            "attachment/file",
+            "api/now/attachment/file",
             query={
                 "table_name": "table",
                 "table_sys_id": "1234",
@@ -539,7 +538,7 @@ class TestAttachmentDeleteRecord:
         a = attachment.AttachmentClient(client)
         a.delete_record(dict(sys_id="1234"), False)
 
-        client.delete.assert_called_with("attachment/1234")
+        client.delete.assert_called_with("api/now/attachment/1234")
 
     def test_normal_mode_missing(self, client):
         client.delete.side_effect = errors.UnexpectedAPIResponse(
@@ -571,8 +570,8 @@ class TestAttachmentDeleteRecords:
         a.delete_attached_records("table", 5555, False)
 
         assert client.delete.call_count == 2
-        client.delete.assert_any_call("attachment/1234")
-        client.delete.assert_any_call("attachment/4321")
+        client.delete.assert_any_call("api/now/attachment/1234")
+        client.delete.assert_any_call("api/now/attachment/4321")
 
     def test_normal_mode_missing(self, client):
         client.get.return_value = Response(

--- a/tests/unit/plugins/module_utils/test_client.py
+++ b/tests/unit/plugins/module_utils/test_client.py
@@ -349,7 +349,9 @@ class TestClientGet:
 
         c.get("api/now/table/incident/1", query=dict(a="1"))
 
-        request_mock.assert_called_with("GET", "api/now/table/incident/1", query=dict(a="1"))
+        request_mock.assert_called_with(
+            "GET", "api/now/table/incident/1", query=dict(a="1")
+        )
 
 
 class TestClientPost:
@@ -412,7 +414,10 @@ class TestClientPatch:
         c.patch("api/now/table/incident/1", {"some": "data"}, query={"g": "f"})
 
         request_mock.assert_called_with(
-            "PATCH", "api/now/table/incident/1", data=dict(some="data"), query=dict(g="f")
+            "PATCH",
+            "api/now/table/incident/1",
+            data=dict(some="data"),
+            query=dict(g="f"),
         )
 
 
@@ -471,4 +476,6 @@ class TestClientDelete:
 
         c.delete("api/now/table/resource/1", query=dict(x="y"))
 
-        request_mock.assert_called_with("DELETE", "api/now/table/resource/1", query=dict(x="y"))
+        request_mock.assert_called_with(
+            "DELETE", "api/now/table/resource/1", query=dict(x="y")
+        )

--- a/tests/unit/plugins/module_utils/test_client.py
+++ b/tests/unit/plugins/module_utils/test_client.py
@@ -152,7 +152,7 @@ class TestClientRequest:
         request_mock = mocker.patch.object(c, "_request")
         request_mock.return_value = mock_response
 
-        resp = c.request("GET", "some/path")
+        resp = c.request("GET", "api/now/some/path")
 
         request_mock.assert_called_once_with(
             "GET",
@@ -170,7 +170,7 @@ class TestClientRequest:
         request_mock = mocker.patch.object(c, "_request")
         request_mock.return_value = mock_response
 
-        resp = c.request("PUT", "some/path", data={"some": "data"})
+        resp = c.request("PUT", "api/now/some/path", data={"some": "data"})
 
         request_mock.assert_called_once_with(
             "PUT",
@@ -190,7 +190,7 @@ class TestClientRequest:
 
         c = client.Client("https://instance.com", "user", "pass")
         with pytest.raises(errors.AuthError):
-            c.request("GET", "some/path")
+            c.request("GET", "api/now/some/path")
 
     def test_http_error(self, mocker):
         request_mock = mocker.patch.object(client, "Request").return_value
@@ -199,7 +199,7 @@ class TestClientRequest:
         )
 
         c = client.Client("https://instance.com", "user", "pass")
-        resp = c.request("GET", "some/path")
+        resp = c.request("GET", "api/now/some/path")
 
         assert resp.status == 404
         assert resp.data == "My Error"
@@ -212,7 +212,7 @@ class TestClientRequest:
         c = client.Client("https://instance.com", "user", "pass")
 
         with pytest.raises(errors.ServiceNowError, match="some error"):
-            c.request("GET", "some/path")
+            c.request("GET", "api/now/some/path")
 
     def test_path_escaping(self, mocker):
         request_mock = mocker.patch.object(client, "Request").return_value
@@ -220,7 +220,7 @@ class TestClientRequest:
         raw_request.read.return_value = "{}"
 
         c = client.Client("https://instance.com", "user", "pass")
-        c.request("GET", "some path")
+        c.request("GET", "api/now/some path")
 
         request_mock.open.assert_called_once()
         path_arg = request_mock.open.call_args.args[1]
@@ -233,7 +233,7 @@ class TestClientRequest:
         raw_request.read.return_value = "{}"
 
         c = client.Client("https://instance.com", "user", "pass")
-        c.request("GET", "some/path", query=query)
+        c.request("GET", "api/now/some/path", query=query)
 
         request_mock.open.assert_called_once()
         path_arg = request_mock.open.call_args.args[1]
@@ -253,7 +253,7 @@ class TestClientRequest:
         raw_request.read.return_value = "{}"
 
         c = client.Client("https://instance.com", "user", "pass")
-        c.request("GET", "some/path", query=query)
+        c.request("GET", "api/now/some/path", query=query)
 
         request_mock.open.assert_called_once()
         path_arg = request_mock.open.call_args.args[1]
@@ -270,7 +270,7 @@ class TestClientRequest:
 
         resp = c.request(
             "GET",
-            "some/path",
+            "api/now/some/path",
             headers={"Accept": "image/apng", "Content-type": "text/plain"},
         )
 
@@ -294,7 +294,7 @@ class TestClientRequest:
 
         resp = c.request(
             "PUT",
-            "some/path",
+            "api/now/some/path",
             headers={"Accept": "text/plain", "Content-type": "text/plain"},
             bytes="some_data",
         )
@@ -319,7 +319,7 @@ class TestClientGet:
         request_mock = mocker.patch.object(c, "request")
         request_mock.return_value = mock_response
 
-        resp = c.get("table/incident/1")
+        resp = c.get("api/now/table/incident/1")
 
         assert resp == mock_response
         assert resp.json == {"incident": 1}
@@ -330,7 +330,7 @@ class TestClientGet:
         request_mock = mocker.patch.object(c, "request")
         request_mock.return_value = mock_response
 
-        resp = c.get("table/incident/1")
+        resp = c.get("api/now/table/incident/1")
 
         assert resp == mock_response
 
@@ -340,16 +340,16 @@ class TestClientGet:
         request_mock.return_value = client.Response(403, "forbidden")
 
         with pytest.raises(errors.UnexpectedAPIResponse, match="forbidden"):
-            c.get("table/incident/1")
+            c.get("api/now/table/incident/1")
 
     def test_query(self, mocker):
         c = client.Client("https://instance.com", "user", "pass")
         request_mock = mocker.patch.object(c, "request")
         request_mock.return_value = client.Response(200, '{"incident": 1}', None)
 
-        c.get("table/incident/1", query=dict(a="1"))
+        c.get("api/now/table/incident/1", query=dict(a="1"))
 
-        request_mock.assert_called_with("GET", "table/incident/1", query=dict(a="1"))
+        request_mock.assert_called_with("GET", "api/now/table/incident/1", query=dict(a="1"))
 
 
 class TestClientPost:
@@ -359,7 +359,7 @@ class TestClientPost:
         request_mock = mocker.patch.object(c, "request")
         request_mock.return_value = mock_response
 
-        resp = c.post("table/incident", {"some": "data"})
+        resp = c.post("api/now/table/incident", {"some": "data"})
 
         assert resp == mock_response
         assert resp.json == {"incident": 1}
@@ -370,17 +370,17 @@ class TestClientPost:
         request_mock.return_value = client.Response(400, "bad request")
 
         with pytest.raises(errors.UnexpectedAPIResponse, match="bad request"):
-            c.post("table/incident", {"some": "data"})
+            c.post("api/now/table/incident", {"some": "data"})
 
     def test_query(self, mocker):
         c = client.Client("https://instance.com", "user", "pass")
         request_mock = mocker.patch.object(c, "request")
         request_mock.return_value = client.Response(201, '{"incident": 1}')
 
-        c.post("table/incident", {"some": "data"}, query={"b": "3"})
+        c.post("api/now/table/incident", {"some": "data"}, query={"b": "3"})
 
         request_mock.assert_called_with(
-            "POST", "table/incident", data=dict(some="data"), query=dict(b="3")
+            "POST", "api/now/table/incident", data=dict(some="data"), query=dict(b="3")
         )
 
 
@@ -391,7 +391,7 @@ class TestClientPatch:
         request_mock = mocker.patch.object(c, "request")
         request_mock.return_value = mock_response
 
-        resp = c.patch("table/incident/1", {"some": "data"})
+        resp = c.patch("api/now/table/incident/1", {"some": "data"})
 
         assert resp == mock_response
         assert resp.json == {"incident": 1}
@@ -402,17 +402,17 @@ class TestClientPatch:
         request_mock.return_value = client.Response(400, "bad request")
 
         with pytest.raises(errors.UnexpectedAPIResponse, match="bad request"):
-            c.patch("table/incident/1", {"some": "data"})
+            c.patch("api/now/table/incident/1", {"some": "data"})
 
     def test_query(self, mocker):
         c = client.Client("https://instance.com", "user", "pass")
         request_mock = mocker.patch.object(c, "request")
         request_mock.return_value = client.Response(200, '{"incident": 1}')
 
-        c.patch("table/incident/1", {"some": "data"}, query={"g": "f"})
+        c.patch("api/now/table/incident/1", {"some": "data"}, query={"g": "f"})
 
         request_mock.assert_called_with(
-            "PATCH", "table/incident/1", data=dict(some="data"), query=dict(g="f")
+            "PATCH", "api/now/table/incident/1", data=dict(some="data"), query=dict(g="f")
         )
 
 
@@ -423,7 +423,7 @@ class TestClientPut:
         request_mock = mocker.patch.object(c, "request")
         request_mock.return_value = mock_response
 
-        resp = c.put("table/incident/1", {"some": "data"})
+        resp = c.put("api/now/table/incident/1", {"some": "data"})
 
         assert resp == mock_response
         assert resp.json == {"incident": 1}
@@ -434,17 +434,17 @@ class TestClientPut:
         request_mock.return_value = client.Response(400, "bad request")
 
         with pytest.raises(errors.UnexpectedAPIResponse, match="bad request"):
-            c.put("table/incident/1", {"some": "data"})
+            c.put("api/now/table/incident/1", {"some": "data"})
 
     def test_query(self, mocker):
         c = client.Client("https://instance.com", "user", "pass")
         request_mock = mocker.patch.object(c, "request")
         request_mock.return_value = client.Response(200, '{"incident": 1}')
 
-        c.put("table/incident/1", {"some": "data"}, query={"j": "i"})
+        c.put("api/now/table/incident/1", {"some": "data"}, query={"j": "i"})
 
         request_mock.assert_called_with(
-            "PUT", "table/incident/1", data=dict(some="data"), query=dict(j="i")
+            "PUT", "api/now/table/incident/1", data=dict(some="data"), query=dict(j="i")
         )
 
 
@@ -454,7 +454,7 @@ class TestClientDelete:
         request_mock = mocker.patch.object(c, "request")
         request_mock.return_value = client.Response(204, {})
 
-        c.delete("table/resource/1")
+        c.delete("api/now/table/resource/1")
 
     def test_error(self, mocker):
         c = client.Client("https://instance.com", "user", "pass")
@@ -462,13 +462,13 @@ class TestClientDelete:
         request_mock.return_value = client.Response(404, "not found")
 
         with pytest.raises(errors.UnexpectedAPIResponse, match="not found"):
-            c.delete("table/resource/1")
+            c.delete("api/now/table/resource/1")
 
     def test_query(self, mocker):
         c = client.Client("https://instance.com", "user", "pass")
         request_mock = mocker.patch.object(c, "request")
         request_mock.return_value = client.Response(204, {})
 
-        c.delete("table/resource/1", query=dict(x="y"))
+        c.delete("api/now/table/resource/1", query=dict(x="y"))
 
-        request_mock.assert_called_with("DELETE", "table/resource/1", query=dict(x="y"))
+        request_mock.assert_called_with("DELETE", "api/now/table/resource/1", query=dict(x="y"))

--- a/tests/unit/plugins/module_utils/test_table.py
+++ b/tests/unit/plugins/module_utils/test_table.py
@@ -30,7 +30,7 @@ class TestTableListRecords:
 
         assert [] == records
         client.get.assert_called_once_with(
-            "table/my_table",
+            "api/now/table/my_table",
             query=dict(
                 sysparm_exclude_reference_link="true",
                 sysparm_limit=1000,
@@ -57,7 +57,7 @@ class TestTableListRecords:
         t.list_records("my_table", dict(a="b"))
 
         client.get.assert_called_once_with(
-            "table/my_table",
+            "api/now/table/my_table",
             query=dict(
                 sysparm_exclude_reference_link="true",
                 a="b",
@@ -82,13 +82,13 @@ class TestTableListRecords:
         assert [dict(a=3, b="sys_id"), dict(a=2, b="sys_ie")] == records
         assert 2 == len(client.get.mock_calls)
         client.get.assert_any_call(
-            "table/my_table",
+            "api/now/table/my_table",
             query=dict(
                 sysparm_exclude_reference_link="true", sysparm_limit=1, sysparm_offset=0
             ),
         )
         client.get.assert_any_call(
-            "table/my_table",
+            "api/now/table/my_table",
             query=dict(
                 sysparm_exclude_reference_link="true", sysparm_limit=1, sysparm_offset=1
             ),
@@ -106,7 +106,7 @@ class TestTableGetRecord:
 
         assert dict(a=3, b="sys_id") == record
         client.get.assert_called_with(
-            "table/my_table",
+            "api/now/table/my_table",
             query=dict(
                 sysparm_exclude_reference_link="true",
                 our="query",
@@ -151,7 +151,7 @@ class TestTableCreateRecord:
 
         assert dict(a=3, b="sys_id") == record
         client.post.assert_called_with(
-            "table/my_table",
+            "api/now/table/my_table",
             dict(a=4),
             query=dict(sysparm_exclude_reference_link="true"),
         )
@@ -175,7 +175,7 @@ class TestTableUpdateRecord:
 
         assert dict(a=3, b="sys_id") == record
         client.patch.assert_called_with(
-            "table/my_table/id",
+            "api/now/table/my_table/id",
             dict(a=4),
             query=dict(sysparm_exclude_reference_link="true"),
         )
@@ -197,7 +197,7 @@ class TestTableDeleteRecord:
 
         t.delete_record("my_table", dict(sys_id="id"), False)
 
-        client.delete.assert_called_with("table/my_table/id")
+        client.delete.assert_called_with("api/now/table/my_table/id")
 
     def test_check_mode(self, client):
         client.delete.return_value = Response(204, "")


### PR DESCRIPTION
##### SUMMARY
ServiceNow Update Sets allow for extending the functionality of ServiceNow by, for example, obtaining and formatting results from joined tables. Through the ServiceNow REST API the records from Update Sets can be programmatically obtained. Currently, in the HTTP client it is assumed that all API endpoints start with base path `/api/now`, which might not be true in case of Updated Sets or in general when the requests might refer to the records outside namespace `now`.

This update removes the assumption about the base URL path from the HTTP client, by accepting any path, which makes it more generic. While it does not directly address any issue, it shall be seen as a prerequisite to issue #108, the resolution of which can be done by using a particular Updated Set, which is accessible on URL path starting with `/api/snc`.

##### ISSUE TYPE
- Feature Pull Request (a prerequisite to)

##### COMPONENT NAME
This update does not introduce any new components.

##### ADDITIONAL INFORMATION
The primary target of this update is `request` method of class `Client`, located in file `plugins/module_utils/client.py`, where the base path is changed to "/". Consequentially, all the code relying upon the request method, either directly or indirectly, is affected. Accordingly, the `TableClient` and `AttachmentClient` have been updated. The unit tests for `Client`, `TableClient` and `AttachmentClient` have also been adapted to the change in the base URL path.