### PR TITLE
now.py inventory plugin updated to support refresh_token and added in grant_type

### DIFF
--- a/changelogs/fragments/inventory_grant.yaml
+++ b/changelogs/fragments/inventory_grant.yaml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-- now.py inventory plugin updated to support refresh_token and added in grant_type 
+- now - inventory plugin updated to support ``refresh_token`` and ``grant_type`` (https://github.com/ansible-collections/servicenow.itsm/issues/168).

--- a/changelogs/fragments/inventory_grant.yaml
+++ b/changelogs/fragments/inventory_grant.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- now.py inventory plugin updated to support refresh_token and added in grant_type 

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -94,6 +94,7 @@ options:
         env:
           - name: SN_REFRESH_TOKEN
         type: str
+        version_added: 1.4.0
       timeout:
         description:
           - Timeout in seconds for the connection with the ServiceNow instance.

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -75,6 +75,24 @@ options:
         env:
           - name: SN_CLIENT_SECRET
         type: str
+      grant_type:
+        description:
+          - Grant type used for OAuth authentication.
+          - If not set, the value of the C(SN_GRANT_TYPE) environment variable will be used.
+        choices: [ 'password', 'refresh_token' ]
+        default: password
+        env:
+          - name: SN_GRANT_TYPE
+        type: str
+      refresh_token:
+        description:
+          - Refresh token used for OAuth authentication.
+          - If not set, the value of the C(SN_REFRESH_TOKEN) environment
+            variable will be used.
+          - Required when I(grant_type=refresh_token).
+        env:
+          - name: SN_REFRESH_TOKEN
+        type: str
       timeout:
         description:
           - Timeout in seconds for the connection with the ServiceNow instance.
@@ -616,6 +634,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             password=os.getenv("SN_PASSWORD"),
             client_id=os.getenv("SN_CLIENT_ID"),
             client_secret=os.getenv("SN_SECRET_ID"),
+            refresh_token=os.getenv("SN_REFRESH_TOKEN"),
+            grant_type=os.getenv("SN_GRANT_TYPE"),
             timeout=os.getenv("SN_TIMEOUT"),
         )
 

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -84,6 +84,7 @@ options:
         env:
           - name: SN_GRANT_TYPE
         type: str
+        version_added: 1.4.0
       refresh_token:
         description:
           - Refresh token used for OAuth authentication.


### PR DESCRIPTION
now.py inventory plugin updated to support refresh_token and added in grant_type

##### SUMMARY
Adds in support for refresh_token to now.py  inventory plugin

Fixes #168 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
now.py inventory plugin

##### ADDITIONAL INFORMATION

Before Change:
`ansible-inventory -i ~/git/tower-snow/inv/service_now.yml --list`

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
ansible-inventory 2.9.27
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.6/site-packages/ansible
  executable location = /bin/ansible-inventory
  python version = 3.6.8 (default, Sep  9 2021, 07:49:02) [GCC 8.5.0 20210514 (Red Hat 8.5.0-3)]
Using /etc/ansible/ansible.cfg as config file
host_list declined parsing /root/git/tower-snow/inv/token_service_now.yml as it did not pass its verify_file() method
script declined parsing /root/git/tower-snow/inv/token_service_now.yml as it did not pass its verify_file() method
[WARNING]: 'ansible_host_source' option is deprecated since version 1.2.0 and will be removed in 2.0.0.
toml declined parsing /root/git/tower-snow/inv/token_service_now.yml as it did not pass its verify_file() method
[WARNING]:  * Failed to parse /root/git/tower-snow/inv/token_service_now.yml with auto plugin: Failed to authenticate with the instance:
401 Unauthorized
  File "/usr/lib/python3.6/site-packages/ansible/inventory/manager.py", line 280, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/usr/lib/python3.6/site-packages/ansible/plugins/inventory/auto.py", line 58, in parse
    plugin.parse(inventory, loader, path, cache=cache)
  File "/root/.ansible/collections/ansible_collections/servicenow/itsm/plugins/inventory/now.py", line 690, in parse
    records = fetch_records(table_client, table, query)
  File "/root/.ansible/collections/ansible_collections/servicenow/itsm/plugins/inventory/now.py", line 443, in fetch_records
    return table_client.list_records(table, snow_query)
  File "/root/.ansible/collections/ansible_collections/servicenow/itsm/plugins/module_utils/table.py", line 39, in list_records
    _path(table), query=dict(base_query, sysparm_offset=offset)
  File "/root/.ansible/collections/ansible_collections/servicenow/itsm/plugins/module_utils/client.py", line 168, in get
    resp = self.request("GET", path, query=query)
  File "/root/.ansible/collections/ansible_collections/servicenow/itsm/plugins/module_utils/client.py", line 159, in request
    headers = dict(headers or DEFAULT_HEADERS, **self.auth_header)
  File "/root/.ansible/collections/ansible_collections/servicenow/itsm/plugins/module_utils/client.py", line 79, in auth_header
    self._auth_header = self._login()
  File "/root/.ansible/collections/ansible_collections/servicenow/itsm/plugins/module_utils/client.py", line 84, in _login
    return self._login_oauth()
  File "/root/.ansible/collections/ansible_collections/servicenow/itsm/plugins/module_utils/client.py", line 115, in _login_oauth
    headers=dict(Accept="application/json"),
  File "/root/.ansible/collections/ansible_collections/servicenow/itsm/plugins/module_utils/client.py", line 133, in _request
    e.code, e.reason
[WARNING]:  * Failed to parse /root/git/tower-snow/inv/token_service_now.yml with yaml plugin: Plugin configuration YAML file, not YAML
inventory
File "/usr/lib/python3.6/site-packages/ansible/inventory/manager.py", line 280, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/usr/lib/python3.6/site-packages/ansible/plugins/inventory/yaml.py", line 112, in parse
    raise AnsibleParserError('Plugin configuration YAML file, not YAML inventory')
[WARNING]:  * Failed to parse /root/git/tower-snow/inv/token_service_now.yml with ini plugin: Invalid host pattern 'plugin:' supplied,
ending in ':' is not allowed, this character is reserved to provide a port.
  File "/usr/lib/python3.6/site-packages/ansible/inventory/manager.py", line 280, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/usr/lib/python3.6/site-packages/ansible/plugins/inventory/ini.py", line 138, in parse
    raise AnsibleParserError(e)
[WARNING]: Unable to parse /root/git/tower-snow/inv/token_service_now.yml as an inventory source
[WARNING]: No inventory was parsed, only implicit localhost is available
{
    "_meta": {
        "hostvars": {}
    },
    "all": {
        "children": [
            "ungrouped"
        ]
    }
}
```

After Change:
`ansible-inventory -i ~/git/tower-snow/inv/service_now.yml --list`

```
[WARNING]: 'ansible_host_source' option is deprecated since version 1.2.0 and will be removed in 2.0.0.
[WARNING]: The ansible_host variable for host lnux100 is empty.
[WARNING]: The ansible_host variable for host lnux101 is empty.
{
    "_meta": {
        "hostvars": {
            "lnux100": {
                "fqdn": "",
                "host_name": "",
                "ip_address": "",
                "name": "lnux100"
            },
            "lnux101": {
                "fqdn": "",
                "host_name": "",
                "ip_address": "",
                "name": "lnux101"
            }
        }
    },
    "all": {
        "children": [
            "ungrouped"
        ]
    },
    "ungrouped": {
        "hosts": [
            "lnux100",
            "lnux101"
        ]
    }
}
```
