### PR TITLE
Add change request task module

### DIFF
--- a/changelogs/fragments/change_request_task.yaml
+++ b/changelogs/fragments/change_request_task.yaml
@@ -1,4 +1,3 @@
 ---
 minor_changes:
-  - Adds change_request_task and change_request_task_info modules. It allows users to modify all standard parameters defined in the ServiceNow docs (https://docs.servicenow.com/bundle/quebec-it-service-management/page/product/change-management/task/create-a-change-task.html), as well as properties required to create and close tasks.
-  - table.py - add change_request and configuration item search options
+  - table.py - add change_request and configuration item search options.

--- a/changelogs/fragments/change_request_task.yaml
+++ b/changelogs/fragments/change_request_task.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Adds change_request_task and change_request_task_info modules. It allows users to modify all standard parameters defined in the ServiceNow docs (https://docs.servicenow.com/bundle/quebec-it-service-management/page/product/change-management/task/create-a-change-task.html), as well as properties required to create and close tasks.
+  - table.py - add change_request and configuration item search options

--- a/plugins/module_utils/change_request_task.py
+++ b/plugins/module_utils/change_request_task.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2021, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+PAYLOAD_FIELDS_MAPPING = dict(
+    state=[
+        ("-5", "pending"),
+        ("1", "open"),
+        ("2", "in_progress"),
+        ("3", "closed"),
+        ("4", "canceled"),
+    ],
+    on_hold=[("true", True), ("false", False)],
+)

--- a/plugins/module_utils/table.py
+++ b/plugins/module_utils/table.py
@@ -109,4 +109,6 @@ def find_change_request(table_client, change_request_number):
 
 
 def find_configuration_item(table_client, item_name):
-    return table_client.get_record("cmdb_ci", dict(name=item_name), must_exist=True)
+    return table_client.get_record(
+        "cmdb_ci", dict(name=item_name), must_exist=True
+    )

--- a/plugins/module_utils/table.py
+++ b/plugins/module_utils/table.py
@@ -100,3 +100,13 @@ def find_standard_change_template(table_client, template_name):
         dict(name=template_name),
         must_exist=True,
     )
+
+
+def find_change_request(table_client, change_request_number):
+    return table_client.get_record(
+        "change_request", dict(number=change_request_number), must_exist=True
+    )
+
+
+def find_configuration_item(table_client, item_name):
+    return table_client.get_record("cmdb_ci", dict(name=item_name), must_exist=True)

--- a/plugins/modules/change_request_task.py
+++ b/plugins/modules/change_request_task.py
@@ -23,7 +23,7 @@ description:
   - Create, delete or update a ServiceNow change request tasks.
   - For more information, refer to the ServiceNow change management documentation at
     U(https://docs.servicenow.com/bundle/paris-it-service-management/page/product/change-management/concept/c_ITILChangeManagement.html).
-version_added: 1.2.0
+version_added: 1.3.0
 extends_documentation_fragment:
   - servicenow.itsm.instance
   - servicenow.itsm.sys_id

--- a/plugins/modules/change_request_task.py
+++ b/plugins/modules/change_request_task.py
@@ -1,0 +1,419 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2021, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+module: change_request_task
+
+author:
+  - Matej Pevec (@mysteriouswolf)
+  - Manca Bizjak (@mancabizjak)
+  - Miha Dolinar (@mdolin)
+  - Tadej Borovsak (@tadeboro)
+
+short_description: Manage ServiceNow change request tasks
+
+description:
+  - Create, delete or update a ServiceNow change request tasks.
+  - For more information, refer to the ServiceNow change management documentation at
+    U(https://docs.servicenow.com/bundle/paris-it-service-management/page/product/change-management/concept/c_ITILChangeManagement.html).
+version_added: 1.2.0
+extends_documentation_fragment:
+  - servicenow.itsm.instance
+  - servicenow.itsm.sys_id
+  - servicenow.itsm.number
+
+seealso:
+  - module: servicenow.itsm.change_request_task_info
+
+options:
+  configuration_item:
+    description:
+      - The configuration item (CI) or service name that the change task applies to.
+      - Note that contrary to I(configuration_item_id), configuration item names may not uniquely identify a record.
+        In case there are more configuration items with the same name, the module fails and does nothing.
+      - Mutually exclusive with I(configuration_item_id).
+    type: str
+  configuration_item_id:
+    description:
+      - The configuration item (CI) or service ID that the change task applies to.
+      - Mutually exclusive with I(configuration_item).
+    type: str
+  change_request_number:
+    description:
+      - I(number) of the change request this task belongs to.
+      - Note that contrary to I(change_request_id), change request number may not uniquely identify a record.
+        In case there are more change requests with the same number, the module fails and does nothing.
+      - Mutually exclusive with I(change_request_id).
+    type: str
+  change_request_id:
+    description:
+      - I(sys_id) of the change request this task belongs to.
+      - Mutually exclusive with I(change_request_number).
+    type: str
+  type:
+    description:
+      - The type of change task.
+      - Default workflow generates tasks in I(type) C(review)
+      - If the task I(type) is C(implementation), the I(planned_start_date) and I(planned_end_date) values
+        must fall within the planned start and end dates specified in the I(change_request).
+    choices: [ planning, implementation, testing, review ]
+    type: str
+  state:
+    description:
+      - The state of the change request task.
+      - Cannot be changed to C(pending) when I(on_hold) is C(true)
+        (module fails and does nothing).
+    choices: [ pending, open, in_progress, closed, canceled, absent ]
+    type: str
+  assigned_to:
+    description:
+      - The user that the change task is assigned to.
+    type: str
+  assignment_group:
+    description:
+      - The group that the change task is assigned to.
+    type: str
+  short_description:
+    description:
+      - A summary of the task.
+      - This field has to be set either in the record or here.
+    type: str
+  description:
+    description:
+      - A detailed description of the task.
+      - This field has to be set either in the record or here.
+    type: str
+  on_hold:
+    description:
+      - A change task cannot be put on hold when I(state) is C(pending), C(canceled), or C(closed)
+        (module fails and does nothing).
+      - Provide an On hold reason if a change task is placed on hold.
+    type: bool
+  hold_reason:
+    description:
+      - Reason why change task is on hold.
+      - Required if change task's I(on_hold) value will be C(true).
+    type: str
+  planned_start_date:
+    description:
+      - The date you plan to begin working on the task.
+    type: str
+  planned_end_date:
+    description:
+      - The date the change task is planned to be completed.
+    type: str
+  close_code:
+    description:
+      - Provide information on how the change task was resolved.
+      - The change task must have this parameter set prior to
+        transitioning to the C(closed) state.
+    choices: [ successful, successful_issues, unsuccessful ]
+    type: str
+  close_notes:
+    description:
+      - Resolution notes added by the user who closed the change task.
+      - The change task must have this parameter set prior to
+        transitioning to the C(closed) state.
+    type: str
+  other:
+    description:
+      - Optional remaining parameters.
+      - For more information on optional parameters, refer to the ServiceNow
+        change task documentation at
+        U(https://docs.servicenow.com/bundle/paris-it-service-management/page/product/change-management/task/create-a-change-task.html).
+    type: dict
+"""
+
+EXAMPLES = """
+- name: Create a change task
+  servicenow.itsm.change_request_task:
+    configuration_item: Rogue Squadron Launcher
+    change_request_number: CHG0000001
+    type: planning
+    state: open
+    assigned_to: fred.luddy
+    assignment_group: robot.embedded
+    short_description: Implement collision avoidance
+    description: "Implement collision avoidance based on the newly installed TOF sensor arrays."
+    on_hold: true
+    hold_reason: "Waiting for a report from the hardware team"
+    planned_start_date: 2021-07-15 08:00:00
+    planned_end_date: 2021-07-21 16:00:00
+    other:
+      approval: approved
+
+- name: Change state of the change task
+  servicenow.itsm.change_request_task:
+    state: in_progress
+    on_hold: false
+    number: CTASK0000001
+
+- name: Close a change task
+  servicenow.itsm.change_request_task:
+    state: closed
+    close_code: "successful"
+    close_notes: "Closed"
+    number: CTASK0000001
+
+- name: Delete a change task
+  servicenow.itsm.change_request_task:
+    state: absent
+    number: CTASK0000001
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ..module_utils import arguments, client, table, errors, utils, validation
+from ..module_utils.change_request_task import PAYLOAD_FIELDS_MAPPING
+
+DIRECT_PAYLOAD_FIELDS = (
+    "state",
+    "short_description",
+    "description",
+    "on_hold",
+    "planned_start_date",
+    "planned_end_date",
+    "close_code",
+    "close_notes",
+)
+
+
+def ensure_absent(module, table_client):
+    mapper = utils.PayloadMapper(PAYLOAD_FIELDS_MAPPING, module.warn)
+    query = utils.filter_dict(module.params, "sys_id", "number")
+    task = table_client.get_record("change_task", query)
+
+    if task:
+        table_client.delete_record("change_task", task, module.check_mode)
+        return True, None, dict(before=mapper.to_ansible(task), after=None)
+
+    return False, None, dict(before=None, after=None)
+
+
+def validate_params(params, change_task=None):
+    missing = []
+    if params["state"] == "closed":
+        missing.extend(
+            validation.missing_from_params_and_remote(
+                ("close_code", "close_notes"), params, change_task
+            )
+        )
+
+    # Description must be set
+    missing.extend(
+        validation.missing_from_params_and_remote(
+            ("short_description", "description"), params, change_task
+        )
+    )
+
+    if missing:
+        raise errors.ServiceNowError(
+            "Missing required parameters {0}".format(", ".join(missing))
+        )
+
+
+def ensure_present(module, table_client):
+    mapper = utils.PayloadMapper(PAYLOAD_FIELDS_MAPPING, module.warn)
+    query = utils.filter_dict(module.params, "sys_id", "number")
+    payload = build_payload(module, table_client)
+
+    if not query:
+        # User did not specify an existing change task, so we need to create a new one.
+        validate_params(module.params)
+        new = mapper.to_ansible(
+            table_client.create_record(
+                "change_task", mapper.to_snow(payload), module.check_mode
+            )
+        )
+        return True, new, dict(before=None, after=new)
+
+    old = mapper.to_ansible(
+        table_client.get_record("change_task", query, must_exist=True)
+    )
+    if is_superset_with_date(old, payload):
+        # No change in parameters we are interested in - nothing to do.
+        return False, old, dict(before=old, after=old)
+
+    validate_params(module.params, old)
+    new = mapper.to_ansible(
+        table_client.update_record(
+            "change_task",
+            mapper.to_snow(old),
+            mapper.to_snow(payload),
+            module.check_mode,
+        )
+    )
+    return True, new, dict(before=old, after=new)
+
+
+def is_superset_with_date(superset, candidate):
+    datetime_fields = ("planned_start_date", "planned_end_date")
+
+    for k in datetime_fields:
+        if k in candidate and (superset.get(k, "") or "").replace("T", " ") != (
+            candidate[k] or ""
+        ).replace("T", " "):
+            return False
+
+    return utils.is_superset(
+        superset, dict((k, v) for k, v in candidate.items() if k not in datetime_fields)
+    )
+
+
+def build_payload(module, table_client):
+    payload = (module.params["other"] or {}).copy()
+    payload.update(utils.filter_dict(module.params, *DIRECT_PAYLOAD_FIELDS))
+
+    if module.params["type"]:
+        payload["change_task_type"] = module.params["type"]
+
+    if module.params["hold_reason"]:
+        payload["on_hold_reason"] = module.params["hold_reason"]
+
+    # Map the configuration item
+    if module.params["configuration_item"]:
+        configuration_item = table.find_configuration_item(
+            table_client, module.params["configuration_item"]
+        )
+        payload["cmdb_ci"] = configuration_item["sys_id"]
+
+    if module.params["configuration_item_id"]:
+        payload["cmdb_ci"] = module.params["configuration_item_id"]
+
+    # Map the change request
+    if module.params["change_request_number"]:
+        configuration_item = table.find_change_request(
+            table_client, module.params["change_request_number"]
+        )
+        payload["change_request"] = configuration_item["sys_id"]
+
+    if module.params["change_request_id"]:
+        payload["change_request"] = module.params["change_request_id"]
+
+    # Map the assignee
+    if module.params["assigned_to"]:
+        user = table.find_user(table_client, module.params["assigned_to"])
+        payload["assigned_to"] = user["sys_id"]
+
+    # Map the assigned group
+    if module.params["assignment_group"]:
+        assignment_group = table.find_assignment_group(
+            table_client, module.params["assignment_group"]
+        )
+        payload["assignment_group"] = assignment_group["sys_id"]
+
+    return payload
+
+
+def run(module, table_client):
+    if module.params["state"] == "absent":
+        return ensure_absent(module, table_client)
+    return ensure_present(module, table_client)
+
+
+def main():
+    module_args = dict(
+        arguments.get_spec("instance", "sys_id", "number"),
+        configuration_item=dict(
+            type="str",
+        ),
+        configuration_item_id=dict(
+            type="str",
+        ),
+        change_request_id=dict(
+            type="str",
+        ),
+        change_request_number=dict(
+            type="str",
+        ),
+        type=dict(
+            type="str",
+            choices=[
+                "planning",
+                "implementation",
+                "testing",
+                "testing",
+            ],
+        ),
+        state=dict(
+            type="str",
+            choices=[
+                "pending",
+                "open",
+                "in_progress",
+                "closed",
+                "canceled",
+                "absent",
+            ],
+        ),
+        assigned_to=dict(
+            type="str",
+        ),
+        assignment_group=dict(
+            type="str",
+        ),
+        short_description=dict(
+            type="str",
+        ),
+        description=dict(
+            type="str",
+        ),
+        on_hold=dict(
+            type="bool",
+        ),
+        hold_reason=dict(
+            type="str",
+        ),
+        planned_start_date=dict(
+            type="str",
+        ),
+        planned_end_date=dict(
+            type="str",
+        ),
+        close_code=dict(
+            type="str",
+            choices=[
+                "successful",
+                "successful_issues",
+                "unsuccessful",
+            ],
+        ),
+        close_notes=dict(
+            type="str",
+        ),
+        other=dict(
+            type="dict",
+        ),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+        required_if=[
+            ("state", "absent", ("sys_id", "number"), True),
+            ("on_hold", True, ("hold_reason",)),
+        ],
+        mutually_exclusive=[
+            ("change_request_id", "change_request_number"),
+            ("configuration_item_id", "configuration_item"),
+        ],
+    )
+
+    try:
+        snow_client = client.Client(**module.params["instance"])
+        table_client = table.TableClient(snow_client)
+        changed, record, diff = run(module, table_client)
+        module.exit_json(changed=changed, record=record, diff=diff)
+    except errors.ServiceNowError as e:
+        module.fail_json(msg=str(e))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/change_request_task_info.py
+++ b/plugins/modules/change_request_task_info.py
@@ -1,0 +1,240 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2021, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+module: change_request_task_info
+
+author:
+  - Matej Pevec (@mysteriouswolf)
+  - Manca Bizjak (@mancabizjak)
+  - Miha Dolinar (@mdolin)
+  - Tadej Borovsak (@tadeboro)
+short_description: List ServiceNow change request tasks
+description:
+  - Retrieve information about ServiceNow change request tasks.
+  - For more information, refer to the ServiceNow change management documentation at
+    U(https://docs.servicenow.com/bundle/paris-it-service-management/page/product/change-management/concept/c_ITILChangeManagement.html).
+version_added: 1.2.0
+extends_documentation_fragment:
+  - servicenow.itsm.instance
+  - servicenow.itsm.sys_id.info
+  - servicenow.itsm.number.info
+  - servicenow.itsm.query
+seealso:
+  - module: servicenow.itsm.change_request_task
+"""
+
+EXAMPLES = r"""
+- name: Retrieve all change request tasks
+  servicenow.itsm.change_request_task_info:
+  register: result
+
+- name: Retrieve a specific change request task by its sys_id
+  servicenow.itsm.change_request_task_info:
+    sys_id: 471bfbc7a9fe198101e77a3e10e5d47f
+  register: result
+
+- name: Retrieve change request tasks by number
+  servicenow.itsm.change_request_task_info:
+    number: CTASK0000001
+  register: result
+
+- name: Retrieve change request tasks that contain SAP in their short description
+  servicenow.itsm.change_request_task_info:
+    query:
+      - short_description: LIKE SAP
+  register: result
+
+- name: Retrieve new change requests assigned to abel.tuter or bertie.luby
+  servicenow.itsm.change_request_task_info:
+    query:
+      - state: = new
+        assigned_to: = abel.tuter
+      - state: = new
+        assigned_to: = bertie.luby
+"""
+
+RETURN = r"""
+records:
+  description:
+    - A list of change task records.
+  returned: success
+  type: list
+  sample:
+    - "active": "true"
+      "activity_due": ""
+      "additional_assignee_list": ""
+      "approval": "not requested"
+      "approval_history": ""
+      "approval_set": ""
+      "assigned_to": "f298d2d2c611227b0106c6be7f154bc8"
+      "assignment_group": ""
+      "business_duration": ""
+      "business_service": ""
+      "calendar_duration": ""
+      "change_request": "a9e9c33dc61122760072455df62663d2"
+      "change_task_type": ""
+      "close_code": ""
+      "close_notes": ""
+      "closed_at": ""
+      "closed_by": ""
+      "cmdb_ci": ""
+      "comments": ""
+      "comments_and_work_notes": ""
+      "company": ""
+      "contact_type": "phone"
+      "contract": ""
+      "correlation_display": ""
+      "correlation_id": ""
+      "created_from": ""
+      "delivery_plan": ""
+      "delivery_task": ""
+      "description": "Preliminary System Testing"
+      "due_date": "2020-09-05 22:22:39"
+      "escalation": "0"
+      "expected_start": ""
+      "follow_up": ""
+      "group_list": ""
+      "impact": "3"
+      "knowledge": "false"
+      "location": ""
+      "made_sla": "false"
+      "number": "CTASK0010005"
+      "on_hold": false
+      "on_hold_reason": ""
+      "opened_at": "2020-08-30 22:22:48"
+      "opened_by": "6816f79cc0a8016401c5a33be04be441"
+      "order": ""
+      "parent": ""
+      "planned_end_date": ""
+      "planned_start_date": ""
+      "priority": "3"
+      "reassignment_count": ""
+      "route_reason": ""
+      "service_offering": ""
+      "short_description": "Preliminary System Testing"
+      "sla_due": ""
+      "state": "open"
+      "sys_class_name": "change_task"
+      "sys_created_by": "admin"
+      "sys_created_on": "2020-08-30 22:22:48"
+      "sys_domain": "global"
+      "sys_domain_path": "/"
+      "sys_id": "a9f2e5bdc61122760052c1250f7ac503"
+      "sys_mod_count": "0"
+      "sys_tags": ""
+      "sys_updated_by": "admin"
+      "sys_updated_on": "2020-08-30 22:22:48"
+      "task_effective_number": "CTASK0010005"
+      "time_worked": ""
+      "universal_request": ""
+      "upon_approval": ""
+      "upon_reject": ""
+      "urgency": "3"
+      "user_input": ""
+      "watch_list": ""
+      "work_end": ""
+      "work_notes": ""
+      "work_notes_list": ""
+      "work_start": ""
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ..module_utils import arguments, client, errors, query, utils, table
+from ..module_utils.change_request_task import PAYLOAD_FIELDS_MAPPING
+
+
+def remap_params(query, table_client):
+    query_load = []
+
+    for item in query:
+        q = dict()
+        for k, v in item.items():
+            if k == "type":
+                q["change_task_type"] = (v[0], v[1])
+
+            elif k == "hold_reason":
+                q["on_hold_reason"] = (v[0], v[1])
+
+            elif k == "configuration_item_id":
+                q["cmdb_ci"] = (v[0], v[1])
+
+            elif k == "configuration_item":
+                configuration_item = table.find_configuration_item(table_client, v[1])
+                q["cmdb_ci"] = (v[0], configuration_item["sys_id"])
+
+            elif k == "change_request_id":
+                q["change_request"] = (v[0], v[1])
+
+            elif k == "change_request_number":
+                change_request = table.find_change_request(table_client, v[1])
+                q["change_request"] = (v[0], change_request["sys_id"])
+
+            elif k == "assigned_to":
+                user = table.find_user(table_client, v[1])
+                q["assigned_to"] = (v[0], user["sys_id"])
+
+            elif k == "assignment_group":
+                assignment_group = table.find_assignment_group(table_client, v[1])
+                q["assignment_group"] = (v[0], assignment_group["sys_id"])
+
+            else:
+                q[k] = v
+
+        query_load.append(q)
+
+    return query_load
+
+
+def sysparms_query(module, table_client, mapper):
+    parsed, err = query.parse_query(module.params["query"])
+    if err:
+        raise errors.ServiceNowError(err)
+
+    remap_query = remap_params(parsed, table_client)
+
+    return query.serialize_query(query.map_query_values(remap_query, mapper))
+
+
+def run(module, table_client):
+    mapper = utils.PayloadMapper(PAYLOAD_FIELDS_MAPPING, module.warn)
+
+    if module.params["query"]:
+        query = {"sysparm_query": sysparms_query(module, table_client, mapper)}
+    else:
+        query = utils.filter_dict(module.params, "sys_id", "number")
+
+    return [
+        mapper.to_ansible(record)
+        for record in table_client.list_records("change_task", query)
+    ]
+
+
+def main():
+    module = AnsibleModule(
+        supports_check_mode=True,
+        argument_spec=dict(
+            arguments.get_spec("instance", "sys_id", "number", "query"),
+        ),
+        mutually_exclusive=[("sys_id", "query"), ("number", "query")],
+    )
+
+    try:
+        snow_client = client.Client(**module.params["instance"])
+        table_client = table.TableClient(snow_client)
+        records = run(module, table_client)
+        module.exit_json(changed=False, records=records)
+    except errors.ServiceNowError as e:
+        module.fail_json(msg=str(e))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/change_request_task_info.py
+++ b/plugins/modules/change_request_task_info.py
@@ -21,7 +21,7 @@ description:
   - Retrieve information about ServiceNow change request tasks.
   - For more information, refer to the ServiceNow change management documentation at
     U(https://docs.servicenow.com/bundle/paris-it-service-management/page/product/change-management/concept/c_ITILChangeManagement.html).
-version_added: 1.2.0
+version_added: 1.3.0
 extends_documentation_fragment:
   - servicenow.itsm.instance
   - servicenow.itsm.sys_id.info

--- a/tests/integration/targets/change_request_task/tasks/main.yml
+++ b/tests/integration/targets/change_request_task/tasks/main.yml
@@ -1,0 +1,414 @@
+- environment:
+    SN_HOST: "{{ sn_host }}"
+    SN_USERNAME: "{{ sn_username }}"
+    SN_PASSWORD: "{{ sn_password }}"
+
+  block:
+    - name: Retrieve all entries in the change_task table
+      servicenow.itsm.change_request_task_info:
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result.records != []
+          - result.records | length != 0
+
+
+    - name: Create test change_request for refferencing in change tasks
+      servicenow.itsm.change_request:
+        requested_by: admin
+        state: new
+        type: standard
+        template: Clear BGP sessions on a Cisco router - 1
+        priority: low
+        risk: low
+        impact: low
+      register: change_request_result
+
+    - ansible.builtin.assert:
+        that:
+          - change_request_result is changed
+          - change_request_result.record.state == "new"
+          - change_request_result.record.type == "standard"
+          - change_request_result.record.priority == "low"
+          - change_request_result.record.risk == "low"
+          - change_request_result.record.impact == "low"
+
+
+    - name: Create test change_request_task - check mode
+      servicenow.itsm.change_request_task: &create-change_request_task
+        change_request_number: "{{ change_request_result.record.number }}"
+        type: planning
+        state: pending
+        short_description: "Implement collision avoidance"
+        description: "Implement collision avoidance based on the newly installed TOF sensor arrays."
+        other:
+          approval: approved
+      check_mode: true
+      register: result
+
+    - ansible.builtin.assert: &create-change_request_task-result
+        that:
+          - result is changed
+          - result.record.change_request == change_request_result.record.sys_id
+          - result.record.change_task_type == "planning"
+          - result.record.state == "pending"
+          - result.record.short_description == "Implement collision avoidance"
+          - result.record.description == "Implement collision avoidance based on the newly installed TOF sensor arrays."
+          - result.record.approval == "approved"
+
+
+    - name: Create test change_request_task
+      servicenow.itsm.change_request_task: *create-change_request_task
+      register: test_result
+
+    - set_fact:
+        result: "{{ test_result }}"
+
+    - ansible.builtin.assert: *create-change_request_task-result
+
+
+    - name: Make sure change_request_task exists
+      servicenow.itsm.change_request_task_info:
+        number: "{{ test_result.record.number }}"
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result.records[0].sys_id == test_result.record.sys_id
+          - result.records[0].change_request == change_request_result.record.sys_id
+          - result.records[0].change_task_type == "planning"
+          - result.records[0].state == "pending"
+          - result.records[0].short_description == "Implement collision avoidance"
+          - result.records[0].description == "Implement collision avoidance based on the newly installed TOF sensor arrays."
+          - result.records[0].approval == "approved"
+
+
+    - name: Update change_request_task with same type, state and ID (previously set from its name)
+      servicenow.itsm.change_request_task:
+        number: "{{ test_result.record.number }}"
+        change_request_id: "{{ change_request_result.record.sys_id }}"
+        type: planning
+        state: pending
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result is not changed
+
+
+    - name: Set on hold (should fail since the reason is not set)
+      servicenow.itsm.change_request_task:
+        number: "{{ test_result.record.number }}"
+        on_hold: true
+      ignore_errors: true
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'on_hold is True but all of the following are missing: hold_reason'"
+
+
+    - name: Set on hold while in state pending (should fail due to on_hold and state value incompatibility)
+      servicenow.itsm.change_request_task:
+        on_hold: true
+        hold_reason: "Not enough resources for the task"
+      ignore_errors: true
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'Cannot put a task in state \"pending\" on hold'"
+
+
+    - name: Update change_request_task - check mode
+      servicenow.itsm.change_request_task: &update-change_request_task
+        number: "{{ test_result.record.number }}"
+        description: "Something changed"
+        state: in_progress
+      check_mode: true
+      register: result
+
+    - ansible.builtin.assert: &update-change_request_task-result
+        that:
+          - result is changed
+          - result.record.short_description == "Implement collision avoidance"
+          - result.record.state == "in_progress"
+          - result.record.description == "Something changed"
+          - result.record.change_task_type == "planning"
+
+
+    - name: Update change_request_task
+      servicenow.itsm.change_request_task: *update-change_request_task
+
+    - ansible.builtin.assert: *update-change_request_task-result
+
+
+    - name: Make sure change_request_task was updated
+      servicenow.itsm.change_request_task_info:
+        number: "{{ test_result.record.number }}"
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result.records[0].short_description == "Implement collision avoidance"
+          - result.records[0].state == "in_progress"
+          - result.records[0].description == "Something changed"
+          - result.records[0].change_task_type == "planning"
+
+
+    - name: Update change_request_task with same params - unchanged
+      servicenow.itsm.change_request_task: *update-change_request_task
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result is not changed
+
+
+    - name: Update change_request_task planned_end_date - check mode
+      servicenow.itsm.change_request_task: &update-change_request_task-planned_end_date
+        number: "{{ test_result.record.number }}"
+        planned_end_date: 2021-07-15 08:00:00
+      check_mode: true
+      register: result
+
+    - ansible.builtin.assert: &update-change_request_task-planned_end_date-result
+        that:
+          - result is changed
+          - result.record.planned_end_date == "2021-07-15T08:00:00"
+
+
+    - name: Update change_request_task planned_end_date
+      servicenow.itsm.change_request_task: *update-change_request_task-planned_end_date
+
+    - ansible.builtin.assert: *update-change_request_task-planned_end_date-result
+
+
+    - name: Make sure planned_end_date of change_request_task was updated
+      servicenow.itsm.change_request_task_info:
+        number: "{{ test_result.record.number }}"
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result.records[0].number == test_result.record.number
+          - result.records[0].planned_end_date == "2021-07-15 08:00:00"
+
+
+    - name: Update change_request_task with same planned_end_date - unchanged
+      servicenow.itsm.change_request_task: *update-change_request_task-planned_end_date
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result is not changed
+
+
+    - name: Put change_request on hold - check mode
+      servicenow.itsm.change_request_task: &update-change_request_task-state-review
+        number: "{{ test_result.record.number }}"
+        on_hold: true
+        hold_reason: "Not enough resources for the task"
+      check_mode: true
+      register: result
+
+    - ansible.builtin.assert: &update-change_request_task-state-result-review
+        that:
+          - result is changed
+          - result.record.on_hold == True
+          - result.record.on_hold_reason == "Not enough resources for the task"
+
+
+    - name: Put change_request on hold
+      servicenow.itsm.change_request_task: *update-change_request_task-state-review
+
+    - ansible.builtin.assert: *update-change_request_task-state-result-review
+
+
+    - name: Make sure the hold state of change_request was updated
+      servicenow.itsm.change_request_task_info:
+        number: "{{ test_result.record.number }}"
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result.records[0].number == test_result.record.number
+          - result.records[0].on_hold == True
+          - result.records[0].on_hold_reason == "Not enough resources for the task"
+
+
+    - name: Update change_request with same hold state - unchanged
+      servicenow.itsm.change_request_task: *update-change_request_task-state-review
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result is not changed
+
+
+    - name: Fail to close the task
+      servicenow.itsm.change_request_task:
+        number: "{{ test_result.record.number }}"
+        state: closed
+      ignore_errors: true
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'close_code' in result.msg"
+          - "'close_notes' in result.msg"
+
+
+    - name: Update change_request_task state to closed - check mode
+      servicenow.itsm.change_request_task: &update-change_request_task-state-closed
+        number: "{{ test_result.record.number }}"
+        state: closed
+        close_code: successful
+        close_notes: Task done
+      check_mode: true
+      register: result
+
+    - ansible.builtin.assert: &update-change_request_task-state-result-closed
+        that:
+          - result is changed
+          - result.record.state == "closed"
+          - result.record.close_code == "successful"
+          - result.record.close_notes == "Task done"
+
+
+    - name: Update change_request_task state to closed
+      servicenow.itsm.change_request_task: *update-change_request_task-state-closed
+
+    - ansible.builtin.assert: *update-change_request_task-state-result-closed
+
+
+    - name: Get change_request_task info by sysparm query - state and close_notes
+      servicenow.itsm.change_request_task_info:
+        query:
+         - state: = closed
+           close_notes: = Task done
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result.records[0].state == "closed"
+          - result.records[0].close_notes == "Task done"
+
+
+    - name: Make sure change_request_task state was updated and is in closed state
+      servicenow.itsm.change_request_task_info:
+        number: "{{ test_result.record.number }}"
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result.records[0].number == test_result.record.number
+          - result.records[0].state == "closed"
+          - result.records[0].close_code == "successful"
+          - result.records[0].close_notes == "Task done"
+
+
+    - name: Get specific change request task info by sysparm query
+      servicenow.itsm.change_request_task_info:
+        query:
+         - number: = {{ test_result.record.number }}
+           state: = closed
+           close_code: = successful
+           close_notes: = Task done
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result.records | length == 1
+          - result.records[0].number == test_result.record.number
+          - result.records[0].state == "closed"
+          - result.records[0].close_code == "successful"
+          - result.records[0].close_notes == "Task done"
+
+
+    - name: Update change_request_task with same state - unchanged
+      servicenow.itsm.change_request_task: *update-change_request_task-state-closed
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result is not changed
+
+
+    - name: Get change_request_task info by sysparm query - short_description
+      servicenow.itsm.change_request_task_info:
+        query:
+          - short_description: LIKE Oracle
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - "'Oracle' in result.records[0].short_description"
+
+
+    - name: Delete change_request_task - check mode
+      servicenow.itsm.change_request_task: &delete-change_request_task
+        number: "{{ test_result.record.number }}"
+        state: absent
+      check_mode: true
+      register: result
+
+    - ansible.builtin.assert: &delete-change_request_task-result
+        that:
+          - result is changed
+
+
+    - name: Delete change_request_task
+      servicenow.itsm.change_request_task: *delete-change_request_task
+
+    - ansible.builtin.assert: *delete-change_request_task-result
+
+
+    - name: Make sure change_request_task is absent
+      servicenow.itsm.change_request_task_info:
+        number: "{{ test_result.record.number }}"
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result.records | length == 0
+
+
+    - name: Delete change_request_task - unchanged
+      servicenow.itsm.change_request_task: *delete-change_request_task
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result is not changed
+
+
+    - name: Test bad parameter combinator (number + query)
+      servicenow.itsm.change_request_task_info:
+        number: "{{ test_result.record.number }}"
+        query:
+         - short_description: LIKE Oracle
+      ignore_errors: true
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'parameters are mutually exclusive: number|query' in result.msg"
+
+
+    - name: Test invalid operator detection
+      servicenow.itsm.change_request_task_info:
+        query:
+         - short_description: LIKEE Oracle
+      ignore_errors: true
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'Invalid condition' in result.msg"

--- a/tests/unit/plugins/module_utils/test_table.py
+++ b/tests/unit/plugins/module_utils/test_table.py
@@ -215,3 +215,21 @@ class TestFindUser:
         user = table.find_user(table_client, "test")
 
         assert dict(sys_id="1234", user_name="test") == user
+
+
+class TestFindChangeRequest:
+    def test_change_request_lookup(self, table_client):
+        table_client.get_record.return_value = dict(sys_id="1234", number="TST123")
+
+        user = table.find_change_request(table_client, "TST123")
+
+        assert dict(sys_id="1234", number="TST123") == user
+
+
+class TestFindConfigurationItem:
+    def test_change_request_lookup(self, table_client):
+        table_client.get_record.return_value = dict(sys_id="1234", name="TST123")
+
+        user = table.find_change_request(table_client, "TST123")
+
+        assert dict(sys_id="1234", name="TST123") == user

--- a/tests/unit/plugins/modules/test_change_request_task.py
+++ b/tests/unit/plugins/modules/test_change_request_task.py
@@ -1,0 +1,531 @@
+# -*- coding: utf-8 -*-
+# # Copyright: (c) 2021, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+import pytest
+
+from ansible_collections.servicenow.itsm.plugins.modules import change_request_task
+from ansible_collections.servicenow.itsm.plugins.module_utils import errors
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires python2.7 or higher"
+)
+
+
+class TestEnsureAbsent:
+    def test_delete_change_request(self, create_module, table_client):
+        module = create_module(
+            params=dict(
+                instance=dict(host="my.host.name", username="user", password="pass"),
+                state="absent",
+                number="CTASK0000001",
+                sys_id=None,
+                on_hold=None,
+            )
+        )
+        table_client.get_record.return_value = dict(state="3", number="CTASK0000001")
+
+        result = change_request_task.ensure_absent(module, table_client)
+
+        table_client.delete_record.assert_called_once()
+        assert result == (
+            True,
+            None,
+            dict(before=dict(state="closed", number="CTASK0000001"), after=None),
+        )
+
+    def test_delete_change_request_not_present(self, create_module, table_client):
+        module = create_module(
+            params=dict(
+                instance=dict(host="my.host.name", username="user", password="pass"),
+                state="absent",
+                number=None,
+                sys_id="1234",
+                on_hold=None,
+            ),
+        )
+        table_client.get_record.return_value = None
+
+        result = change_request_task.ensure_absent(module, table_client)
+
+        table_client.delete_record.assert_not_called()
+        assert result == (False, None, dict(before=None, after=None))
+
+
+class TestValidateParams:
+    VALID_PARAMS = dict(
+        state="closed",
+        close_code="successful",
+        close_notes="Solved",
+        description="dsc",
+        short_description="sd",
+        on_hold=None,
+    )
+    VALID_PARAMS_HOLD = dict(
+        state="in_progress",
+        close_code="successful",
+        close_notes="Solved",
+        description="dsc",
+        short_description="sd",
+        on_hold=True,
+        hold_reason="Waiting",
+    )
+
+    @pytest.mark.parametrize(
+        "missing_field",
+        ["close_code", "close_notes", "description", "short_description"],
+    )
+    def test_validate_params_missing_field(self, missing_field):
+        params = self.VALID_PARAMS.copy()
+        params[missing_field] = None
+
+        with pytest.raises(errors.ServiceNowError, match=missing_field):
+            change_request_task.validate_params(params)
+
+    @pytest.mark.parametrize(
+        "missing_field",
+        [
+            "hold_reason",
+        ],
+    )
+    def test_validate_params_missing_on_hold_field(self, missing_field):
+        params = self.VALID_PARAMS_HOLD.copy()
+        params[missing_field] = None
+
+    def test_validate_params(self):
+        change_request_task.validate_params(self.VALID_PARAMS)
+
+    def test_validate_params_on_hold(self):
+        change_request_task.validate_params(self.VALID_PARAMS_HOLD)
+
+
+class TestEnsurePresent:
+    def test_ensure_present_create_new(self, create_module, table_client):
+        module = create_module(
+            params=dict(
+                instance=dict(host="my.host.name", username="user", password="pass"),
+                configuration_item_id=None,
+                configuration_item=None,
+                change_request_id=None,
+                change_request_number=None,
+                type="planning",
+                state="open",
+                assigned_to=None,
+                assignment_group=None,
+                short_description="sd",
+                description="description",
+                on_hold=None,
+                hold_reason=None,
+                planned_start_date=None,
+                planned_end_date=None,
+                close_code=None,
+                close_notes=None,
+                other=None,
+                sys_id=None,
+                number=None,
+            ),
+        )
+        table_client.create_record.return_value = dict(
+            change_task_type="planning",
+            state="1",
+            short_description="sd",
+            description="description",
+            number="CTASK0000001",
+        )
+
+        result = change_request_task.ensure_present(module, table_client)
+
+        table_client.create_record.assert_called_once()
+        assert result == (
+            True,
+            dict(
+                change_task_type="planning",
+                state="open",
+                short_description="sd",
+                description="description",
+                number="CTASK0000001",
+            ),
+            dict(
+                before=None,
+                after=dict(
+                    change_task_type="planning",
+                    state="open",
+                    short_description="sd",
+                    description="description",
+                    number="CTASK0000001",
+                ),
+            ),
+        )
+
+    def test_ensure_present_nothing_to_do(self, create_module, table_client):
+        module = create_module(
+            params=dict(
+                instance=dict(host="my.host.name", username="user", password="pass"),
+                configuration_item_id=None,
+                configuration_item=None,
+                change_request_id=None,
+                change_request_number=None,
+                type="planning",
+                state="open",
+                assigned_to=None,
+                assignment_group=None,
+                short_description="sd",
+                description="description",
+                on_hold=None,
+                hold_reason=None,
+                planned_start_date=None,
+                planned_end_date=None,
+                close_code=None,
+                close_notes=None,
+                other=None,
+                sys_id=None,
+                number="CTASK0000001",
+            ),
+        )
+        table_client.get_record.return_value = dict(
+            change_task_type="planning",
+            state="1",
+            short_description="sd",
+            description="description",
+            number="CTASK0000001",
+        )
+
+        result = change_request_task.ensure_present(module, table_client)
+
+        table_client.get_record.assert_called_once()
+        assert result == (
+            False,
+            dict(
+                change_task_type="planning",
+                state="open",
+                short_description="sd",
+                description="description",
+                number="CTASK0000001",
+            ),
+            dict(
+                before=dict(
+                    change_task_type="planning",
+                    state="open",
+                    short_description="sd",
+                    description="description",
+                    number="CTASK0000001",
+                ),
+                after=dict(
+                    change_task_type="planning",
+                    state="open",
+                    short_description="sd",
+                    description="description",
+                    number="CTASK0000001",
+                ),
+            ),
+        )
+
+    def test_ensure_present_update(self, create_module, table_client):
+        module = create_module(
+            params=dict(
+                instance=dict(host="my.host.name", username="user", password="pass"),
+                configuration_item_id=None,
+                configuration_item=None,
+                change_request_id=None,
+                change_request_number=None,
+                type="planning",
+                state="in_progress",
+                assigned_to=None,
+                assignment_group=None,
+                short_description="sd",
+                description="description",
+                on_hold=None,
+                hold_reason=None,
+                planned_start_date=None,
+                planned_end_date=None,
+                close_code=None,
+                close_notes=None,
+                other=None,
+                sys_id=None,
+                number="CTASK0000001",
+            ),
+        )
+
+        table_client.get_record.return_value = dict(
+            change_task_type="planning",
+            state="1",
+            short_description="sd",
+            description="description",
+            number="CTASK0000001",
+        )
+        table_client.update_record.return_value = dict(
+            change_task_type="planning",
+            state="2",
+            short_description="sd",
+            description="description",
+            number="CTASK0000001",
+        )
+
+        result = change_request_task.ensure_present(module, table_client)
+
+        table_client.update_record.assert_called_once()
+        assert result == (
+            True,
+            dict(
+                change_task_type="planning",
+                state="in_progress",
+                short_description="sd",
+                description="description",
+                number="CTASK0000001",
+            ),
+            dict(
+                before=dict(
+                    change_task_type="planning",
+                    state="open",
+                    short_description="sd",
+                    description="description",
+                    number="CTASK0000001",
+                ),
+                after=dict(
+                    change_task_type="planning",
+                    state="in_progress",
+                    short_description="sd",
+                    description="description",
+                    number="CTASK0000001",
+                ),
+            ),
+        )
+
+
+class TestBuildPayload:
+    def test_build_payload(self, create_module, table_client):
+        module = create_module(
+            params=dict(
+                instance=dict(host="my.host.name", username="user", password="pass"),
+                configuration_item_id=None,
+                configuration_item="config item",
+                change_request_id=None,
+                change_request_number="CR1234",
+                type="planning",
+                state="open",
+                assigned_to="some.user",
+                assignment_group="some.group",
+                short_description="UV",
+                description="Unmapped value",
+                on_hold=None,
+                hold_reason="Some reason",
+                planned_start_date=None,
+                planned_end_date=None,
+                close_code=None,
+                close_notes=None,
+                other=None,
+                sys_id=None,
+                number=None,
+            ),
+        )
+        table_client.get_record.side_effect = [
+            {"sys_id": "c248952584a34ae1a851a38d7fc08fcf"},
+            {"sys_id": "e361760abb09450da835b5e4f2271dcf"},
+            {"sys_id": "4488052c5f5248f8b787ec9df5459c09"},
+            {"sys_id": "18fee81900824bfeb78e8c9062fb8f06"},
+        ]
+
+        result = change_request_task.build_payload(module, table_client)
+
+        assert result["change_task_type"] == "planning"
+        assert result["on_hold_reason"] == "Some reason"
+        assert result["cmdb_ci"] == "c248952584a34ae1a851a38d7fc08fcf"
+        assert result["change_request"] == "e361760abb09450da835b5e4f2271dcf"
+        assert result["assigned_to"] == "4488052c5f5248f8b787ec9df5459c09"
+        assert result["assignment_group"] == "18fee81900824bfeb78e8c9062fb8f06"
+        assert result["short_description"] == "UV"
+        assert "type" not in result
+        assert "hold_reason" not in result
+        assert "configuration_item_id" not in result
+        assert "configuration_item" not in result
+        assert "change_request_id" not in result
+        assert "change_request_number" not in result
+        assert "hold_reason" not in result
+        assert "hold_reason" not in result
+
+    def test_build_payload_with_other_option(self, create_module, table_client):
+        module = create_module(
+            params=dict(
+                instance=dict(host="my.host.name", username="user", password="pass"),
+                configuration_item_id="1234",
+                configuration_item=None,
+                change_request_id="4321",
+                change_request_number=None,
+                type="planning",
+                state="open",
+                assigned_to="some.user",
+                assignment_group="some.group",
+                short_description="UV",
+                description="Unmapped value",
+                on_hold=None,
+                hold_reason="Some reason",
+                planned_start_date=None,
+                planned_end_date=None,
+                close_code=None,
+                close_notes=None,
+                other=None,
+                sys_id=None,
+                number=None,
+            ),
+        )
+        table_client.get_record.side_effect = [
+            {"sys_id": "c248952584a34ae1a851a38d7fc08fcf"},
+            {"sys_id": "e361760abb09450da835b5e4f2271dcf"},
+        ]
+
+        result = change_request_task.build_payload(module, table_client)
+
+        assert result["change_task_type"] == "planning"
+        assert result["on_hold_reason"] == "Some reason"
+        assert result["cmdb_ci"] == "1234"
+        assert result["change_request"] == "4321"
+        assert result["assigned_to"] == "c248952584a34ae1a851a38d7fc08fcf"
+        assert result["assignment_group"] == "e361760abb09450da835b5e4f2271dcf"
+        assert result["short_description"] == "UV"
+        assert "type" not in result
+        assert "hold_reason" not in result
+        assert "configuration_item_id" not in result
+        assert "configuration_item" not in result
+        assert "change_request_id" not in result
+        assert "change_request_number" not in result
+        assert "hold_reason" not in result
+        assert "hold_reason" not in result
+
+
+class TestSupersetWithDateCheck:
+    @pytest.mark.parametrize(
+        "superset,candidate",
+        [
+            (dict(), dict()),
+            (dict(a=1), dict()),
+            (dict(a=1), dict(a=1)),
+            (dict(a=1, b=2), dict(b=2)),
+        ],
+    )
+    def test_valid_superset(self, superset, candidate):
+        assert change_request_task.is_superset_with_date(superset, candidate) is True
+
+    @pytest.mark.parametrize(
+        "superset,candidate",
+        [
+            (dict(), dict(a=1)),  # superset is missing a key
+            (dict(a=1), dict(a=2)),  # key value is different
+            (dict(param="2021-07-09 08:40:33"), dict(param="2021-07-09T08:40:33")),
+        ],
+    )
+    def test_not_a_superset(self, superset, candidate):
+        assert change_request_task.is_superset_with_date(superset, candidate) is False
+
+    @pytest.mark.parametrize(
+        "record,params",
+        [
+            (
+                dict(planned_start_date="2021-07-09T08:40:33"),
+                dict(planned_start_date="2021-07-09T08:40:33"),
+            ),
+            (
+                dict(planned_start_date="2021-07-09T08:40:33"),
+                dict(planned_start_date="2021-07-09 08:40:33"),
+            ),
+            (
+                dict(planned_start_date="2021-07-09 08:40:33"),
+                dict(planned_start_date="2021-07-09T08:40:33"),
+            ),
+            (
+                dict(planned_start_date="2021-07-09 08:40:33"),
+                dict(planned_start_date="2021-07-09 08:40:33"),
+            ),
+            (
+                dict(planned_end_date="2021-07-09T08:40:33"),
+                dict(planned_end_date="2021-07-09T08:40:33"),
+            ),
+            (
+                dict(planned_end_date="2021-07-09T08:40:33"),
+                dict(planned_end_date="2021-07-09 08:40:33"),
+            ),
+            (
+                dict(planned_end_date="2021-07-09 08:40:33"),
+                dict(planned_end_date="2021-07-09T08:40:33"),
+            ),
+            (
+                dict(planned_end_date="2021-07-09 08:40:33"),
+                dict(planned_end_date="2021-07-09 08:40:33"),
+            ),
+        ],
+    )
+    def test_same_point_in_time(self, record, params):
+        assert change_request_task.is_superset_with_date(record, params) is True
+
+    @pytest.mark.parametrize(
+        "record,params",
+        [
+            (
+                dict(planned_start_date="2021-07-09 08:40:33"),
+                dict(planned_start_date="2021-07-09 08:40:34"),
+            ),
+            (
+                dict(planned_end_date="2021-07-09 08:40:33"),
+                dict(planned_end_date="2021-07-09 08:40:34"),
+            ),
+        ],
+    )
+    def test_different_point_in_time(self, record, params):
+        assert change_request_task.is_superset_with_date(record, params) is False
+
+    @pytest.mark.parametrize(
+        "record,params",
+        [
+            (
+                dict(planned_start_date=None),
+                dict(planned_start_date=None),
+            ),
+            (
+                dict(planned_end_date=""),
+                dict(planned_end_date=""),
+            ),
+            (
+                dict(),
+                dict(planned_start_date=None),
+            ),
+            (
+                dict(),
+                dict(planned_start_date=""),
+            ),
+        ],
+    )
+    def test_empty_superset_dates(self, record, params):
+        assert change_request_task.is_superset_with_date(record, params) is True
+
+    @pytest.mark.parametrize(
+        "record,params",
+        [
+            (
+                dict(planned_start_date=""),
+                dict(planned_start_date="2021-07-09 08:40:34"),
+            ),
+            (
+                dict(planned_start_date="2021-07-09 08:40:33"),
+                dict(planned_start_date=""),
+            ),
+            (
+                dict(planned_start_date=None),
+                dict(planned_start_date="2021-07-09 08:40:34"),
+            ),
+            (
+                dict(planned_start_date="2021-07-09 08:40:33"),
+                dict(planned_start_date=None),
+            ),
+            (
+                dict(),
+                dict(planned_start_date="2021-07-09 08:40:33"),
+            ),
+        ],
+    )
+    def test_empty_not_superset_dates(self, record, params):
+        assert change_request_task.is_superset_with_date(record, params) is False

--- a/tests/unit/plugins/modules/test_change_request_task_info.py
+++ b/tests/unit/plugins/modules/test_change_request_task_info.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+# # Copyright: (c) 2021, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+
+import pytest
+
+from ansible_collections.servicenow.itsm.plugins.modules import change_request_task_info
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires python2.7 or higher"
+)
+
+
+class TestRemapCaller:
+    def test_remap_params_direct(self, table_client):
+        query = [
+            {"type": ("=", "planning")},
+            {"hold_reason": ("=", "Some reason")},
+            {"configuration_item_id": ("=", "4321")},
+            {"change_request_id": ("=", "1234")},
+            {"assigned_to": ("=", "some.user")},
+            {"assignment_group": ("=", "some.group")},
+            {"short_description": ("=", "Unmapped value")},
+        ]
+        table_client.get_record.side_effect = [
+            {"sys_id": "c248952584a34ae1a851a38d7fc08fcf"},
+            {"sys_id": "e361760abb09450da835b5e4f2271dcf"},
+            {"sys_id": "4488052c5f5248f8b787ec9df5459c09"},
+            {"sys_id": "18fee81900824bfeb78e8c9062fb8f06"},
+        ]
+
+        result = change_request_task_info.remap_params(query, table_client)
+
+        assert result == [
+            {"change_task_type": ("=", "planning")},
+            {"on_hold_reason": ("=", "Some reason")},
+            {"cmdb_ci": ("=", "4321")},
+            {"change_request": ("=", "1234")},
+            {"assigned_to": ("=", "c248952584a34ae1a851a38d7fc08fcf")},
+            {"assignment_group": ("=", "e361760abb09450da835b5e4f2271dcf")},
+            {"short_description": ("=", "Unmapped value")},
+        ]
+
+    def test_remap_params_full(self, table_client):
+        query = [
+            {"type": ("=", "planning")},
+            {"hold_reason": ("=", "Some reason")},
+            {"configuration_item": ("=", "config item")},
+            {"change_request_number": ("=", "CR1234")},
+            {"assigned_to": ("=", "some.user")},
+            {"assignment_group": ("=", "some.group")},
+            {"short_description": ("=", "Unmapped value")},
+        ]
+        table_client.get_record.side_effect = [
+            {"sys_id": "c248952584a34ae1a851a38d7fc08fcf"},
+            {"sys_id": "e361760abb09450da835b5e4f2271dcf"},
+            {"sys_id": "4488052c5f5248f8b787ec9df5459c09"},
+            {"sys_id": "18fee81900824bfeb78e8c9062fb8f06"},
+        ]
+
+        result = change_request_task_info.remap_params(query, table_client)
+
+        assert result == [
+            {"change_task_type": ("=", "planning")},
+            {"on_hold_reason": ("=", "Some reason")},
+            {"cmdb_ci": ("=", "c248952584a34ae1a851a38d7fc08fcf")},
+            {"change_request": ("=", "e361760abb09450da835b5e4f2271dcf")},
+            {"assigned_to": ("=", "4488052c5f5248f8b787ec9df5459c09")},
+            {"assignment_group": ("=", "18fee81900824bfeb78e8c9062fb8f06")},
+            {"short_description": ("=", "Unmapped value")},
+        ]
+
+
+class TestMain:
+    def test_minimal_set_of_params(self, run_main):
+        params = dict(
+            instance=dict(
+                host="https://my.host.name", username="user", password="pass"
+            ),
+        )
+        success, result = run_main(change_request_task_info, params)
+
+        assert success is True
+
+    def test_all_params(self, run_main):
+        params = dict(
+            instance=dict(
+                host="https://my.host.name", username="user", password="pass"
+            ),
+            sys_id="id",
+            number="n",
+        )
+        success, result = run_main(change_request_task_info, params)
+
+        assert success is True
+
+    def test_fail(self, run_main):
+        success, result = run_main(change_request_task_info)
+
+        assert success is False
+        assert "instance" in result["msg"]
+
+
+class TestRun:
+    def test_run(self, create_module, table_client):
+        module = create_module(
+            params=dict(
+                instance=dict(
+                    host="https://my.host.name", username="user", password="pass"
+                ),
+                sys_id=None,
+                number="n",
+                query=None,
+            )
+        )
+        table_client.list_records.return_value = [dict(p=1), dict(q=2), dict(r=3)]
+
+        change_requests = change_request_task_info.run(module, table_client)
+
+        table_client.list_records.assert_called_once_with(
+            "change_task", dict(number="n")
+        )
+        assert change_requests == [dict(p=1), dict(q=2), dict(r=3)]


### PR DESCRIPTION
Depends-on: https://github.com/ansible/ansible-zuul-jobs/pull/1299

Adds change_request_task and change_request_task_info modules. It allows
users to modify all standard parameters defined in the ServiceNow docs
(https://docs.servicenow.com/bundle/quebec-it-service-management/page/product/change-management/task/create-a-change-task.html),
as well as properties required to create and close tasks.

table.py - add change_request and configuration item search options

##### ISSUE TYPE

- New Module Pull Request

