### PR TITLE
Propose an update to now Inventory plugin docs to give examples of how AND OR queries operate

### DIFF
--- a/changelogs/fragments/now_inv_docs.yaml
+++ b/changelogs/fragments/now_inv_docs.yaml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-- now - Updated documents to make clear how AND OR querys operate.
+- now - Updated documents to make clear how AND OR queries operate.

--- a/changelogs/fragments/now_inv_docs.yaml
+++ b/changelogs/fragments/now_inv_docs.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- now - Updated documents to make clear how AND OR querys operate.

--- a/docs/servicenow.itsm.now_inventory.rst
+++ b/docs/servicenow.itsm.now_inventory.rst
@@ -888,6 +888,31 @@ Examples
     # |  |  |--{cpu_type = Intel}
     # |  |  |--{name = INSIGHT-NY-03}
 
+    # Example of a query which returns hosts where ip_address is not like 192.29.32 AND the name starts with lnux.
+    # AND Query Example
+    plugin: servicenow.itsm.now
+    query:
+      - ip_address: NOT LIKE 192.29.32
+        name: STARTSWITH lnux
+
+    # `ansible-inventory -i inventory.now.yaml --graph --vars` output:
+    # @all:
+    #   |--@ungrouped:
+    #   |  |--lnux101
+
+    # Example of a query which returns hosts where ip_address is not like 192.29.32 OR the name starts with lnux.
+    # OR Query Example
+    plugin: servicenow.itsm.now
+    query:
+      - ip_address: NOT LIKE 192.29.32
+      - name: STARTSWITH lnux
+
+    # `ansible-inventory -i inventory.now.yaml --graph --vars` output:
+    # @all:
+    #   |--@ungrouped:
+    #   |  |--lnux100
+    #   |  |--lnux101
+
     # NOTE: All examples from here on are deprecated and should not be used when writing new
     # inventory sources.
 


### PR DESCRIPTION
##### SUMMARY
Propose an update to now Inventory plugin docs to give examples of how AND OR queries operate.
Update adds 2 examples to the docs one for and AND query and one for an OR query.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
now.py inventory plugin

##### ADDITIONAL INFORMATION
This was something I required to do some trial and error for to get working and thought it would be helpful to share in the official documents.

Before this change there was no examples of using an AND or an OR query.  Added to give clarity to other users in the future.
```
    # Example of a query which returns hosts where ip_address is not like 192.29.32 AND the name starts with lnux.
    # AND Query Example
    plugin: servicenow.itsm.now
    query:
      - ip_address: NOT LIKE 192.29.32
        name: STARTSWITH lnux

    # `ansible-inventory -i inventory.now.yaml --graph --vars` output:
    # @all:
    #   |--@ungrouped:
    #   |  |--lnux101

    # Example of a query which returns hosts where ip_address is not like 192.29.32 OR the name starts with lnux.
    # OR Query Example
    plugin: servicenow.itsm.now
    query:
      - ip_address: NOT LIKE 192.29.32
      - name: STARTSWITH lnux

    # `ansible-inventory -i inventory.now.yaml --graph --vars` output:
    # @all:
    #   |--@ungrouped:
    #   |  |--lnux100
    #   |  |--lnux101
```
