### PR TITLE
Fix validate-modules errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Ansible Collection for ServiceNow IT Service Management ([ITSM](https://www.
 
 This collection has been tested against following Ansible versions: **>=2.9.10**.
 
-For collections that support Ansible 2.9, please ensure you update your `network_os` to use the
+For collections that support Ansible 2.9, please ensure you update your `network_os` to use the 
 fully qualified collection name (for example, `cisco.ios.ios`). 
 Plugins and modules within a collection may be tested with only specific Ansible versions.
 A collection may contain metadata that identifies these versions.

--- a/changelogs/fragments/validate.yml
+++ b/changelogs/fragments/validate.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- now - fix validate-modules errors in now inventory plugins.

--- a/docs/servicenow.itsm.now_inventory.rst
+++ b/docs/servicenow.itsm.now_inventory.rst
@@ -61,6 +61,7 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=string</span>
                     </div>
                 </td>
                 <td>
@@ -161,6 +162,7 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=string</span>
                     </div>
                 </td>
                 <td>
@@ -183,6 +185,7 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=string</span>
                     </div>
                 </td>
                 <td>
@@ -603,6 +606,7 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=string</span>
                     </div>
                 </td>
                 <td>
@@ -626,6 +630,7 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=string</span>
                     </div>
                 </td>
                 <td>

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -7,31 +7,9 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import os
-
-from ansible.errors import AnsibleParserError
-from ansible.inventory.group import to_safe_group_name as orig_safe
-from ansible.plugins.inventory import (
-    BaseInventoryPlugin,
-    Constructable,
-    to_safe_group_name,
-)
-
-from ..module_utils.client import Client
-from ..module_utils.errors import ServiceNowError
-from ..module_utils.query import parse_query, serialize_query
-from ..module_utils.table import TableClient
-from ..module_utils.relations import (
-    REL_FIELDS,
-    REL_QUERY,
-    REL_TABLE,
-    enhance_records_with_rel_groups,
-)
-
 
 DOCUMENTATION = r"""
 name: now
-plugin_type: inventory
 author:
   - Manca Bizjak (@mancabizjak)
   - Miha Dolinar (@mdolin)
@@ -111,6 +89,7 @@ options:
     description:
       - List of I(table) columns to be included as hostvars.
     type: list
+    elements: str
     default: [name, host_name, fqdn, ip_address]
   enhanced:
     description:
@@ -166,6 +145,7 @@ options:
                   - Mutually exclusive with I(excludes).
                 type: list
                 default: None
+                elements: str
               excludes:
                 description:
                   - Add a host to the group if <column> matches any value
@@ -173,6 +153,7 @@ options:
                   - For reference fields, you need to provide C(sys_id).
                   - Mutually exclusive with I(includes).
                 type: list
+                elements: str
                 default: None
   group_by:
     description:
@@ -201,6 +182,7 @@ options:
               - Mutually exclusive with I(excludes).
             type: list
             default: None
+            elements: str
           excludes:
             description:
               - Create Ansible inventory groups only for records with <column>
@@ -208,6 +190,7 @@ options:
               - For reference fields, you need to provide C(sys_id).
               - Mutually exclusive with I(includes).
             type: list
+            elements: str
             default: None
 """
 
@@ -386,6 +369,27 @@ named_groups:
 #  |  |--lnux101
 #  |--@ungrouped:
 """
+
+import os
+
+from ansible.errors import AnsibleParserError
+from ansible.inventory.group import to_safe_group_name as orig_safe
+from ansible.plugins.inventory import (
+    BaseInventoryPlugin,
+    Constructable,
+    to_safe_group_name,
+)
+
+from ..module_utils.client import Client
+from ..module_utils.errors import ServiceNowError
+from ..module_utils.query import parse_query, serialize_query
+from ..module_utils.table import TableClient
+from ..module_utils.relations import (
+    REL_FIELDS,
+    REL_QUERY,
+    REL_TABLE,
+    enhance_records_with_rel_groups,
+)
 
 
 def _includes_query(column, includes):


### PR DESCRIPTION
##### SUMMARY

* Developer can now validate parameters for plugins using
  ansible-test sanity --test validate-modules
  Fix errors provided by this check.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
README.md
changelogs/fragments/validate.yml
docs/servicenow.itsm.now_inventory.rst
plugins/inventory/now.py
