### PR TITLE
Enhance inventory with groups from CMDB relations

### DIFF
--- a/changelogs/fragments/enhanced-inventory.yaml
+++ b/changelogs/fragments/enhanced-inventory.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- now - Enhance inventory with additional groups from CMDB relations (https://github.com/ansible-collections/servicenow.itsm/issues/108).

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -30,7 +30,7 @@ from ..module_utils.relations import (
 
 
 DOCUMENTATION = r"""
-name: servicenow.itsm.now
+name: now
 plugin_type: inventory
 author:
   - Manca Bizjak (@mancabizjak)

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -658,11 +658,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         enhanced = self.get_option("enhanced")
 
         if enhanced and (named_groups or group_by):
-            self.display.warning(
+            raise AnsibleParserError(
                 "Option 'enhanced' is incompatible with options 'named_groups' or "
-                "'group_by' and is therefore assumed False"
+                "'group_by'."
             )
-            enhanced = False
 
         table_client = TableClient(client)
 

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -116,8 +116,9 @@ options:
     description:
       - Enable enhanced inventory which provides relationship information from CMDB.
       - Mutually exclusive with deprecated options I(named_groups) and I(group_by).
-    type: Bool
+    type: bool
     default: false
+    version_added: 1.3.0
   ansible_host_source:
     description:
       - Host variable to use as I(ansible_host) when generating inventory hosts.

--- a/plugins/module_utils/relations.py
+++ b/plugins/module_utils/relations.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2022, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import re
+
+
+REL_TABLE = "cmdb_rel_ci"
+# sysparm_fields to be used when querying REL_TABLE. Uses dot-walking
+# notation to extract fields from linked tables in a single REST API call.
+# https://docs.servicenow.com/bundle/rome-application-development/page/integrate/inbound-rest/concept/c_RESTAPI.html#d1168970e439
+REL_FIELDS = set(
+    (
+        "sys_id",
+        "type.name",
+        "parent.sys_id",
+        "parent.name",
+        "parent.sys_class_name",
+        "child.sys_id",
+        "child.name",
+        "child.sys_class_name",
+    )
+)
+
+# Similar as above but for sysparm_query
+REL_QUERY = None
+
+
+def _extend_records_with_groups(records, groups):
+    for record in records:
+        sys_id = record.get("sys_id")
+        sys_id_groups = groups.get(sys_id, set())
+        record["relationship_groups"] = sys_id_groups
+
+    return records
+
+
+def _extract_ci_rel_type(type_name):
+    # type_name is of form "Parent description::Child description".
+    # Return the value of form (Parent_description, Child_description).
+    type_name = type_name or "__"
+    type_name = re.sub(r"\s|:", "_", type_name)
+    ci_rel_type = tuple(type_name.split("__"))
+
+    return ci_rel_type
+
+
+def _extract_parent_relation(rel_record):
+    sys_id = rel_record.get("parent.sys_id", "")
+    ci_name = rel_record.get("child.name", "")
+    ci_class = rel_record.get("child.sys_class_name", "")
+    type_name = rel_record.get("type.name", "")
+    ci_rel_type = _extract_ci_rel_type(type_name)[1]
+
+    return sys_id, ci_name, ci_class, ci_rel_type
+
+
+def _extract_child_relation(rel_record):
+    sys_id = rel_record.get("child.sys_id", "")
+    ci_name = rel_record.get("parent.name", "")
+    ci_class = rel_record.get("parent.sys_class_name", "")
+    type_name = rel_record.get("type.name", "")
+    ci_rel_type = _extract_ci_rel_type(type_name)[0]
+
+    return sys_id, ci_name, ci_class, ci_rel_type
+
+
+def _relations_to_groups(rel_records):
+    groups = dict()
+
+    extract_relation = dict(
+        parent=_extract_parent_relation, child=_extract_child_relation
+    )
+
+    for rel_record in rel_records or list():
+        for target in ("child", "parent"):
+            t_extr_rel = extract_relation[target]
+            sys_id, ci_name, ci_class, ci_rel_type = t_extr_rel(rel_record)
+
+            if sys_id and ci_name and ci_rel_type and ci_class:
+                rel_group = "{0}_{1}".format(ci_name, ci_rel_type)
+
+                items = groups.setdefault(sys_id, set())
+                items.add(rel_group)
+
+    return groups
+
+
+def enhance_records_with_rel_groups(records, rel_records):
+    groups = _relations_to_groups(rel_records)
+    records = _extend_records_with_groups(records, groups)
+
+    return records

--- a/tests/unit/plugins/inventory/test_now.py
+++ b/tests/unit/plugins/inventory/test_now.py
@@ -11,9 +11,10 @@ import sys
 
 import pytest
 
-from ansible.errors import AnsibleParserError
+from ansible.errors import AnsibleParserError, AnsibleError
 from ansible.inventory.data import InventoryData
 from ansible.module_utils.common.text.converters import to_text
+from ansible.template import Templar
 
 from ansible_collections.servicenow.itsm.plugins.inventory import now
 
@@ -26,6 +27,7 @@ pytestmark = pytest.mark.skipif(
 def inventory_plugin():
     plugin = now.InventoryModule()
     plugin.inventory = InventoryData()
+    plugin.templar = Templar(loader=None)
     return plugin
 
 
@@ -51,6 +53,13 @@ class TestFetchRecords:
 
         table_client.list_records.assert_called_once_with(
             "table_name", dict(sysparm_display_value=True, sysparm_query="my!=value")
+        )
+
+    def test_no_query_with_fields(self, table_client):
+        now.fetch_records(table_client, "table_name", None, fields=["a", "b", "c"])
+
+        table_client.list_records.assert_called_once_with(
+            "table_name", dict(sysparm_display_value=True, sysparm_fields="a,b,c")
         )
 
 
@@ -292,3 +301,578 @@ class TestInventoryModuleFillAutoGroups:
         groups = inventory_plugin.inventory.get_groups_dict()
         assert set(groups["b_a_d"]) == set(("a3",))
         assert set(groups["glass"]) == set(("a4",))
+
+
+class TestInventoryModuleFillEnhancedAutoGroups:
+    def test_construction(self, inventory_plugin):
+        record = dict(
+            sys_id="1",
+            ip_address="1.1.1.1",
+            fqdn="a1",
+            relationship_groups=set(
+                (
+                    "NY-01-01_Rack_contains",
+                    "Storage Area Network 002_Sends_data_to",
+                    "Blackberry_Depends_on",
+                    "Retail Adding Points_Depends_on",
+                )
+            ),
+        )
+
+        host = inventory_plugin.add_host(record, "ip_address", "fqdn")
+        inventory_plugin.fill_enhanced_auto_groups(record, host)
+
+        assert set(inventory_plugin.inventory.groups) == set(
+            (
+                "all",
+                "ungrouped",
+                "NY_01_01_Rack_contains",
+                "Storage_Area_Network_002_Sends_data_to",
+                "Blackberry_Depends_on",
+                "Retail_Adding_Points_Depends_on",
+            )
+        )
+
+        assert set(inventory_plugin.inventory.hosts) == set(("a1",))
+
+        a1 = inventory_plugin.inventory.get_host("a1")
+        a1_groups = (group.name for group in a1.groups)
+        assert set(a1_groups) == set(
+            (
+                "NY_01_01_Rack_contains",
+                "Storage_Area_Network_002_Sends_data_to",
+                "Blackberry_Depends_on",
+                "Retail_Adding_Points_Depends_on",
+            )
+        )
+
+        assert a1.vars == dict(
+            inventory_file=None, inventory_dir=None, ansible_host="1.1.1.1"
+        )
+
+    def test_construction_empty(self, inventory_plugin):
+        record = dict(
+            sys_id="1", ip_address="1.1.1.1", fqdn="a1", relationship_groups=set()
+        )
+
+        host = inventory_plugin.add_host(record, "ip_address", "fqdn")
+        inventory_plugin.fill_enhanced_auto_groups(record, host)
+
+        assert set(inventory_plugin.inventory.groups) == set(("all", "ungrouped"))
+
+        assert set(inventory_plugin.inventory.hosts) == set(("a1",))
+
+        a1 = inventory_plugin.inventory.get_host("a1")
+        a1_groups = (group.name for group in a1.groups)
+        assert set(a1_groups) == set()
+
+        assert a1.vars == dict(
+            inventory_file=None, inventory_dir=None, ansible_host="1.1.1.1"
+        )
+
+
+class TestInventoryModuleFillConstructed:
+    def test_construction_empty(self, inventory_plugin):
+        records = []
+        columns = []
+        host_source = "ip_address"
+        name_source = "fqdn"
+        compose = {}
+        groups = {}
+        keyed_groups = []
+        strict = False
+        enhanced = False
+
+        inventory_plugin.fill_constructed(
+            records,
+            columns,
+            host_source,
+            name_source,
+            compose,
+            groups,
+            keyed_groups,
+            strict,
+            enhanced,
+        )
+
+        assert set(inventory_plugin.inventory.groups) == set(("all", "ungrouped"))
+        assert set(inventory_plugin.inventory.hosts) == set()
+
+    def test_construction_host(self, inventory_plugin):
+        records = [
+            dict(
+                sys_id="1",
+                ip_address="1.1.1.1",
+                fqdn="a1",
+            ),
+            dict(
+                sys_id="2",
+                ip_address="1.1.1.2",
+                fqdn="a2",
+            ),
+        ]
+
+        columns = []
+        host_source = "ip_address"
+        name_source = "fqdn"
+        compose = {}
+        groups = {}
+        keyed_groups = []
+        strict = False
+        enhanced = False
+
+        inventory_plugin.fill_constructed(
+            records,
+            columns,
+            host_source,
+            name_source,
+            compose,
+            groups,
+            keyed_groups,
+            strict,
+            enhanced,
+        )
+
+        assert set(inventory_plugin.inventory.groups) == set(("all", "ungrouped"))
+        assert set(inventory_plugin.inventory.hosts) == set(("a1", "a2"))
+
+        a1 = inventory_plugin.inventory.get_host("a1")
+        a1_groups = (group.name for group in a1.groups)
+        assert set(a1_groups) == set()
+
+        assert a1.vars == dict(
+            inventory_file=None, inventory_dir=None, ansible_host="1.1.1.1"
+        )
+
+        a2 = inventory_plugin.inventory.get_host("a2")
+        a2_groups = (group.name for group in a2.groups)
+        assert set(a2_groups) == set()
+
+        assert a2.vars == dict(
+            inventory_file=None, inventory_dir=None, ansible_host="1.1.1.2"
+        )
+
+    def test_construction_hostvars(self, inventory_plugin):
+        records = [
+            dict(sys_id="1", ip_address="1.1.1.1", fqdn="a1", cost="82", cost_cc="EUR"),
+            dict(sys_id="2", ip_address="1.1.1.2", fqdn="a2", cost="94", cost_cc="USD"),
+        ]
+
+        columns = ["cost", "cost_cc"]
+        host_source = "ip_address"
+        name_source = "fqdn"
+        compose = {}
+        groups = {}
+        keyed_groups = []
+        strict = False
+        enhanced = False
+
+        inventory_plugin.fill_constructed(
+            records,
+            columns,
+            host_source,
+            name_source,
+            compose,
+            groups,
+            keyed_groups,
+            strict,
+            enhanced,
+        )
+
+        assert set(inventory_plugin.inventory.groups) == set(("all", "ungrouped"))
+        assert set(inventory_plugin.inventory.hosts) == set(("a1", "a2"))
+
+        a1 = inventory_plugin.inventory.get_host("a1")
+        a1_groups = (group.name for group in a1.groups)
+        assert set(a1_groups) == set()
+
+        assert a1.vars == dict(
+            inventory_file=None,
+            inventory_dir=None,
+            ansible_host="1.1.1.1",
+            cost="82",
+            cost_cc="EUR",
+        )
+
+        a2 = inventory_plugin.inventory.get_host("a2")
+        a2_groups = (group.name for group in a2.groups)
+        assert set(a2_groups) == set()
+
+        assert a2.vars == dict(
+            inventory_file=None,
+            inventory_dir=None,
+            ansible_host="1.1.1.2",
+            cost="94",
+            cost_cc="USD",
+        )
+
+    def test_construction_composite_vars(self, inventory_plugin):
+        records = [
+            dict(
+                sys_id="1",
+                ip_address="1.1.1.1",
+                fqdn="a1",
+                cost="82",
+                cost_cc="EUR",
+                sys_updated_on="2021-09-17 02:13:25",
+            ),
+            dict(
+                sys_id="2",
+                ip_address="1.1.1.2",
+                fqdn="a2",
+                cost="94",
+                cost_cc="USD",
+                sys_updated_on="2021-08-30 01:47:03",
+            ),
+        ]
+
+        columns = []
+        host_source = "ip_address"
+        name_source = "fqdn"
+        compose = dict(
+            cost_res='"%s %s" % (cost, cost_cc)',
+            amortized_cost="cost | int // 2",
+            sys_updated_on_date="sys_updated_on | slice(2) | first | join",
+            sys_updated_on_time="sys_updated_on | slice(2) | last | join | trim",
+            silently_failed="non_existing + 3",
+        )
+        groups = {}
+        keyed_groups = []
+        strict = False
+        enhanced = False
+
+        inventory_plugin.fill_constructed(
+            records,
+            columns,
+            host_source,
+            name_source,
+            compose,
+            groups,
+            keyed_groups,
+            strict,
+            enhanced,
+        )
+
+        assert set(inventory_plugin.inventory.groups) == set(("all", "ungrouped"))
+        assert set(inventory_plugin.inventory.hosts) == set(("a1", "a2"))
+
+        a1 = inventory_plugin.inventory.get_host("a1")
+        a1_groups = (group.name for group in a1.groups)
+        assert set(a1_groups) == set()
+
+        assert a1.vars == dict(
+            inventory_file=None,
+            inventory_dir=None,
+            ansible_host="1.1.1.1",
+            cost_res="82 EUR",
+            amortized_cost="41",
+            sys_updated_on_date="2021-09-17",
+            sys_updated_on_time="02:13:25",
+        )
+
+        a2 = inventory_plugin.inventory.get_host("a2")
+        a2_groups = (group.name for group in a2.groups)
+        assert set(a2_groups) == set()
+
+        assert a2.vars == dict(
+            inventory_file=None,
+            inventory_dir=None,
+            ansible_host="1.1.1.2",
+            cost_res="94 USD",
+            amortized_cost="47",
+            sys_updated_on_date="2021-08-30",
+            sys_updated_on_time="01:47:03",
+        )
+
+    def test_construction_composite_vars_strict(self, inventory_plugin):
+        records = [
+            dict(sys_id="1", ip_address="1.1.1.1", fqdn="a1"),
+            dict(sys_id="2", ip_address="1.1.1.2", fqdn="a2"),
+        ]
+
+        columns = []
+        host_source = "ip_address"
+        name_source = "fqdn"
+        compose = dict(silently_failed="non_existing + 3")
+        groups = {}
+        keyed_groups = []
+        strict = True
+        enhanced = False
+
+        with pytest.raises(AnsibleError, match="non_existing"):
+            inventory_plugin.fill_constructed(
+                records,
+                columns,
+                host_source,
+                name_source,
+                compose,
+                groups,
+                keyed_groups,
+                strict,
+                enhanced,
+            )
+
+    def test_construction_composed_groups(self, inventory_plugin):
+        records = [
+            dict(sys_id="1", ip_address="1.1.1.1", fqdn="a1"),
+            dict(sys_id="2", ip_address="1.1.1.2", fqdn="a2"),
+        ]
+
+        columns = []
+        host_source = "ip_address"
+        name_source = "fqdn"
+        compose = {}
+        groups = dict(
+            ip1='ip_address == "1.1.1.1"',
+            ip2='ip_address != "1.1.1.1"',
+            cost="cost_usd < 90",  # ignored due to strict = False
+        )
+        keyed_groups = []
+        strict = False
+        enhanced = False
+
+        inventory_plugin.fill_constructed(
+            records,
+            columns,
+            host_source,
+            name_source,
+            compose,
+            groups,
+            keyed_groups,
+            strict,
+            enhanced,
+        )
+
+        assert set(inventory_plugin.inventory.groups) == set(
+            ("all", "ungrouped", "ip1", "ip2")
+        )
+
+        assert set(inventory_plugin.inventory.hosts) == set(("a1", "a2"))
+
+        a1 = inventory_plugin.inventory.get_host("a1")
+        a1_groups = (group.name for group in a1.groups)
+        assert set(a1_groups) == set(("ip1",))
+
+        assert a1.vars == dict(
+            inventory_file=None, inventory_dir=None, ansible_host="1.1.1.1"
+        )
+
+        a2 = inventory_plugin.inventory.get_host("a2")
+        a2_groups = (group.name for group in a2.groups)
+        assert set(a2_groups) == set(("ip2",))
+
+        assert a2.vars == dict(
+            inventory_file=None, inventory_dir=None, ansible_host="1.1.1.2"
+        )
+
+    def test_construction_composed_groups_strict(self, inventory_plugin):
+        records = [
+            dict(sys_id="1", ip_address="1.1.1.1", fqdn="a1"),
+            dict(sys_id="2", ip_address="1.1.1.2", fqdn="a2"),
+        ]
+
+        columns = []
+        host_source = "ip_address"
+        name_source = "fqdn"
+        compose = {}
+        groups = dict(
+            ip1='ip_address == "1.1.1.1"',
+            ip2='ip_address != "1.1.1.1"',
+            cost="cost_usd < 90",
+        )
+        keyed_groups = []
+        strict = True
+        enhanced = False
+
+        with pytest.raises(AnsibleError, match="cost_usd"):
+            inventory_plugin.fill_constructed(
+                records,
+                columns,
+                host_source,
+                name_source,
+                compose,
+                groups,
+                keyed_groups,
+                strict,
+                enhanced,
+            )
+
+    def test_construction_keyed_groups(self, inventory_plugin):
+        records = [
+            dict(sys_id="1", ip_address="1.1.1.1", fqdn="a1", cost_cc="EUR"),
+            dict(sys_id="2", ip_address="1.1.1.2", fqdn="a2", cost_cc="USD"),
+        ]
+
+        columns = []
+        host_source = "ip_address"
+        name_source = "fqdn"
+        compose = {}
+        groups = {}
+        keyed_groups = [
+            dict(
+                key="cost_cc",
+                default_value="EUR",
+                prefix="cc",
+            )
+        ]
+        strict = False
+        enhanced = False
+
+        inventory_plugin.fill_constructed(
+            records,
+            columns,
+            host_source,
+            name_source,
+            compose,
+            groups,
+            keyed_groups,
+            strict,
+            enhanced,
+        )
+
+        assert set(inventory_plugin.inventory.groups) == set(
+            ("all", "ungrouped", "cc_EUR", "cc_USD")
+        )
+
+        assert set(inventory_plugin.inventory.hosts) == set(("a1", "a2"))
+
+        a1 = inventory_plugin.inventory.get_host("a1")
+        a1_groups = (group.name for group in a1.groups)
+        assert set(a1_groups) == set(("cc_EUR",))
+
+        assert a1.vars == dict(
+            inventory_file=None, inventory_dir=None, ansible_host="1.1.1.1"
+        )
+
+        a2 = inventory_plugin.inventory.get_host("a2")
+        a2_groups = (group.name for group in a2.groups)
+        assert set(a2_groups) == set(("cc_USD",))
+
+        assert a2.vars == dict(
+            inventory_file=None, inventory_dir=None, ansible_host="1.1.1.2"
+        )
+
+    def test_construction_keyed_groups_with_parent(self, inventory_plugin):
+        records = [
+            dict(sys_id="1", ip_address="1.1.1.1", fqdn="a1", cost_cc="EUR"),
+            dict(sys_id="2", ip_address="1.1.1.2", fqdn="a2", cost_cc="USD"),
+        ]
+
+        columns = []
+        host_source = "ip_address"
+        name_source = "fqdn"
+        compose = {}
+        groups = {}
+        keyed_groups = [
+            dict(
+                key="cost_cc",
+                default_value="EUR",
+                prefix="cc",
+                parent_group="ip_address",
+            )
+        ]
+        strict = False
+        enhanced = False
+
+        inventory_plugin.fill_constructed(
+            records,
+            columns,
+            host_source,
+            name_source,
+            compose,
+            groups,
+            keyed_groups,
+            strict,
+            enhanced,
+        )
+
+        assert set(inventory_plugin.inventory.groups) == set(
+            ("all", "ungrouped", "cc_EUR", "cc_USD", "ip_address")
+        )
+
+        assert set(inventory_plugin.inventory.hosts) == set(("a1", "a2"))
+
+        a1 = inventory_plugin.inventory.get_host("a1")
+        a1_groups = (group.name for group in a1.groups)
+        assert set(a1_groups) == set(("cc_EUR", "ip_address"))
+
+        assert a1.vars == dict(
+            inventory_file=None, inventory_dir=None, ansible_host="1.1.1.1"
+        )
+
+        a2 = inventory_plugin.inventory.get_host("a2")
+        a2_groups = (group.name for group in a2.groups)
+        assert set(a2_groups) == set(("cc_USD", "ip_address"))
+
+        assert a2.vars == dict(
+            inventory_file=None, inventory_dir=None, ansible_host="1.1.1.2"
+        )
+
+    def test_construction_enhanced(self, inventory_plugin):
+        records = [
+            dict(
+                sys_id="1",
+                ip_address="1.1.1.1",
+                fqdn="a1",
+                relationship_groups=set(("NY-01-01_Rack_contains",)),
+            ),
+            dict(
+                sys_id="2",
+                ip_address="1.1.1.2",
+                fqdn="a2",
+                relationship_groups=set(
+                    ("Storage Area Network 002_Sends_data_to", "OWA-SD-01_Runs_on")
+                ),
+            ),
+        ]
+
+        columns = []
+        host_source = "ip_address"
+        name_source = "fqdn"
+        compose = {}
+        groups = {}
+        keyed_groups = []
+        strict = False
+        enhanced = True
+
+        inventory_plugin.fill_constructed(
+            records,
+            columns,
+            host_source,
+            name_source,
+            compose,
+            groups,
+            keyed_groups,
+            strict,
+            enhanced,
+        )
+
+        assert set(inventory_plugin.inventory.groups) == set(
+            (
+                "all",
+                "ungrouped",
+                "NY_01_01_Rack_contains",
+                "Storage_Area_Network_002_Sends_data_to",
+                "OWA_SD_01_Runs_on",
+            )
+        )
+
+        assert set(inventory_plugin.inventory.hosts) == set(("a1", "a2"))
+
+        a1 = inventory_plugin.inventory.get_host("a1")
+        a1_groups = (group.name for group in a1.groups)
+        assert set(a1_groups) == set(("NY_01_01_Rack_contains",))
+
+        assert a1.vars == dict(
+            inventory_file=None, inventory_dir=None, ansible_host="1.1.1.1"
+        )
+
+        a2 = inventory_plugin.inventory.get_host("a2")
+        a2_groups = (group.name for group in a2.groups)
+        assert set(a2_groups) == set(
+            ("Storage_Area_Network_002_Sends_data_to", "OWA_SD_01_Runs_on")
+        )
+
+        assert a2.vars == dict(
+            inventory_file=None, inventory_dir=None, ansible_host="1.1.1.2"
+        )

--- a/tests/unit/plugins/inventory/test_now.py
+++ b/tests/unit/plugins/inventory/test_now.py
@@ -560,29 +560,31 @@ class TestInventoryModuleFillConstructed:
         a1_groups = (group.name for group in a1.groups)
         assert set(a1_groups) == set()
 
-        assert a1.vars == dict(
-            inventory_file=None,
-            inventory_dir=None,
-            ansible_host="1.1.1.1",
-            cost_res="82 EUR",
-            amortized_cost="41",
-            sys_updated_on_date="2021-09-17",
-            sys_updated_on_time="02:13:25",
-        )
+        raise Exception(repr(a1.vars))
 
-        a2 = inventory_plugin.inventory.get_host("a2")
-        a2_groups = (group.name for group in a2.groups)
-        assert set(a2_groups) == set()
+        # assert a1.vars == dict(
+        #     inventory_file=None,
+        #     inventory_dir=None,
+        #     ansible_host="1.1.1.1",
+        #     cost_res="82 EUR",
+        #     amortized_cost="41",
+        #     sys_updated_on_date="2021-09-17",
+        #     sys_updated_on_time="02:13:25",
+        # )
 
-        assert a2.vars == dict(
-            inventory_file=None,
-            inventory_dir=None,
-            ansible_host="1.1.1.2",
-            cost_res="94 USD",
-            amortized_cost="47",
-            sys_updated_on_date="2021-08-30",
-            sys_updated_on_time="01:47:03",
-        )
+        # a2 = inventory_plugin.inventory.get_host("a2")
+        # a2_groups = (group.name for group in a2.groups)
+        # assert set(a2_groups) == set()
+
+        # assert a2.vars == dict(
+        #     inventory_file=None,
+        #     inventory_dir=None,
+        #     ansible_host="1.1.1.2",
+        #     cost_res="94 USD",
+        #     amortized_cost="47",
+        #     sys_updated_on_date="2021-08-30",
+        #     sys_updated_on_time="01:47:03",
+        # )
 
     def test_construction_composite_vars_strict(self, inventory_plugin):
         records = [
@@ -593,7 +595,7 @@ class TestInventoryModuleFillConstructed:
         columns = []
         host_source = "ip_address"
         name_source = "fqdn"
-        compose = dict(silently_failed="non_existing + 3")
+        compose = dict(failed="non_existing + 3")
         groups = {}
         keyed_groups = []
         strict = True

--- a/tests/unit/plugins/inventory/test_now.py
+++ b/tests/unit/plugins/inventory/test_now.py
@@ -533,7 +533,7 @@ class TestInventoryModuleFillConstructed:
             cost_res='"%s %s" % (cost, cost_cc)',
             amortized_cost="cost | int // 2",
             sys_updated_on_date="sys_updated_on | slice(2) | first | join",
-            sys_updated_on_time="sys_updated_on | slice(2) | last | join | trim",
+            sys_updated_on_time="sys_updated_on | slice(2) | list | last | join | trim",
             silently_failed="non_existing + 3",
         )
         groups = {}
@@ -560,31 +560,29 @@ class TestInventoryModuleFillConstructed:
         a1_groups = (group.name for group in a1.groups)
         assert set(a1_groups) == set()
 
-        raise Exception(repr(a1.vars))
+        assert a1.vars == dict(
+            inventory_file=None,
+            inventory_dir=None,
+            ansible_host="1.1.1.1",
+            cost_res="82 EUR",
+            amortized_cost="41",
+            sys_updated_on_date="2021-09-17",
+            sys_updated_on_time="02:13:25",
+        )
 
-        # assert a1.vars == dict(
-        #     inventory_file=None,
-        #     inventory_dir=None,
-        #     ansible_host="1.1.1.1",
-        #     cost_res="82 EUR",
-        #     amortized_cost="41",
-        #     sys_updated_on_date="2021-09-17",
-        #     sys_updated_on_time="02:13:25",
-        # )
+        a2 = inventory_plugin.inventory.get_host("a2")
+        a2_groups = (group.name for group in a2.groups)
+        assert set(a2_groups) == set()
 
-        # a2 = inventory_plugin.inventory.get_host("a2")
-        # a2_groups = (group.name for group in a2.groups)
-        # assert set(a2_groups) == set()
-
-        # assert a2.vars == dict(
-        #     inventory_file=None,
-        #     inventory_dir=None,
-        #     ansible_host="1.1.1.2",
-        #     cost_res="94 USD",
-        #     amortized_cost="47",
-        #     sys_updated_on_date="2021-08-30",
-        #     sys_updated_on_time="01:47:03",
-        # )
+        assert a2.vars == dict(
+            inventory_file=None,
+            inventory_dir=None,
+            ansible_host="1.1.1.2",
+            cost_res="94 USD",
+            amortized_cost="47",
+            sys_updated_on_date="2021-08-30",
+            sys_updated_on_time="01:47:03",
+        )
 
     def test_construction_composite_vars_strict(self, inventory_plugin):
         records = [

--- a/tests/unit/plugins/module_utils/test_relations.py
+++ b/tests/unit/plugins/module_utils/test_relations.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2022, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+
+import pytest
+
+from ansible_collections.servicenow.itsm.plugins.module_utils import relations
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires python2.7 or higher"
+)
+
+
+class TestAddRelationsToRecords:
+    def test_add_empty_relations_to_records(self):
+        records = [dict(sys_id="s1", name="abc")]
+        rels = dict()
+
+        relations._extend_records_with_groups(records, rels)
+
+        assert records == [dict(sys_id="s1", name="abc", relationship_groups=set())]
+
+    def test_add_relations_to_empty_records(self):
+        records = []
+        rels = dict()
+
+        relations._extend_records_with_groups(records, rels)
+
+        assert records == []
+
+    def test_add_relations_to_records(self):
+        records = [dict(sys_id="s1", name="abc")]
+        rels = dict(s1=set(("g1", "g2")), s2=set(("g3",)))
+
+        relations._extend_records_with_groups(records, rels)
+
+        assert records == [
+            dict(sys_id="s1", name="abc", relationship_groups=set(("g1", "g2")))
+        ]
+
+
+class TestGroupRelations:
+    def test_group_empty_relations(self):
+        records = []
+        rels = relations._relations_to_groups(records)
+        assert rels == dict()
+
+    def test_group_relations(self):
+        records = [
+            {
+                "parent.sys_id": "p1",
+                "child.name": "cn1",
+                "child.sys_class_name": "cscn1",
+                "child.sys_id": "c1",
+                "parent.name": "pn1",
+                "parent.sys_class_name": "pscn1",
+                "type.name": "parent1::child1",
+            },
+            {
+                "parent.sys_id": "p1",
+                "child.name": "cn2",
+                "child.sys_class_name": "cscn2",
+                "child.sys_id": "c2",
+                "parent.name": "pn1",
+                "parent.sys_class_name": "pscn1",
+                "type.name": "parent1::child2",
+            },
+        ]
+
+        actual = relations._relations_to_groups(records)
+
+        assert actual == dict(
+            p1=set(("cn1_child1", "cn2_child2")),
+            c1=set(("pn1_parent1",)),
+            c2=set(("pn1_parent1",)),
+        )
+
+
+class TestExtractRelation:
+    @pytest.mark.parametrize(
+        "record,expected",
+        [
+            (dict(), ("", "", "", "")),
+            (dict(some_key="value"), ("", "", "", "")),
+            ({"parent.sys_id": "s1"}, ("s1", "", "", "")),
+            ({"child.name": "cn"}, ("", "cn", "", "")),
+            ({"child.sys_class_name": "cscn"}, ("", "", "cscn", "")),
+            ({"type.name": "par::ch"}, ("", "", "", "ch")),
+            (
+                {
+                    "parent.sys_id": "s1",
+                    "child.name": "child_name",
+                    "child.sys_class_name": "child_sys_class_name",
+                    "type.name": "Parent desc::Child desc",
+                },
+                ("s1", "child_name", "child_sys_class_name", "Child_desc"),
+            ),
+        ],
+    )
+    def test_extract_parent_relation(self, record, expected):
+        actual = relations._extract_parent_relation(record)
+        assert actual == expected
+
+    @pytest.mark.parametrize(
+        "record,expected",
+        [
+            (dict(), ("", "", "", "")),
+            (dict(some_key="value"), ("", "", "", "")),
+            ({"child.sys_id": "s1"}, ("s1", "", "", "")),
+            ({"parent.name": "pn"}, ("", "pn", "", "")),
+            ({"parent.sys_class_name": "pscn"}, ("", "", "pscn", "")),
+            ({"type.name": "par::ch"}, ("", "", "", "par")),
+            (
+                {
+                    "child.sys_id": "s1",
+                    "parent.name": "parent_name",
+                    "parent.sys_class_name": "parent_sys_class_name",
+                    "type.name": "Parent desc::Child desc",
+                },
+                ("s1", "parent_name", "parent_sys_class_name", "Parent_desc"),
+            ),
+        ],
+    )
+    def test_extract_child_relation(self, record, expected):
+        actual = relations._extract_child_relation(record)
+        assert actual == expected
+
+
+class TestGetRelationType:
+    @pytest.mark.parametrize(
+        "type_name,expected",
+        [
+            (None, ("", "")),
+            ("", ("", "")),
+            ("Parent::Child", ("Parent", "Child")),
+            (
+                "Par ent desc ription::Child description",
+                ("Par_ent_desc_ription", "Child_description"),
+            ),
+        ],
+    )
+    def test_extract_rel_ci_type_empty(self, type_name, expected):
+        actual = relations._extract_ci_rel_type(type_name)
+        assert actual == expected
+
+
+class TestEnhanceRecordsWithRelationGroups:
+    def test_enhance_empty_records_with_empty_rel_groups(self):
+        records = []
+        rel_records = []
+
+        relations.enhance_records_with_rel_groups(records, rel_records)
+
+        assert records == []
+
+    def test_enhance_empty_records_with_rel_groups(self):
+        records = []
+        rel_records = [
+            {
+                "parent.sys_id": "s1",
+                "child.name": "child_name",
+                "child.sys_class_name": "child_sys_class_name",
+                "type.name": "Parent desc::Child desc",
+            }
+        ]
+
+        relations.enhance_records_with_rel_groups(records, rel_records)
+
+        assert records == []
+
+    def test_enhance_records_with_rel_groups(self):
+        records = [dict(sys_id="s1"), dict(sys_id="s2")]
+        rel_records = [
+            {
+                "parent.sys_id": "s1",
+                "child.name": "child_name",
+                "child.sys_class_name": "child_sys_class_name",
+                "type.name": "Parent desc::Child desc",
+            }
+        ]
+
+        relations.enhance_records_with_rel_groups(records, rel_records)
+
+        assert records == [
+            dict(sys_id="s1", relationship_groups=set(("child_name_Child_desc",))),
+            dict(sys_id="s2", relationship_groups=set()),
+        ]


### PR DESCRIPTION
##### SUMMARY
Extends inventory plugin module with groups extracted from CMDB relations.

Addresses issue #108.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Changes to `now`, added `relations` module utilities.

##### ADDITIONAL INFORMATION
To enable this extension, add option `enhanced: true` to the inventory file.

Unlike the implementation from the old, deprecated repository, which required installation of an update set, this implementation obtains all the required data through ServiceNow REST API.