### PR TITLE
Add modules for managing problem tasks

### DIFF
--- a/plugins/doc_fragments/problem_task_mapping.py
+++ b/plugins/doc_fragments/problem_task_mapping.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2022, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+class ModuleDocFragment(object):
+    DOCUMENTATION = r"""
+options:
+  problem_task_mapping:
+    version_added: "1.3.0"
+    description:
+      - User mapping for I(Problem task) object, where user can override Choice Lists values for objects.
+    type: dict
+    suboptions:
+      state:
+        description:
+          - State of problem tasks.
+          - If I(state) value is C(new), I(short_description) parameter must be filled in.
+        type: dict
+      priority:
+        description:
+          - How quickly the service desk should address the problem task.
+        type: dict
+"""

--- a/plugins/module_utils/arguments.py
+++ b/plugins/module_utils/arguments.py
@@ -63,6 +63,15 @@ PROBLEM_MAPPING_SPEC = dict(
     ),
 )
 
+PROBLEM_TASK_MAPPING_SPEC = dict(
+    type="dict",
+    required=False,
+    options=dict(
+        state=dict(type="dict"),
+        priority=dict(type="dict"),
+    ),
+)
+
 SHARED_SPECS = dict(
     instance=dict(
         type="dict",
@@ -139,6 +148,7 @@ SHARED_SPECS = dict(
     change_request_task_mapping=CHANGE_REQUEST_TASK_MAPPING_SPEC,
     configuration_item_mapping=CONFIGURATION_ITEM_MAPPING_SPEC,
     problem_mapping=PROBLEM_MAPPING_SPEC,
+    problem_task_mapping=PROBLEM_TASK_MAPPING_SPEC,
 )
 
 

--- a/plugins/module_utils/problem_task.py
+++ b/plugins/module_utils/problem_task.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2021, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+PAYLOAD_FIELDS_MAPPING = dict(
+    type=[("rca", "root_cause_analysis"), ("general", "general")],
+    state=[
+        ("151", "new"),
+        ("152", "assess"),
+        ("154", "work_in_progress"),
+        ("157", "closed"),
+    ],
+    priority=[
+        ("1", "critical"),
+        ("2", "high"),
+        ("3", "moderate"),
+        ("4", "low"),
+        ("5", "planning"),
+    ],
+)

--- a/plugins/module_utils/table.py
+++ b/plugins/module_utils/table.py
@@ -110,3 +110,9 @@ def find_change_request(table_client, change_request_number):
 
 def find_configuration_item(table_client, item_name):
     return table_client.get_record("cmdb_ci", dict(name=item_name), must_exist=True)
+
+
+def find_problem(table_client, problem_number):
+    return table_client.get_record(
+        "problem", dict(number=problem_number), must_exist=True
+    )

--- a/plugins/modules/problem.py
+++ b/plugins/modules/problem.py
@@ -33,6 +33,8 @@ extends_documentation_fragment:
   - servicenow.itsm.problem_mapping
 seealso:
   - module: servicenow.itsm.problem_info
+  - module: servicenow.itsm.problem_task
+  - module: servicenow.itsm.problem_task_info
 
 options:
   state:

--- a/plugins/modules/problem_task.py
+++ b/plugins/modules/problem_task.py
@@ -1,0 +1,433 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2021, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+DOCUMENTATION = r"""
+module: problem_task
+
+author:
+  - Manca Bizjak (@mancabizjak)
+  - Miha Dolinar (@mdolin)
+  - Tadej Borovsak (@tadeboro)
+
+short_description: Manage ServiceNow problem tasks
+
+description:
+  - Create, delete or update a ServiceNow problem tasks
+  - For more information, refer to the ServiceNow problem management documentation at
+    U(https://docs.servicenow.com/bundle/paris-it-service-management/page/product/problem-management/concept/c_ProblemManagement.html).
+
+version_added: 1.0.0
+
+extends_documentation_fragment:
+  - servicenow.itsm.instance
+  - servicenow.itsm.sys_id
+  - servicenow.itsm.number
+  - servicenow.itsm.problem_task_mapping
+seealso:
+  - module: servicenow.itsm.problem_task_info
+  - module: servicenow.itsm.problem
+  - module: servicenow.itsm.problem_info
+
+options:
+  state:
+    description:
+      - State of problem tasks.
+      - If I(state) value is C(new), I(short_description) parameter must be filled in.
+    choices: [ new, assess, work_in_progress, closed, absent ]
+    type: str
+  type:
+    description:
+      - Read-only state. Determines whether the problem task is created specifically
+        to investigate the cause of the problem or is a general task.
+    choices: [ root_cause_analysis, general]
+    type: str
+  configuration_item:
+    description:
+      - Configuration item (CI) that the problem applies to. The CI class of the selected
+        configuration item identifies the type of problem.
+    type: str
+  due_date:
+    description:
+      - Date within which the problem task should be completed.
+    type: str
+  source_problem:
+    description:
+      - Number of the problem for which the problem task is created.
+    type: str
+  priority:
+    description:
+      - How quickly the service desk should address the problem task.
+    choices: [ critical, high, moderate, low, planning ]
+    type: str
+  assignment_group:
+    description:
+      - Specific group to whom the problem task is assigned to.
+    type: str
+  assigned_to:
+    description:
+      - Specific problem analyst to whom the task is assigned to.
+    type: str
+  short_description:
+    description:
+      - Brief description of the problem task.
+    type: str
+  description:
+    description:
+      - Detailed description of the problem task.
+    type: str
+  close_code:
+    description:
+      - Provide information on how the change task was resolved.
+      - The change task must have this parameter set prior to
+        transitioning to the C(closed) state.
+    choices: [ completed, canceled ]
+    type: str
+  close_notes:
+    description:
+      - Resolution notes added by the user who closed the change task.
+      - The change task must have this parameter set prior to
+        transitioning to the C(closed) state.
+    type: str
+  other:
+    description:
+      - Optional remaining parameters.
+      - For more information on optional parameters, refer to the ServiceNow
+        create problem task documentation at
+        U(https://docs.servicenow.com/bundle/quebec-it-service-management/page/product/problem-management/task/create-problem-task.html).
+    type: dict
+"""
+
+EXAMPLES = r"""
+- name: Create problem task
+  servicenow.itsm.problem_task:
+    instance:
+      host: https://instance_id.service-now.com
+      username: user
+      password: pass
+
+    state: new
+    type: general
+    source_problem: PRB0000001
+    short_description: User is not receiving email
+    description: User has been unable to receive email for the past 15 minutes
+    priority: low
+
+- name: Change state of the problem task
+  servicenow.itsm.problem_task:
+    instance:
+      host: https://instance_id.service-now.com
+      username: user
+      password: pass
+
+    number: PTASK0010005
+    state: assess
+    assigned_to: fred.luddy
+
+- name: Close problem task
+  servicenow.itsm.problem_task:
+    instance:
+      host: https://instance_id.service-now.com
+      username: user
+      password: pass
+
+    state: closed
+    number: PTASK0010005
+    close_code:
+    close_notes: Closed
+
+- name: Delete problem task
+  servicenow.itsm.problem_task:
+    instance:
+      host: https://instance_id.service-now.com
+      username: user
+      password: pass
+
+    state: absent
+    number: PTASK0010005
+"""
+
+RETURN = r"""
+record:
+  description:
+    - A list of problem records.
+  returned: success
+  type: dict
+  sample:
+      "active": "true"
+      "activity_due": ""
+      "additional_assignee_list": ""
+      "approval": "not requested"
+      "tranquilitybusiness_service": ""
+      "calendar_duration": ""
+      "cause_code": ""
+      "cause_notes": ""
+      "close_code": ""
+      "close_notes": ""
+      "closed_at": ""
+      "closed_by": ""
+      "cmdb_ci": "26da329f0a0a0bb400f69d8159bc753d"
+      "comments": ""
+      "comments_and_work_notes": ""
+      "company": ""
+      "contact_type": ""
+      "contract": ""
+      "correlation_display": ""
+      "correlation_id": ""
+      "delivery_plan": ""
+      "delivery_task": ""
+      "description": ""
+      "due_date": ""
+      "escalation": "0"
+      "expected_start": ""
+      "fix_notes": ""
+      "follow_up": ""
+      "group_list": ""
+      "impact": "low"
+      "knowledge": "false"
+      "location": ""
+      "made_sla": "true"
+      "number": "PTASK0010005"
+      "opened_at": "2020-12-17 10:21:49"
+      "opened_by": "d3dbbf173b331300ad3cc9bb34efc466"
+      "order": ""
+      "other_reason": ""
+      "parent": ""
+      "priority": "2"
+      "problem": "d7296d02c0a801670085e737da016e70"
+      "problem_task_type": "rca"
+      "reassignment_count": "0"
+      "reopen_count": "1"
+      "reopened_at": "2020-12-17 10:23:10"
+      "reopened_by": "6816f79cc0a8016401c5a33be04be441"
+      "route_reason": ""
+      "service_offering": ""
+      "short_description": "SAP outage, please investigate the cause"
+      "sla_due": ""
+      "started_at": "2020-12-17 10:23:14"
+      "started_by": "6816f79cc0a8016401c5a33be04be441"
+      "state": "154"
+      "sys_class_name": "problem_task"
+      "sys_created_by": "admin"
+      "sys_created_on": "2020-12-17 10:22:25"
+      "sys_domain": "global"
+      "sys_domain_path": "/"
+      "sys_id": "5f6bec57531063004247ddeeff7b1216"
+      "sys_mod_count": "5"
+      "sys_tags": ""
+      "sys_updated_by": "admin"
+      "sys_updated_on": "2020-12-17 10:27:14"
+      "task_effective_number": "PTASK0010005"
+      "time_worked": ""
+      "universal_request": ""
+      "upon_approval": "proceed"
+      "upon_reject": "cancel"
+      "urgency": "low"
+      "user_input": ""
+      "vendor": ""
+      "watch_list": ""
+      "work_end": ""
+      "work_notes": ""
+      "work_notes_list": ""
+      "work_start": ""
+      "workaround": ""
+"""
+
+from datetime import datetime
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ..module_utils import arguments, client, errors, table, utils
+from ..module_utils.utils import get_mapper
+from ..module_utils.problem_task import PAYLOAD_FIELDS_MAPPING
+
+DIRECT_PAYLOAD_FIELDS = (
+    "state",
+    "type",
+    "configuration_item",
+    "due_date",
+    "source_problem",
+    "priority",
+    "assignment_group",
+    "assigned_to",
+    "short_description",
+    "description",
+    "close_notes",
+)
+
+
+def ensure_absent(module, table_client):
+    mapper = get_mapper(module, "problem_task_mapping", PAYLOAD_FIELDS_MAPPING)
+    query = utils.filter_dict(module.params, "sys_id", "number")
+    problem_task = table_client.get_record("problem_task", query)
+
+    if problem_task:
+        table_client.delete_record("problem_task", problem_task, module.check_mode)
+        return True, None, dict(before=mapper.to_ansible(problem_task), after=None)
+
+    return False, None, dict(before=None, after=None)
+
+
+def build_payload(module, table_client):
+    payload = (module.params["other"] or {}).copy()
+    payload.update(utils.filter_dict(module.params, *DIRECT_PAYLOAD_FIELDS))
+
+    if module.params["configuration_item"]:
+        configuration_item = table.find_configuration_item(
+            table_client, module.params["configuration_item"]
+        )
+        payload["cmdb_ci"] = configuration_item["sys_id"]
+
+    if module.params["source_problem"]:
+        problem = table.find_problem(table_client, module.params["source_problem"])
+        payload["problem"] = problem["sys_id"]
+
+    if module.params["assignment_group"]:
+        assignment_group = table.find_assignment_group(
+            table_client, module.params["assignment_group"]
+        )
+        payload["assignment_group"] = assignment_group["sys_id"]
+
+    if module.params["assigned_to"]:
+        user = table.find_user(table_client, module.params["assigned_to"])
+        payload["assigned_to"] = user["sys_id"]
+
+    if module.params["state"] == "work_in_progress":
+        started_by = table.find_user(table_client, module.params["assigned_to"])
+        payload["started_by"] = started_by["sys_id"]
+        payload["started_at"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+    return payload
+
+
+def ensure_present(module, table_client):
+    mapper = get_mapper(module, "problem_task_mapping", PAYLOAD_FIELDS_MAPPING)
+    query = utils.filter_dict(module.params, "sys_id", "number")
+    payload = build_payload(module, table_client)
+
+    if not query:
+        # User did not specify existing problem, so we need to create a new one.
+        new = mapper.to_ansible(
+            table_client.create_record(
+                "problem_task", mapper.to_snow(payload), module.check_mode
+            )
+        )
+        return True, new, dict(before=None, after=new)
+
+    old = mapper.to_ansible(
+        table_client.get_record("problem_task", query, must_exist=True)
+    )
+    if utils.is_superset(old, payload):
+        # No change in parameters we are interested in - nothing to do.
+        return False, old, dict(before=old, after=old)
+
+    new = mapper.to_ansible(
+        table_client.update_record(
+            "problem_task",
+            mapper.to_snow(old),
+            mapper.to_snow(payload),
+            module.check_mode,
+        )
+    )
+
+    return True, new, dict(before=old, after=new)
+
+
+def run(module, table_client):
+    if module.params["state"] == "absent":
+        return ensure_absent(module, table_client)
+    return ensure_present(module, table_client)
+
+
+def main():
+    module_args = dict(
+        arguments.get_spec("instance", "sys_id", "number", "problem_task_mapping"),
+        state=dict(
+            type="str",
+            choices=[
+                "new",
+                "assess",
+                "work_in_progress",
+                "closed",
+                "absent",
+            ],
+        ),
+        type=dict(
+            choices=[
+                "root_cause_analysis",
+                "general",
+            ],
+            type="str",
+        ),
+        configuration_item=dict(
+            type="str",
+        ),
+        due_date=dict(
+            type="str",
+        ),
+        source_problem=dict(
+            type="str",
+        ),
+        priority=dict(
+            choices=[
+                "critical",
+                "high",
+                "moderate",
+                "low",
+                "planning",
+            ],
+            type="str",
+        ),
+        assignment_group=dict(
+            type="str",
+        ),
+        assigned_to=dict(
+            type="str",
+        ),
+        short_description=dict(
+            type="str",
+        ),
+        description=dict(
+            type="str",
+        ),
+        close_code=dict(
+            type="str",
+            choices=["completed", "canceled"],
+        ),
+        close_notes=dict(
+            type="str",
+        ),
+        other=dict(
+            type="dict",
+        ),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+        required_if=[
+            ("state", "absent", ("sys_id", "number"), True),
+            ("state", "new", ("short_description",)),
+            ("state", "assess", ("assigned_to",)),
+        ],
+    )
+
+    try:
+        snow_client = client.Client(**module.params["instance"])
+        table_client = table.TableClient(snow_client)
+        changed, record, diff = run(module, table_client)
+        module.exit_json(changed=changed, record=record, diff=diff)
+    except errors.ServiceNowError as e:
+        module.fail_json(msg=str(e))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/problem_task_info.py
+++ b/plugins/modules/problem_task_info.py
@@ -10,53 +10,52 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 DOCUMENTATION = r"""
-module: problem_info
+module: problem_task_info
 
 author:
   - Manca Bizjak (@mancabizjak)
   - Miha Dolinar (@mdolin)
   - Tadej Borovsak (@tadeboro)
-  - Matej Pevec (@mysteriouswolf)
-short_description: List ServiceNow problems
+short_description: List ServiceNow problem tasks
 description:
-  - Retrieve information about ServiceNow problems.
+  - Retrieve information about ServiceNow problem tasks.
   - For more information, refer to the ServiceNow problem management documentation at
     U(https://docs.servicenow.com/bundle/paris-it-service-management/page/product/problem-management/concept/c_ProblemManagement.html).
-version_added: 1.0.0
+version_added: 1.3.0
 extends_documentation_fragment:
   - servicenow.itsm.instance
   - servicenow.itsm.sys_id.info
   - servicenow.itsm.number.info
   - servicenow.itsm.query
 seealso:
-  - module: servicenow.itsm.problem
   - module: servicenow.itsm.problem_task
-  - module: servicenow.itsm.problem_task_info
+  - module: servicenow.itsm.problem
+  - module: servicenow.itsm.problem_info
 """
 
 EXAMPLES = r"""
-- name: Retrieve all problems
-  servicenow.itsm.problem_info:
+- name: Retrieve all problem tasks
+  servicenow.itsm.problem_task_info:
   register: result
 
-- name: Retrieve a specific problem by its sys_id
-  servicenow.itsm.problem_info:
+- name: Retrieve a specific problem task by its sys_id
+  servicenow.itsm.problem_task_info:
     sys_id: 471bfbc7a9fe198101e77a3e10e5d47f
   register: result
 
-- name: Retrieve problems by number
-  servicenow.itsm.problem_info:
-    number: PRB0007601
+- name: Retrieve problem tasks by number
+  servicenow.itsm.problem_task_info:
+    number: PTASK0007601
   register: result
 
-- name: Retrieve problems that do not contain SAP in its short description
-  servicenow.itsm.problem_info:
+- name: Retrieve problem tasks that do not contain SAP in its short description
+  servicenow.itsm.problem_task_info:
     query:
       - short_description: NOT LIKE SAP
   register: result
 
-- name: Retrieve new problems assigned to abel.tuter or bertie.luby
-  servicenow.itsm.problem_info:
+- name: Retrieve new problem tasks assigned to abel.tuter or bertie.luby
+  servicenow.itsm.problem_task_info:
     query:
       - state: = new
         assigned_to: = abel.tuter
@@ -77,123 +76,89 @@ records:
       "approval": "not requested"
       "approval_history": ""
       "approval_set": ""
-      "assigned_to": "73ab3f173b331300ad3cc9bb34efc4df"
+      "assigned_to": "7e3bbb173b331300ad3cc9bb34efc4a8"
       "assignment_group": ""
-      "attachments":
-      -  "average_image_color": ""
-         "chunk_size_bytes": "700000"
-         "compressed": "true"
-         "content_type": "text/plain"
-         "download_link": "https://www.example.com/api/now/attachment/31cdf4d50706301022f9ffa08c1ed07f/file"
-         "file_name": "sample_file1.txt"
-         "hash": "6f2b0dec698566114435a23f15dcac848a40e1fd3e0eda4afe24a663dda23f2e"
-         "image_height": ""
-         "image_width": ""
-         "size_bytes": "210"
-         "size_compressed": "206"
-         "state": "pending"
-         "sys_created_by": "admin"
-         "sys_created_on": "2021-08-17 11:19:49"
-         "sys_id": "31cdf4d50706301022f9ffa08c1ed07f"
-         "sys_mod_count": "0"
-         "sys_tags": ""
-         "sys_updated_by": "admin"
-         "sys_updated_on": "2021-08-17 11:19:49"
-         "table_name": "problem"
-         "table_sys_id": "6dcdb4d50706301022f9ffa08c1ed0fb"
       "business_duration": ""
       "business_service": ""
       "calendar_duration": ""
-      "category": "software"
+      "cause_code": ""
       "cause_notes": ""
+      "close_code": ""
       "close_notes": ""
       "closed_at": ""
       "closed_by": ""
-      "cmdb_ci": "27d32778c0a8000b00db970eeaa60f16"
+      "cmdb_ci": "26da329f0a0a0bb400f69d8159bc753d"
       "comments": ""
       "comments_and_work_notes": ""
       "company": ""
-      "confirmed_at": ""
-      "confirmed_by": ""
       "contact_type": ""
       "contract": ""
       "correlation_display": ""
       "correlation_id": ""
       "delivery_plan": ""
       "delivery_task": ""
-      "description": "Unable to send or receive emails."
+      "description": ""
       "due_date": ""
-      "duplicate_of": ""
       "escalation": "0"
       "expected_start": ""
-      "first_reported_by_task": ""
-      "fix_communicated_at": ""
-      "fix_communicated_by": ""
       "fix_notes": ""
       "follow_up": ""
       "group_list": ""
       "impact": "low"
       "knowledge": "false"
-      "known_error": "false"
       "location": ""
       "made_sla": "true"
-      "major_problem": "false"
-      "number": "PRB0007601"
-      "opened_at": "2018-08-30 08:08:39"
-      "opened_by": "6816f79cc0a8016401c5a33be04be441"
+      "number": "PTASK0010005"
+      "opened_at": "2020-12-17 10:21:49"
+      "opened_by": "d3dbbf173b331300ad3cc9bb34efc466"
       "order": ""
+      "other_reason": ""
       "parent": ""
-      "priority": "5"
-      "problem_state": "new"
+      "priority": "2"
+      "problem": "d7296d02c0a801670085e737da016e70"
+      "problem_task_type": "rca"
       "reassignment_count": "0"
-      "related_incidents": "0"
-      "reopen_count": "0"
-      "reopened_at": ""
-      "reopened_by": ""
-      "resolution_code": ""
-      "resolved_at": ""
-      "resolved_by": ""
-      "review_outcome": ""
-      "rfc": ""
+      "reopen_count": "1"
+      "reopened_at": "2020-12-17 10:23:10"
+      "reopened_by": "6816f79cc0a8016401c5a33be04be441"
       "route_reason": ""
       "service_offering": ""
-      "short_description": "Unable to send or receive emails."
+      "short_description": "SAP outage, please investigate the cause"
       "sla_due": ""
-      "state": "new"
-      "subcategory": "email"
-      "sys_class_name": "problem"
+      "started_at": "2020-12-17 10:23:14"
+      "started_by": "6816f79cc0a8016401c5a33be04be441"
+      "state": "154"
+      "sys_class_name": "problem_task"
       "sys_created_by": "admin"
-      "sys_created_on": "2018-08-30 08:09:05"
+      "sys_created_on": "2020-12-17 10:22:25"
       "sys_domain": "global"
       "sys_domain_path": "/"
-      "sys_id": "62304320731823002728660c4cf6a7e8"
-      "sys_mod_count": "1"
+      "sys_id": "5f6bec57531063004247ddeeff7b1216"
+      "sys_mod_count": "5"
       "sys_tags": ""
       "sys_updated_by": "admin"
-      "sys_updated_on": "2018-12-12 07:16:57"
-      "task_effective_number": "PRB0007601"
+      "sys_updated_on": "2020-12-17 10:27:14"
+      "task_effective_number": "PTASK0010005"
       "time_worked": ""
       "universal_request": ""
       "upon_approval": "proceed"
       "upon_reject": "cancel"
       "urgency": "low"
       "user_input": ""
+      "vendor": ""
       "watch_list": ""
       "work_end": ""
       "work_notes": ""
       "work_notes_list": ""
       "work_start": ""
       "workaround": ""
-      "workaround_applied": "false"
-      "workaround_communicated_at": ""
-      "workaround_communicated_by": ""
 """
 
 from ansible.module_utils.basic import AnsibleModule
 
-from ..module_utils import arguments, attachment, client, errors, query, table, utils
-from ..module_utils.problem import PAYLOAD_FIELDS_MAPPING
+from ..module_utils import arguments, client, errors, query, utils, table
 from ..module_utils.utils import get_mapper
+from ..module_utils.problem_task import PAYLOAD_FIELDS_MAPPING
 
 
 def remap_params(query, table_client):
@@ -230,8 +195,8 @@ def sysparms_query(module, table_client, mapper):
     return query.serialize_query(query.map_query_values(remap_query, mapper))
 
 
-def run(module, table_client, attachment_client):
-    mapper = get_mapper(module, "problem_mapping", PAYLOAD_FIELDS_MAPPING)
+def run(module, table_client):
+    mapper = get_mapper(module, "problem_task_mapping", PAYLOAD_FIELDS_MAPPING)
 
     if module.params["query"]:
         query = {"sysparm_query": sysparms_query(module, table_client, mapper)}
@@ -239,13 +204,8 @@ def run(module, table_client, attachment_client):
         query = utils.filter_dict(module.params, "sys_id", "number")
 
     return [
-        dict(
-            mapper.to_ansible(record),
-            attachments=attachment_client.list_records(
-                dict(table_name="problem", table_sys_id=record["sys_id"]),
-            ),
-        )
-        for record in table_client.list_records("problem", query)
+        mapper.to_ansible(record)
+        for record in table_client.list_records("problem_task", query)
     ]
 
 
@@ -261,8 +221,7 @@ def main():
     try:
         snow_client = client.Client(**module.params["instance"])
         table_client = table.TableClient(snow_client)
-        attachment_client = attachment.AttachmentClient(snow_client)
-        records = run(module, table_client, attachment_client)
+        records = run(module, table_client)
         module.exit_json(changed=False, records=records)
     except errors.ServiceNowError as e:
         module.fail_json(msg=str(e))

--- a/tests/integration/targets/problem_task/tasks/main.yml
+++ b/tests/integration/targets/problem_task/tasks/main.yml
@@ -1,0 +1,133 @@
+---
+- environment:
+    SN_HOST: "{{ sn_host }}"
+    SN_USERNAME: "{{ sn_username }}"
+    SN_PASSWORD: "{{ sn_password }}"
+
+  block:
+    - name: Create a problem
+      servicenow.itsm.problem:
+        short_description: my-problem
+        state: new
+      register: problem
+
+    - ansible.builtin.assert:
+        that:
+          - problem is changed
+          - problem.record.state == "new"
+          - problem.record.short_description == "my-problem"
+
+
+    - name: Retrieve problem task records
+      servicenow.itsm.problem_task_info:
+      register: initial
+
+
+    - name: Create a problem task (check mode)
+      servicenow.itsm.problem_task: &problem-task-create
+        state: new
+        type: general
+        source_problem: "{{ problem.record.number }}"
+        short_description: my-problem-task
+        priority: low
+      check_mode: true
+      register: problem_task
+
+    - ansible.builtin.assert: &problem-task-create-assertions
+        that:
+          - problem_task is changed
+          - problem_task.record.state == "new"
+          - problem_task.record.short_description == "my-problem-task"
+
+
+    - name: Create a problem task
+      servicenow.itsm.problem_task: *problem-task-create
+      register: problem_task
+  
+    - ansible.builtin.assert: *problem-task-create-assertions
+
+
+    - name: Verify that a new record was created
+      servicenow.itsm.problem_task_info:
+        sys_id: "{{ problem_task.record.sys_id }}"
+      register: result
+  
+    - ansible.builtin.assert:
+        that:
+          - result.records.0.short_description == "my-problem-task"
+
+
+    - name: Change state of a problem task (check mode)
+      servicenow.itsm.problem_task: &problem-task-change
+        state: assess
+        type: general
+        sys_id: "{{ problem_task.record.sys_id }}"
+        assigned_to: problem.admin
+        source_problem: "{{ problem.record.number }}"
+        short_description: my-problem-task
+        priority: low
+      check_mode: true
+      register: problem_task
+
+    - ansible.builtin.assert: &problem-task-change-assertions
+        that:
+          - problem_task is changed
+          - problem_task.record.state == "assess"
+          - problem_task.record.short_description == "my-problem-task"
+
+
+    - name: Change state of a problem task
+      servicenow.itsm.problem_task: *problem-task-change
+      register: problem_task
+  
+    - ansible.builtin.assert: *problem-task-change-assertions
+
+
+    - name: Verify that state was changed
+      servicenow.itsm.problem_task_info:
+        sys_id: "{{ problem_task.record.sys_id }}"
+      register: result
+  
+    - ansible.builtin.assert:
+        that:
+          - result.records.0.state == "assess"
+          - result.records.0.short_description == "my-problem-task"
+
+
+    - name: Delete a problem task (check mode)
+      servicenow.itsm.problem_task: &problem-task-delete
+        state: absent
+        sys_id: "{{ problem_task.record.sys_id }}"
+      check_mode: true
+      register: result
+
+    - ansible.builtin.assert: &problem-task-delete-assertions
+        that:
+          - result is changed
+
+
+    - name: Delete a problem task
+      servicenow.itsm.problem_task: *problem-task-delete
+      register: result
+  
+    - ansible.builtin.assert: *problem-task-delete-assertions
+
+
+    - name: Verify that a record was deleted
+      servicenow.itsm.problem_task_info:
+      register: result
+  
+    - ansible.builtin.assert:
+        that:
+          - result.records | length == initial.records | length
+
+
+    - name: Delete a problem
+      servicenow.itsm.problem:
+        state: absent
+        sys_id: "{{ problem.record.sys_id }}"
+      register: problem
+
+    - ansible.builtin.assert:
+        that:
+          - problem is changed

--- a/tests/unit/plugins/modules/test_problem_task.py
+++ b/tests/unit/plugins/modules/test_problem_task.py
@@ -1,0 +1,298 @@
+# -*- coding: utf-8 -*-
+# # Copyright: (c) 2021, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+import pytest
+
+
+from ansible_collections.servicenow.itsm.plugins.modules import problem_task
+
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires python2.7 or higher"
+)
+
+
+class TestEnsureAbsent:
+    def test_delete_problem_task(self, create_module, table_client):
+        module = create_module(
+            params=dict(
+                instance=dict(host="my.host.name", username="user", password="pass"),
+                state="absent",
+                number="PTASK0010001",
+                sys_id=None,
+            )
+        )
+        table_client.get_record.return_value = dict(state="157", number="PTASK0010001")
+
+        result = problem_task.ensure_absent(module, table_client)
+
+        table_client.delete_record.assert_called_once()
+        assert result == (
+            True,
+            None,
+            dict(before=dict(state="closed", number="PTASK0010001"), after=None),
+        )
+
+    def test_delete_problem_task_not_present(self, create_module, table_client):
+        module = create_module(
+            params=dict(
+                instance=dict(host="my.host.name", username="user", password="pass"),
+                state="absent",
+                number=None,
+                sys_id="1234",
+            ),
+        )
+        table_client.get_record.return_value = None
+
+        result = problem_task.ensure_absent(module, table_client)
+
+        table_client.delete_record.assert_not_called()
+        assert result == (False, None, dict(before=None, after=None))
+
+
+class TestBuildPayload:
+    def test_build_payload(self, create_module, table_client):
+        module = create_module(
+            params=dict(
+                instance=dict(host="my.host.name", username="user", password="pass"),
+                state="new",
+                type="general",
+                configuration_item="P1000001",
+                due_date="2020-12-17 13:37:00",
+                source_problem="PRB0007601",
+                priority="low",
+                assignment_group="network",
+                assigned_to="admin",
+                short_description="sd",
+                description="Test problem_task",
+                close_notes="closed",
+                other=None,
+            ),
+        )
+        table_client.get_record.return_value = {
+            "sys_id": "681ccaf9c0a8016400b98a06818d57c7"
+        }
+
+        result = problem_task.build_payload(module, table_client)
+
+        assert result["state"] == "new"
+        assert result["type"] == "general"
+        assert result["configuration_item"] == "P1000001"
+        assert result["due_date"] == "2020-12-17 13:37:00"
+        assert result["problem"] == "681ccaf9c0a8016400b98a06818d57c7"
+        assert result["priority"] == "low"
+        assert result["assignment_group"] == "681ccaf9c0a8016400b98a06818d57c7"
+        assert result["assigned_to"] == "681ccaf9c0a8016400b98a06818d57c7"
+        assert result["short_description"] == "sd"
+        assert result["description"] == "Test problem_task"
+        assert result["close_notes"] == "closed"
+
+    def test_build_payload_with_other_option(self, create_module, table_client):
+        module = create_module(
+            params=dict(
+                instance=dict(host="my.host.name", username="user", password="pass"),
+                state="new",
+                type="general",
+                configuration_item=None,
+                due_date=None,
+                source_problem="PRB0007601",
+                priority=None,
+                assignment_group=None,
+                assigned_to="admin",
+                short_description="sd",
+                description=None,
+                close_notes=None,
+                other=dict(notify="1"),
+            ),
+        )
+        table_client.get_record.return_value = {
+            "sys_id": "681ccaf9c0a8016400b98a06818d57c7"
+        }
+
+        result = problem_task.build_payload(module, table_client)
+
+        assert result["state"] == "new"
+        assert result["type"] == "general"
+        assert result["problem"] == "681ccaf9c0a8016400b98a06818d57c7"
+        assert result["assigned_to"] == "681ccaf9c0a8016400b98a06818d57c7"
+        assert result["short_description"] == "sd"
+        assert result["notify"] == "1"
+
+
+class TestEnsurePresent:
+    def test_ensure_present_create_new(self, create_module, table_client):
+        module = create_module(
+            params=dict(
+                instance=dict(host="my.host.name", username="user", password="pass"),
+                state="new",
+                type="general",
+                number=None,
+                sys_id=None,
+                configuration_item=None,
+                due_date=None,
+                source_problem="PRB0007601",
+                priority="low",
+                assignment_group=None,
+                assigned_to="admin",
+                short_description="sd",
+                description=None,
+                close_notes=None,
+                other=None,
+            ),
+        )
+        table_client.get_record.return_value = {
+            "sys_id": "681ccaf9c0a8016400b98a06818d57c7"
+        }
+        table_client.create_record.return_value = dict(
+            state="151",
+            type="general",
+            number="PTASK0010001",
+            source_problem="PRB0007601",
+            priority="4",
+            assigned_to="admin",
+            short_description="sd",
+        )
+
+        result = problem_task.ensure_present(module, table_client)
+
+        table_client.create_record.assert_called_once()
+        assert result == (
+            True,
+            dict(
+                state="new",
+                type="general",
+                number="PTASK0010001",
+                source_problem="PRB0007601",
+                priority="low",
+                assigned_to="admin",
+                short_description="sd",
+            ),
+            dict(
+                before=None,
+                after=dict(
+                    state="new",
+                    type="general",
+                    number="PTASK0010001",
+                    source_problem="PRB0007601",
+                    priority="low",
+                    assigned_to="admin",
+                    short_description="sd",
+                ),
+            ),
+        )
+
+    def test_ensure_present_nothing_to_do(self, create_module, table_client):
+        module = create_module(
+            params=dict(
+                instance=dict(host="my.host.name", username="user", password="pass"),
+                number="PTASK0010001",
+                state="new",
+                type="general",
+                sys_id=None,
+                configuration_item=None,
+                due_date=None,
+                source_problem=None,
+                priority="low",
+                assignment_group=None,
+                assigned_to=None,
+                short_description="sd",
+                description=None,
+                close_notes=None,
+                other=None,
+            ),
+        )
+        table_client.get_record.return_value = dict(
+            state="151",
+            number="PTASK0010001",
+            short_description="sd",
+            priority="4",
+            type="general",
+        )
+
+        result = problem_task.ensure_present(module, table_client)
+
+        table_client.get_record.assert_called_once()
+        assert result == (
+            False,
+            dict(
+                state="new",
+                number="PTASK0010001",
+                short_description="sd",
+                priority="low",
+                type="general",
+            ),
+            dict(
+                before=dict(
+                    state="new",
+                    number="PTASK0010001",
+                    short_description="sd",
+                    priority="low",
+                    type="general",
+                ),
+                after=dict(
+                    state="new",
+                    number="PTASK0010001",
+                    short_description="sd",
+                    priority="low",
+                    type="general",
+                ),
+            ),
+        )
+
+    def test_ensure_present_update(self, mocker, create_module, table_client):
+        module = create_module(
+            params=dict(
+                instance=dict(host="my.host.name", username="user", password="pass"),
+                state="assess",
+                type="general",
+                number="PTASK0010001",
+                sys_id=None,
+                configuration_item=None,
+                due_date=None,
+                source_problem=None,
+                priority="low",
+                assignment_group=None,
+                assigned_to=None,
+                short_description="sd",
+                description=None,
+                close_notes=None,
+                other=None,
+            ),
+        )
+        payload_mocker = mocker.patch.object(problem_task, "build_payload")
+        payload_mocker.return_value = dict(
+            state="assess", number="PTASK0010001", short_description="sd"
+        )
+        table_client.get_record.return_value = dict(
+            state="151", number="PTASK0010001", short_description="sd"
+        )
+        table_client.update_record.return_value = dict(
+            state="152", number="PTASK0010001", short_description="sd"
+        )
+
+        result = problem_task.ensure_present(module, table_client)
+
+        table_client.update_record.assert_called_once()
+        assert result == (
+            True,
+            dict(
+                state="assess",
+                number="PTASK0010001",
+                short_description="sd",
+            ),
+            dict(
+                before=dict(state="new", number="PTASK0010001", short_description="sd"),
+                after=dict(
+                    state="assess",
+                    number="PTASK0010001",
+                    short_description="sd",
+                ),
+            ),
+        )

--- a/tests/unit/plugins/modules/test_problem_task_info.py
+++ b/tests/unit/plugins/modules/test_problem_task_info.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+# # Copyright: (c) 2021, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+
+import pytest
+
+from ansible_collections.servicenow.itsm.plugins.modules import problem_task_info
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires python2.7 or higher"
+)
+
+
+class TestRemapCaller:
+    def test_remap_params(self, table_client):
+        query = [
+            {"assigned_to": ("=", "some.user")},
+            {"duplicate_of": ("=", "PRB0000010")},
+            {"impact": ("=", "low")},
+        ]
+        table_client.get_record.side_effect = [
+            {"sys_id": "681ccaf9c0a8016400b98a06818d57c7"},
+            {"sys_id": "6816f79cc0a8016401c5a33be04be441"},
+        ]
+
+        result = problem_task_info.remap_params(query, table_client)
+
+        assert result == [
+            {"assigned_to": ("=", "681ccaf9c0a8016400b98a06818d57c7")},
+            {"duplicate_of": ("=", "6816f79cc0a8016401c5a33be04be441")},
+            {"impact": ("=", "low")},
+        ]
+
+
+class TestMain:
+    def test_minimal_set_of_params(self, run_main):
+        params = dict(
+            instance=dict(
+                host="https://my.host.name", username="user", password="pass"
+            ),
+        )
+        success, result = run_main(problem_task_info, params)
+
+        assert success is True
+
+    def test_all_params(self, run_main):
+        params = dict(
+            instance=dict(
+                host="https://my.host.name", username="user", password="pass"
+            ),
+            sys_id="id",
+            number="n",
+        )
+        success, result = run_main(problem_task_info, params)
+
+        assert success is True
+
+    def test_fail(self, run_main):
+        success, result = run_main(problem_task_info)
+
+        assert success is False
+        assert "instance" in result["msg"]
+
+
+class TestRun:
+    def test_run(self, create_module, table_client):
+        module = create_module(
+            params=dict(
+                instance=dict(
+                    host="https://my.host.name", username="user", password="pass"
+                ),
+                sys_id=None,
+                number="n",
+                query=None,
+            )
+        )
+        table_client.list_records.return_value = [dict(p=1), dict(q=2), dict(r=3)]
+
+        problems = problem_task_info.run(module, table_client)
+
+        table_client.list_records.assert_called_once_with(
+            "problem_task", dict(number="n")
+        )
+        assert problems == [dict(p=1), dict(q=2), dict(r=3)]


### PR DESCRIPTION
In the current implementation, basic functionalities creating and
deleting problem tasks are covered.  We also present often used fields
that are important for problem tasks to be created or in any other way
manipulated. For all other less used or optional parameters, they can
be strung together under other field in the problem tasks as they are.

There is an issue with the state transition from Assess to Work In
Progress and to Closed.  When manually transitioning to Work In
Progress state fields started_at and stared_by are field in but the
module can not change to that state even though these two parameters
are filled.

This is #133 with fixed tests, and added support for user mappings.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
