### PR TITLE
Fix default value of `exclude_reference_link` in table.py

### DIFF
--- a/plugins/module_utils/table.py
+++ b/plugins/module_utils/table.py
@@ -15,8 +15,9 @@ def _path(table, *subpaths):
 
 
 def _query(original=None):
-    # Flatten the response (skip embedded links to resources)
-    return dict(original or {}, sysparm_exclude_reference_link="true")
+    original = original or dict()
+    original["sysparm_exclude_reference_link"] = original.setdefault("sysparm_exclude_reference_link", "true")
+    return original
 
 
 class TableClient:

--- a/plugins/module_utils/table.py
+++ b/plugins/module_utils/table.py
@@ -16,7 +16,7 @@ def _path(table, *subpaths):
 
 def _query(original=None):
     original = original or dict()
-    original["sysparm_exclude_reference_link"] = original.setdefault("sysparm_exclude_reference_link", "true")
+    original.setdefault("sysparm_exclude_reference_link", "true")
     return original
 
 


### PR DESCRIPTION
##### SUMMARY
This PR resolves https://github.com/ansible-collections/servicenow.itsm/issues/181, which as a problem I encountered while resolving user story https://github.com/ansible-collections/servicenow.itsm/issues/164.

While developing ServiceNow REST API "client" module, which essentially codifies [the ServiceNow REST API Explorer](https://docs.servicenow.com/bundle/sandiego-application-development/page/integrate/inbound-rest/concept/use-REST-API-Explorer.html#t_ExploreATable) in an Ansible-native way, I tried to add attribute exclude_reference_link, which, when set to true, excludes Table API links for reference fields.

The problem is that code inside `plugins/module_utils/table.py`'s method _query: https://github.com/ansible-collections/servicenow.itsm/blob/46e2df9561607ecc675e0ee0714fc830f9ec2a6a/plugins/module_utils/table.py#L17-L19

has been developed, which sets exclude_reference_link to true by default, overriding any value that the user of api_info might specify.

Because of the enforced value set to true in the above mentioned function _query, setting this parameter to either false, true or omitting it makes no difference to the resulting records.

For further explanation, please refer to discussion https://github.com/ansible-collections/servicenow.itsm/pull/179#discussion_r922707247, which explains why this PR is necessary.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`plugins/module_utils/table.py` was changed. The PR was made for functionality of module `api_info`

