### PR TITLE
attachment: A module to download attachment using sys_id

### DIFF
--- a/changelogs/fragments/attachments.yaml
+++ b/changelogs/fragments/attachments.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-- module_utils/attachments.py - Add get_attachment() and save_attachment(). (https://github.com/ansible-collections/servicenow.itsm/pull/186)
+- module_utils/attachments.py - Add ``get_attachment`` and ``save_attachment`` (https://github.com/ansible-collections/servicenow.itsm/pull/186).

--- a/changelogs/fragments/attachments.yaml
+++ b/changelogs/fragments/attachments.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- module_utils/attachments.py - Add get_attachment() and save_attachment(). (https://github.com/ansible-collections/servicenow.itsm/pull/186)

--- a/plugins/module_utils/attachment.py
+++ b/plugins/module_utils/attachment.py
@@ -114,7 +114,7 @@ class AttachmentClient:
         response = self.client.get(_path(attachment_sys_id, 'file'))
         with open(dest, 'wb') as f:
             f.write(response.data)
-        return response.data  # What to return if anything?
+        return response  # What to return if anything?
 
         # # FROM https://developer.servicenow.com/dev.do#!/reference/api/sandiego/rest/c_AttachmentAPI#attachment-GET-file
         # # Install requests package for python

--- a/plugins/module_utils/attachment.py
+++ b/plugins/module_utils/attachment.py
@@ -111,7 +111,7 @@ class AttachmentClient:
 
     def get_attachment(self, attachment_sys_id):
         return self.client.get(_path(attachment_sys_id, "file"))
-    
+
     def save_attachment(self, binary_data, dest):
         try:
             with open(dest, "wb") as f:

--- a/plugins/module_utils/attachment.py
+++ b/plugins/module_utils/attachment.py
@@ -118,8 +118,12 @@ class AttachmentClient:
         # ask on meeting
     
     def save_attachment(self, binary_data, dest):
-        with open(dest, "wb") as f:
-            f.write(binary_data)
+        try:
+            with open(dest, "wb") as f:
+                f.write(binary_data)
+        except Exception: # is this better?
+        # except (IOError, OSError):
+            raise errors.ServiceNowError(f"Cannot open or write to {dest}")
 
 
 def transform_metadata_list(metadata_list, hashing_method):

--- a/plugins/module_utils/attachment.py
+++ b/plugins/module_utils/attachment.py
@@ -27,8 +27,8 @@ def _path(*subpaths):
 
 class AttachmentClient:
     def __init__(self, client, batch_size=10000):
-        # 10000 records is default batch size for ServiceNow Attachment REST API, so we also use it
-        # as a default.
+        # 10000 records is default batch size for ServiceNow Attachment
+        # REST API, so we also use it as a default.
         self.client = client
         self.batch_size = batch_size
 
@@ -62,7 +62,8 @@ class AttachmentClient:
         ).json["result"]
 
     def upload_record(self, table, table_sys_id, metadata, check_mode):
-        # Table and table_sys_id parameters uniquely identify the record we will attach a file to.
+        # Table and table_sys_id parameters uniquely identify the record we
+        # will attach a file to.
         query = dict(
             table_name=table,
             table_sys_id=table_sys_id,
@@ -112,32 +113,12 @@ class AttachmentClient:
 
     def get_attachment(self, attachment_sys_id, dest):
         response = self.client.get(_path(attachment_sys_id, 'file'))
+        # how to handle big files?
+        # check service now documentation/file limits
+        # ask on meeting
         with open(dest, 'wb') as f:
             f.write(response.data)
-        return response  # What to return if anything?
-
-        # # FROM https://developer.servicenow.com/dev.do#!/reference/api/sandiego/rest/c_AttachmentAPI#attachment-GET-file
-        # # Install requests package for python
-        # import requests
-
-        # # Set the request parameters
-        # url = 'https://instance.servicenow.com/api/now/attachment/615ea769c0a80166001cf5f2367302f5/file'
-
-        # # Set the user credentials
-        # user = 'username'
-        # pwd = 'password'
-
-        # # Set the proper headers
-        # headers = {"Accept":"*/*"}
-
-        # # Make the HTTP request
-        # response = requests.get(url, auth=(user, pwd), headers=headers)
-
-        # # Check for HTTP codes other than 200
-        # if response.status_code != 200: 
-        #     print('Status:', response.status_code, 'Headers:', response.headers, 'Error Response:',response.json())
-        #     exit()
-
+        return response
 
 
 def transform_metadata_list(metadata_list, hashing_method):

--- a/plugins/module_utils/attachment.py
+++ b/plugins/module_utils/attachment.py
@@ -27,8 +27,7 @@ def _path(*subpaths):
 
 class AttachmentClient:
     def __init__(self, client, batch_size=10000):
-        # 10000 records is default batch size for ServiceNow Attachment
-        # REST API, so we also use it as a default.
+        # 10000 records is default batch size for ServiceNow Attachment REST API, so we also use it as a default.
         self.client = client
         self.batch_size = batch_size
 
@@ -62,8 +61,7 @@ class AttachmentClient:
         ).json["result"]
 
     def upload_record(self, table, table_sys_id, metadata, check_mode):
-        # Table and table_sys_id parameters uniquely identify the record we
-        # will attach a file to.
+        # Table and table_sys_id parameters uniquely identify the record we will attach a file to.
         query = dict(
             table_name=table,
             table_sys_id=table_sys_id,
@@ -113,17 +111,13 @@ class AttachmentClient:
 
     def get_attachment(self, attachment_sys_id):
         return self.client.get(_path(attachment_sys_id, "file"))
-        # how to handle big files?
-        # check service now documentation/file limits
-        # ask on meeting
     
     def save_attachment(self, binary_data, dest):
         try:
             with open(dest, "wb") as f:
                 f.write(binary_data)
-        except Exception: # is this better?
-        # except (IOError, OSError):
-            raise errors.ServiceNowError(f"Cannot open or write to {dest}")
+        except (IOError, OSError) as e:
+            raise errors.ServiceNowError(str(e))
 
 
 def transform_metadata_list(metadata_list, hashing_method):

--- a/plugins/module_utils/attachment.py
+++ b/plugins/module_utils/attachment.py
@@ -112,13 +112,14 @@ class AttachmentClient:
         return list(mapped_records.values())
 
     def get_attachment(self, attachment_sys_id, dest):
-        response = self.client.get(_path(attachment_sys_id, 'file'))
+        response = self.client.get(_path(attachment_sys_id, "file"))
+        url = os.path.join(self.client.host, _path(attachment_sys_id, "file"))
         # how to handle big files?
         # check service now documentation/file limits
         # ask on meeting
-        with open(dest, 'wb') as f:
+        with open(dest, "wb") as f:
             f.write(response.data)
-        return response
+        return url, response
 
 
 def transform_metadata_list(metadata_list, hashing_method):

--- a/plugins/module_utils/attachment.py
+++ b/plugins/module_utils/attachment.py
@@ -27,7 +27,8 @@ def _path(*subpaths):
 
 class AttachmentClient:
     def __init__(self, client, batch_size=10000):
-        # 10000 records is default batch size for ServiceNow Attachment REST API, so we also use it as a default.
+        # 10000 records is default batch size for ServiceNow Attachment REST API, so we also use it
+        # as a default.
         self.client = client
         self.batch_size = batch_size
 

--- a/plugins/module_utils/attachment.py
+++ b/plugins/module_utils/attachment.py
@@ -111,15 +111,15 @@ class AttachmentClient:
 
         return list(mapped_records.values())
 
-    def get_attachment(self, attachment_sys_id, dest):
-        response = self.client.get(_path(attachment_sys_id, "file"))
-        url = os.path.join(self.client.host, _path(attachment_sys_id, "file"))
+    def get_attachment(self, attachment_sys_id):
+        return self.client.get(_path(attachment_sys_id, "file"))
         # how to handle big files?
         # check service now documentation/file limits
         # ask on meeting
+    
+    def save_attachment(self, binary_data, dest):
         with open(dest, "wb") as f:
-            f.write(response.data)
-        return url, response
+            f.write(binary_data)
 
 
 def transform_metadata_list(metadata_list, hashing_method):

--- a/plugins/module_utils/attachment.py
+++ b/plugins/module_utils/attachment.py
@@ -110,6 +110,35 @@ class AttachmentClient:
 
         return list(mapped_records.values())
 
+    def get_attachment(self, attachment_sys_id, dest):
+        response = self.client.get(_path(attachment_sys_id, 'file'))
+        with open(dest, 'wb') as f:
+            f.write(response.data)
+        return response.data  # What to return if anything?
+
+        # # FROM https://developer.servicenow.com/dev.do#!/reference/api/sandiego/rest/c_AttachmentAPI#attachment-GET-file
+        # # Install requests package for python
+        # import requests
+
+        # # Set the request parameters
+        # url = 'https://instance.servicenow.com/api/now/attachment/615ea769c0a80166001cf5f2367302f5/file'
+
+        # # Set the user credentials
+        # user = 'username'
+        # pwd = 'password'
+
+        # # Set the proper headers
+        # headers = {"Accept":"*/*"}
+
+        # # Make the HTTP request
+        # response = requests.get(url, auth=(user, pwd), headers=headers)
+
+        # # Check for HTTP codes other than 200
+        # if response.status_code != 200: 
+        #     print('Status:', response.status_code, 'Headers:', response.headers, 'Error Response:',response.json())
+        #     exit()
+
+
 
 def transform_metadata_list(metadata_list, hashing_method):
     metadata_dict = dict()

--- a/plugins/module_utils/attachment.py
+++ b/plugins/module_utils/attachment.py
@@ -114,7 +114,7 @@ class AttachmentClient:
 
     def save_attachment(self, binary_data, dest):
         try:
-            with open(dest, "wb") as f:
+            with open(str(dest), "wb") as f:
                 f.write(binary_data)
         except (IOError, OSError) as e:
             raise errors.ServiceNowError(str(e))

--- a/plugins/modules/attachment.py
+++ b/plugins/modules/attachment.py
@@ -104,9 +104,7 @@ def run(module, attachment_client):
         fallback_msg = "Not found"
         fallback_dict = dict(detail=fallback_msg)
         error = response.json.get("error", fallback_dict).get("detail", fallback_msg)
-        raise errors.ServiceNowError(
-            "Status code: 404, Details: " + error
-        )
+        raise errors.ServiceNowError("Status code: 404, Details: " + error)
     end = time.time()
     elapsed = round(end - start, 2)
     try:

--- a/plugins/modules/attachment.py
+++ b/plugins/modules/attachment.py
@@ -26,7 +26,7 @@ extends_documentation_fragment:
 options:
   dest:
     description:
-      - Specify the location to download the file.
+      - Specify the path in which the attachment will be downloaded to. The file will be downloaded on all the hosts from the inventory.
     type: str
     required: true
   sys_id:

--- a/plugins/modules/attachment.py
+++ b/plugins/modules/attachment.py
@@ -73,25 +73,31 @@ def run(module, attachment_client):
     elapsed = f"{end - start:.1f}"
     checksum_src = secure_hash_s(response.data)
     checksum_dest = secure_hash(module.params["dest"])
-    size = json.loads(response.headers["x-attachment-metadata"])["size_bytes"],
-    status_code = response.status,
+    size = json.loads(response.headers["x-attachment-metadata"])["size_bytes"]
+    status_code = response.status
     msg = "OK"
 
-    return {      # return True, record, {}
-        'elapsed': elapsed,
-        'checksum_src': checksum_src,
-        'checksum_dest': checksum_dest,
-        'size': size,
-        'status_code': status_code,
-        'msg': msg,
+    return {
+        "size": size,     # return True, record, {}
+        "elapsed": elapsed,
+        "checksum_src": checksum_src,
+        "checksum_dest": checksum_dest,
+        "status_code": status_code,
+        "msg": msg,
     }
 
 
 def main():
     module_args = dict(
-        arguments.get_spec("instance", "sys_id"),
+        arguments.get_spec("instance"),
+        # Overwrites sys_id from SHARED_SPECS to add required=True
+        sys_id=dict(
+            type="str",
+            required=True,
+        ),
         dest=dict(
             type="str",
+            required=True,
         ),
     )
 

--- a/plugins/modules/attachment.py
+++ b/plugins/modules/attachment.py
@@ -1,0 +1,207 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2021, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+DOCUMENTATION = r"""
+module: attachment
+
+author:
+  - Polona Mihalič (@PolonaM)
+
+short_description: a module that users can use to download attachments
+
+description:
+  - Create, delete or update a ServiceNow change request.
+  - For more information, refer to the ServiceNow change management documentation at
+    U(https://docs.servicenow.com/bundle/paris-it-service-management/page/product/change-management/concept/c_ITILChangeManagement.html).
+version_added: 1.0.0
+extends_documentation_fragment:
+  - servicenow.itsm.instance
+  - servicenow.itsm.sys_id
+  - servicenow.itsm.number
+  - servicenow.itsm.attachments
+  - servicenow.itsm.change_request_mapping
+seealso:
+  - module: servicenow.itsm.change_request_info
+
+options:
+  state:
+    description:
+      - The state of the change request.
+      - If I(state) value is C(assess) or C(authorize) or C(scheduled) or
+        C(implement) or C(review) or C(closed),
+        I(assignment_group) parameter must be filled in.
+      - For more information on state model and transition,
+        refere to the ServiceNow documentation at
+        U(https://docs.servicenow.com/bundle/paris-it-service-management/page/product/change-management/concept/c_ChangeStateModel.html)
+      - Default choices are C(new), C(assess), C(authorize), C(scheduled), C(implement), C(review), C(closed), C(canceled), C(absent).
+        One can override them by setting I(change_request_mapping.state).
+    type: str
+  type:
+    description:
+      - Specify what type of change is required.
+    choices: [ standard, normal, emergency ]
+    type: str
+  template:
+    description:
+      - Predefined template name for standard change request.
+      - For more information on templates refer to ServiceNow documentation at
+        U(https://docs.servicenow.com/bundle/quebec-it-service-management/page/product/change-management/concept/c_StandardChangeCatalogPlugin.html)
+        or find template names on <your_service_id>.service-now.com/nav_to.do?uri=%2Fstd_change_producer_version_list.do%3F
+    type: str
+  requested_by:
+    description:
+      - User who requested the change.
+    type: str
+  assignment_group:
+    description:
+      - The group that the change request is assigned to.
+      - Required if I(state) value is C(assess) or C(authorize) or
+        C(scheduled) or C(implement) or C(review) or C(closed).
+    type: str
+  category:
+    description:
+      - The category of the change request.
+    choices: [ hardware, software, service, system_software, aplication_software,
+               network, telecom, documentation, other ]
+    type: str
+  priority:
+    description:
+      - Priority is based on impact and urgency, and it identifies how quickly
+        the service desk should address the task.
+      - Default choices are C(critical), C(high), C(moderate), C(low).
+        One can override them by setting I(change_request_mapping.priority).
+    type: str
+  risk:
+    description:
+      - The risk level for the change.
+      - Default choices are C(high), C(moderate), C(low).
+        One can override them by setting I(change_request_mapping.risk).
+    type: str
+  impact:
+    description:
+      - Impact is a measure of the effect of an incident, problem,
+        or change on business processes.
+      - Default choices are C(high), C(medium), C(low).
+        One can override them by setting I(change_request_mapping.impact).
+    type: str
+  urgency:
+    description:
+      - The extent to which resolution of an change request can bear delay.
+      - Default choices are C(high), C(medium), C(low).
+        One can override them by setting I(change_request_mapping.urgency).
+    type: str
+  short_description:
+    description:
+      - A summary of the change request.
+    type: str
+  description:
+    description:
+      - A detailed description of the change request.
+    type: str
+  close_code:
+    description:
+      - Provide information on how the change request was resolved.
+      - The change request must have this parameter set prior to
+        transitioning to the C(closed) state.
+    choices: [ successful, successful_issues, unsuccessful ]
+    type: str
+  close_notes:
+    description:
+      - Resolution notes added by the user who closed the change request.
+      - The change request must have this parameter set prior to
+        transitioning to the C(closed) state.
+    type: str
+  on_hold:
+    description:
+      - A change request can be put on hold when I(state)
+        is not in the C(new), C(canceled), or C(closed).
+    type: bool
+  hold_reason:
+    description:
+      - Reason why change request is on hold.
+      - Required if change request's I(on_hold) value will be C(true).
+    type: str
+  other:
+    description:
+      - Optional remaining parameters.
+      - For more information on optional parameters, refer to the ServiceNow
+        change request documentation at
+        U(https://docs.servicenow.com/bundle/paris-it-service-management/page/product/change-management/task/t_CreateAChange.html).
+    type: dict
+"""
+
+EXAMPLES = """
+# Run as: ansible-playbook -t download-attachment-sn attachment.yaml
+- name: Download examples
+  hosts: localhost
+  vars:
+    sn_host: https://dev121244.service-now.com
+    sn_username: admin
+    sn_password: rv6F4iErP+=M
+    sn_attachment_id: 0061f0c510247200964f77ffeec6c4de
+  tasks:
+  - name: ServiceNow download attachment module
+    servicenow.itsm.attachment:
+      instance:
+        host: "{{ sn_host }}"
+        username: "{{ sn_username }}"
+        password: "{{ sn_password }}"
+      dest: /tmp/sn-attachment
+      sys_id: "{{ sn_attachment_id }}"
+    tags:
+      - download-attachment-sn
+"""
+
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ..module_utils import (
+    arguments,
+    client,
+    attachment,
+    errors,
+)
+
+
+def run(module, attachment_client):
+    return attachment_client.get_attachment(
+      module.params["sys_id"],
+      module.params["dest"]
+      )  # response is binary file attachment
+
+
+def main():
+    module_args = dict(
+        arguments.get_spec(
+            "instance", "sys_id"  # why is there also attachment? Is sys_id for the attachment or table?
+        ),
+        dest=dict(
+            type="str",
+        ),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    try:
+        snow_client = client.Client(**module.params["instance"])
+        attachment_client = attachment.AttachmentClient(snow_client)
+        record = run(module, attachment_client)  # response is binary file attachment
+        print(record)
+        module.exit_json(changed=True, record='record')  # Changed True because we change the content of the computer where playbook runs
+    except errors.ServiceNowError as e:
+        module.fail_json(msg=str(e))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/attachment.py
+++ b/plugins/modules/attachment.py
@@ -134,7 +134,7 @@ def main():
             required=True,
         ),
         dest=dict(
-            type="str",
+            type="path",
             required=True,
         ),
     )

--- a/plugins/modules/attachment.py
+++ b/plugins/modules/attachment.py
@@ -19,7 +19,7 @@ short_description: a module that users can use to download attachment using sys_
 
 description:
   - Download attachment using sys_id.
-  - For more information, refer to the INSERT LINK FROM SERWICE NOW
+  - For more information, refer to the INSERT LINK FROM SERVICE NOW
 version_added: 2.0.0
 extends_documentation_fragment:
   - servicenow.itsm.instance
@@ -45,7 +45,10 @@ EXAMPLES = """
       - download-attachment-sn
 """
 
+
 import hashlib
+import os
+import time
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -60,7 +63,7 @@ from ..module_utils import (
 def get_checksum_dest(file_path):
     h = hashlib.sha256()
 
-    with open(file_path, 'rb') as file:
+    with open(file_path, "rb") as file:
         while True:
             chunk = file.read(h.block_size)
             if not chunk:
@@ -77,24 +80,22 @@ def get_checksum_src(binary_data):
 
 
 def run(module, attachment_client):
-   # time.time
-    response = attachment_client.get_attachment(
-      module.params["sys_id"],
-      module.params["dest"]
-      )
-    # time.time
-    elapsed =  # v sekundah, uporabi string format
+    start = time.time()
+    url, response = attachment_client.get_attachment(
+        module.params["sys_id"], module.params["dest"]
+    )
+    end = time.time()
+    elapsed = f"{end - start:.1f}"
     checksum_src = get_checksum_src(response.data)
     checksum_dest = get_checksum_dest(module.params["dest"])
+    size = os.path.getsize(module.params["dest"])  # bytes
 
-    return elapsed, response, checksum_src, checksum_dest
+    return elapsed, response, checksum_src, checksum_dest, size, url
 
 
 def main():
     module_args = dict(
-        arguments.get_spec(
-            "instance", "sys_id"  # why is there also attachment? Is sys_id for the attachment or table?
-        ),
+        arguments.get_spec("instance", "sys_id"),
         dest=dict(
             type="str",
         ),
@@ -108,18 +109,18 @@ def main():
     try:
         snow_client = client.Client(**module.params["instance"])
         attachment_client = attachment.AttachmentClient(snow_client)
-        response, checksum_src, checksum_dest = run(module, attachment_client)
+        elapsed, response, checksum_src, checksum_dest, size, url = run(
+            module, attachment_client
+        )
         module.exit_json(
-          changed=True,  # Changed True because we change the content of the computer where playbook runs
-          checksum_dest=checksum_dest,
-          checksum_src=checksum_src,
-          # dest="/tmp/sn-attachment", # already in invocation
-          # elapsed=2, # The number of seconds that elapsed while performing the download
-          # msg="OK (unknown bytes)", # the HTTP message from the request
-          # size=, # size of the target (os.stat)
-          status_code=response.status, # the HTTP status code from the request
-          # url= "https://dev121244.service-now.com/api/now/attachment/11138a9e97901110166e318c1253afd9/file" # the actual URL used for the request
-          )
+            changed=True,
+            checksum_src=checksum_src,
+            checksum_dest=checksum_dest,
+            elapsed=elapsed,
+            size=size,
+            status_code=response.status,
+            url=url,  # the actual URL used for the request
+        )
     except errors.ServiceNowError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/attachment.py
+++ b/plugins/modules/attachment.py
@@ -26,8 +26,11 @@ extends_documentation_fragment:
 options:
   dest:
     description:
-      - Specify the path in which the attachment will be downloaded to. The file will be downloaded on all the hosts from the inventory.
-    type: str
+      - Specifies the path in which the attachment will be downloaded to.
+      - The file will be downloaded to all of the hosts from the inventory.
+      - All the directories on the path should already exist.
+      - If the file at the destination path already exists, it will be overwritten.
+    type: path
     required: true
   sys_id:
     description:

--- a/plugins/modules/attachment.py
+++ b/plugins/modules/attachment.py
@@ -51,36 +51,41 @@ EXAMPLES = """
 
 
 RETURN = r'''
-checksum_dest:
-    description: sha1 checksum of the file after download
-    returned: success
-    type: str
-    sample: 6e642bb8dd5c2e027bf21dd923337cbb4214f827
-checksum_src:
-    description: sha1 checksum of the file
-    returned: success
-    type: str
-    sample: 6e642bb8dd5c2e027bf21dd923337cbb4214f827
-elapsed:
-    description: the number of seconds that elapsed while performing the download
-    returned: success
-    type: float
-    sample: 23
-msg:
-    description: OK or error message
-    returned: always
-    type: str
-    sample: OK
-size:
-    description: size of the target
-    returned: success
-    type: int
-    sample: 1220
-status_code:
-    description: the HTTP status code from the request
-    returned: success
-    type: int
-    sample: 200
+record:
+  description: download attachment record
+  returned: success
+  type: dict
+  return parameters:
+    checksum_dest:
+        description: sha1 checksum of the file after download
+        returned: success
+        type: str
+        sample: 6e642bb8dd5c2e027bf21dd923337cbb4214f827
+    checksum_src:
+        description: sha1 checksum of the file
+        returned: success
+        type: str
+        sample: 6e642bb8dd5c2e027bf21dd923337cbb4214f827
+    elapsed:
+        description: the number of seconds that elapsed while performing the download
+        returned: success
+        type: float
+        sample: 2.3
+    msg:
+        description: OK or error message
+        returned: always
+        type: str
+        sample: OK
+    size:
+        description: size of the target
+        returned: success
+        type: int
+        sample: 1220
+    status_code:
+        description: the HTTP status code from the request
+        returned: success
+        type: int
+        sample: 200
 '''
 
 
@@ -108,10 +113,10 @@ def run(module, attachment_client):
             "Status code: 404, Details: " + json.loads(response.data)["error"]["detail"]
         )
     end = time.time()
-    elapsed = round(end - start, 1) 
+    elapsed = round(end - start, 2)
     checksum_src = secure_hash_s(response.data)
     checksum_dest = secure_hash(module.params["dest"])
-    size = int(json.loads(response.headers["x-attachment-metadata"])["size_bytes"]) # does it matter if it is str or int?
+    size = int(json.loads(response.headers["x-attachment-metadata"])["size_bytes"])
     status_code = response.status
     msg = "OK"
 
@@ -147,8 +152,8 @@ def main():
     try:
         snow_client = client.Client(**module.params["instance"])
         attachment_client = attachment.AttachmentClient(snow_client)
-        records = run(module, attachment_client)
-        module.exit_json(changed=True, records=records)
+        record = run(module, attachment_client)
+        module.exit_json(changed=True, record=record)
     except errors.ServiceNowError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/attachment.py
+++ b/plugins/modules/attachment.py
@@ -67,7 +67,7 @@ def run(module, attachment_client):
         attachment_client.save_attachment(response.data, module.params["dest"])
     elif response.status == 404:
         raise errors.ServiceNowError(
-            "Status code: 404, Details: " + response.json["error"]["detail"]
+            "Status code: 404, Details: " + json.loads(response.data)["error"]["detail"]
         )
     end = time.time()
     elapsed = f"{end - start:.1f}"

--- a/plugins/modules/attachment.py
+++ b/plugins/modules/attachment.py
@@ -15,146 +15,32 @@ module: attachment
 author:
   - Polona Mihalič (@PolonaM)
 
-short_description: a module that users can use to download attachments using sys_id
+short_description: a module that users can use to download attachment using sys_id
 
 description:
-  - Create, delete or update a ServiceNow change request.
-  - For more information, refer to the ServiceNow change management documentation at
-    U(https://docs.servicenow.com/bundle/paris-it-service-management/page/product/change-management/concept/c_ITILChangeManagement.html).
-version_added: 1.0.0
+  - Download attachment using sys_id.
+  - For more information, refer to the INSERT LINK FROM SERWICE NOW
+version_added: 2.0.0
 extends_documentation_fragment:
   - servicenow.itsm.instance
   - servicenow.itsm.sys_id
-  - servicenow.itsm.number
-  - servicenow.itsm.attachments
-  - servicenow.itsm.change_request_mapping
-seealso:
-  - module: servicenow.itsm.change_request_info
 
 options:
-  state:
-    description:
-      - The state of the change request.
-      - If I(state) value is C(assess) or C(authorize) or C(scheduled) or
-        C(implement) or C(review) or C(closed),
-        I(assignment_group) parameter must be filled in.
-      - For more information on state model and transition,
-        refere to the ServiceNow documentation at
-        U(https://docs.servicenow.com/bundle/paris-it-service-management/page/product/change-management/concept/c_ChangeStateModel.html)
-      - Default choices are C(new), C(assess), C(authorize), C(scheduled), C(implement), C(review), C(closed), C(canceled), C(absent).
-        One can override them by setting I(change_request_mapping.state).
-    type: str
   type:
-    description:
-      - Specify what type of change is required.
-    choices: [ standard, normal, emergency ]
+    dest:
+      - Specify download folder.
     type: str
-  template:
-    description:
-      - Predefined template name for standard change request.
-      - For more information on templates refer to ServiceNow documentation at
-        U(https://docs.servicenow.com/bundle/quebec-it-service-management/page/product/change-management/concept/c_StandardChangeCatalogPlugin.html)
-        or find template names on <your_service_id>.service-now.com/nav_to.do?uri=%2Fstd_change_producer_version_list.do%3F
-    type: str
-  requested_by:
-    description:
-      - User who requested the change.
-    type: str
-  assignment_group:
-    description:
-      - The group that the change request is assigned to.
-      - Required if I(state) value is C(assess) or C(authorize) or
-        C(scheduled) or C(implement) or C(review) or C(closed).
-    type: str
-  category:
-    description:
-      - The category of the change request.
-    choices: [ hardware, software, service, system_software, aplication_software,
-               network, telecom, documentation, other ]
-    type: str
-  priority:
-    description:
-      - Priority is based on impact and urgency, and it identifies how quickly
-        the service desk should address the task.
-      - Default choices are C(critical), C(high), C(moderate), C(low).
-        One can override them by setting I(change_request_mapping.priority).
-    type: str
-  risk:
-    description:
-      - The risk level for the change.
-      - Default choices are C(high), C(moderate), C(low).
-        One can override them by setting I(change_request_mapping.risk).
-    type: str
-  impact:
-    description:
-      - Impact is a measure of the effect of an incident, problem,
-        or change on business processes.
-      - Default choices are C(high), C(medium), C(low).
-        One can override them by setting I(change_request_mapping.impact).
-    type: str
-  urgency:
-    description:
-      - The extent to which resolution of an change request can bear delay.
-      - Default choices are C(high), C(medium), C(low).
-        One can override them by setting I(change_request_mapping.urgency).
-    type: str
-  short_description:
-    description:
-      - A summary of the change request.
-    type: str
-  description:
-    description:
-      - A detailed description of the change request.
-    type: str
-  close_code:
-    description:
-      - Provide information on how the change request was resolved.
-      - The change request must have this parameter set prior to
-        transitioning to the C(closed) state.
-    choices: [ successful, successful_issues, unsuccessful ]
-    type: str
-  close_notes:
-    description:
-      - Resolution notes added by the user who closed the change request.
-      - The change request must have this parameter set prior to
-        transitioning to the C(closed) state.
-    type: str
-  on_hold:
-    description:
-      - A change request can be put on hold when I(state)
-        is not in the C(new), C(canceled), or C(closed).
-    type: bool
-  hold_reason:
-    description:
-      - Reason why change request is on hold.
-      - Required if change request's I(on_hold) value will be C(true).
-    type: str
-  other:
-    description:
-      - Optional remaining parameters.
-      - For more information on optional parameters, refer to the ServiceNow
-        change request documentation at
-        U(https://docs.servicenow.com/bundle/paris-it-service-management/page/product/change-management/task/t_CreateAChange.html).
-    type: dict
 """
 
 EXAMPLES = """
-- name: Download examples
-  hosts: localhost
-  vars:
-    sn_host: https://dev121244.service-now.com
-    sn_username: admin
-    sn_password: rv6F4iErP+=M
-    sn_attachment_id: 0061f0c510247200964f77ffeec6c4de
-  tasks:
   - name: ServiceNow download attachment module
     servicenow.itsm.attachment:
       instance:
-        host: "{{ sn_host }}"
-        username: "{{ sn_username }}"
-        password: "{{ sn_password }}"
+        host: sn_host
+        username: sn_username
+        password: sn_password
       dest: /tmp/sn-attachment
-      sys_id: "{{ sn_attachment_id }}"
+      sys_id: sn_attachment_id
     tags:
       - download-attachment-sn
 """
@@ -176,7 +62,6 @@ def get_checksum_dest(file_path):
 
     with open(file_path, 'rb') as file:
         while True:
-            # Reading is buffered, so we can read smaller chunks.
             chunk = file.read(h.block_size)
             if not chunk:
                 break
@@ -187,25 +72,22 @@ def get_checksum_dest(file_path):
 
 def get_checksum_src(binary_data):
     h = hashlib.sha256()
-    # Should we implement also block_size reading?
-    # while True:
-    #     chunk = response.data.read(h.block_size) # replace read 
-    #     if not chunk:
-    #         break
-    #     h.update(chunk)
     h.update(binary_data)
     return h.hexdigest()
 
 
 def run(module, attachment_client):
+   # time.time
     response = attachment_client.get_attachment(
       module.params["sys_id"],
       module.params["dest"]
       )
+    # time.time
+    elapsed =  # v sekundah, uporabi string format
     checksum_src = get_checksum_src(response.data)
     checksum_dest = get_checksum_dest(module.params["dest"])
 
-    return response, checksum_src, checksum_dest
+    return elapsed, response, checksum_src, checksum_dest
 
 
 def main():
@@ -231,19 +113,11 @@ def main():
           changed=True,  # Changed True because we change the content of the computer where playbook runs
           checksum_dest=checksum_dest,
           checksum_src=checksum_src,
-          # dest="/tmp/sn-attachment",
+          # dest="/tmp/sn-attachment", # already in invocation
           # elapsed=2, # The number of seconds that elapsed while performing the download
-          # gid=1001, # group id of the file
-          # group="polonamihalic", # group of the file
-          # md5sum="e67247842e8d985fd709ff18599699c2", # md5 checksum of the file after download - WHY DO WE NEED THIS?
-          # mode="0664", # permissions of the target
           # msg="OK (unknown bytes)", # the HTTP message from the request
-          # owner="polonamihalic", # owner of the file
-          # size=1905, # size of the target
-          # src="/home/polonamihalic/.ansible/tmp/ansible-tmp-1656593431.4899359-251579-202476144348026/tmp6w1hml3g", # source file used after download
-          # state="file", # state of the target
+          # size=, # size of the target (os.stat)
           status_code=response.status, # the HTTP status code from the request
-          # uid=1001, # owner id of the file, after execution
           # url= "https://dev121244.service-now.com/api/now/attachment/11138a9e97901110166e318c1253afd9/file" # the actual URL used for the request
           )
     except errors.ServiceNowError as e:

--- a/plugins/modules/attachment.py
+++ b/plugins/modules/attachment.py
@@ -26,7 +26,7 @@ extends_documentation_fragment:
 options:
   dest:
     description:
-      - Specify download folder.
+      - Specify download file.
     type: str
     required: true
   sys_id:
@@ -50,22 +50,12 @@ EXAMPLES = """
 """
 
 
-RETURN = r'''
+RETURN = r"""
 record:
   description: download attachment record
   returned: success
   type: dict
-  return parameters:
-    checksum_dest:
-        description: sha1 checksum of the file after download
-        returned: success
-        type: str
-        sample: 6e642bb8dd5c2e027bf21dd923337cbb4214f827
-    checksum_src:
-        description: sha1 checksum of the file
-        returned: success
-        type: str
-        sample: 6e642bb8dd5c2e027bf21dd923337cbb4214f827
+  contains:
     elapsed:
         description: the number of seconds that elapsed while performing the download
         returned: success
@@ -86,14 +76,13 @@ record:
         returned: success
         type: int
         sample: 200
-'''
+"""
 
 
 import time
 import json
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.utils.hashing import secure_hash, secure_hash_s
 
 from ..module_utils import (
     arguments,
@@ -114,17 +103,13 @@ def run(module, attachment_client):
         )
     end = time.time()
     elapsed = round(end - start, 2)
-    checksum_src = secure_hash_s(response.data)
-    checksum_dest = secure_hash(module.params["dest"])
     size = int(json.loads(response.headers["x-attachment-metadata"])["size_bytes"])
     status_code = response.status
     msg = "OK"
 
     return {
-        "size": size,  # return True, record, {}
+        "size": size,
         "elapsed": elapsed,
-        "checksum_src": checksum_src,
-        "checksum_dest": checksum_dest,
         "status_code": status_code,
         "msg": msg,
     }

--- a/plugins/modules/attachment.py
+++ b/plugins/modules/attachment.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-# Copyright: (c) 2021, XLAB Steampunk <steampunk@xlab.si>
+# Copyright: (c) 2022, XLAB Steampunk <steampunk@xlab.si>
 #
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -26,7 +26,7 @@ extends_documentation_fragment:
 options:
   dest:
     description:
-      - Specify download file.
+      - Specify the location to download the file.
     type: str
     required: true
   sys_id:
@@ -43,13 +43,11 @@ EXAMPLES = """
   - name: ServiceNow download attachment module
     servicenow.itsm.attachment:
       instance:
-        host: sn_host
-        username: sn_username
-        password: sn_password
+        host: https://instance_id.service-now.com
+        username: user
+        password: pass
       dest: /tmp/sn-attachment
-      sys_id: sn_attachment_id
-    tags:
-      - download-attachment-sn
+      sys_id: 003a3ef24ff1120031577d2ca310c74b
 """
 
 

--- a/plugins/modules/attachment.py
+++ b/plugins/modules/attachment.py
@@ -26,8 +26,8 @@ extends_documentation_fragment:
   - servicenow.itsm.sys_id
 
 options:
-  type:
-    dest:
+  dest:
+    description:
       - Specify download folder.
     type: str
 """

--- a/plugins/modules/attachment.py
+++ b/plugins/modules/attachment.py
@@ -34,6 +34,9 @@ options:
       - Attachment's sys_id.
     type: str
     required: true
+
+notes:
+  - Supports check_mode.
 """
 
 EXAMPLES = """
@@ -96,7 +99,8 @@ def run(module, attachment_client):
     start = time.time()
     response = attachment_client.get_attachment(module.params["sys_id"])
     if response.status == 200:
-        attachment_client.save_attachment(response.data, module.params["dest"])
+        if not module.check_mode:
+            attachment_client.save_attachment(response.data, module.params["dest"])
     elif response.status == 404:
         raise errors.ServiceNowError(
             "Status code: 404, Details: " + json.loads(response.data)["error"]["detail"]

--- a/tests/integration/targets/attachment/tasks/main.yml
+++ b/tests/integration/targets/attachment/tasks/main.yml
@@ -466,13 +466,14 @@
           - result.records.size == 210
           - result.records.status_code == 200
 
-    - name: Download attachment with wrong sys_id
+    - name: Download attachment with wrong id
       servicenow.itsm.attachment:
-        dest: /tmp/sn-attachment
+        dest: "{{ temp_file.path }}"
         sys_id: "wrongid"
+      ignore_errors: true
       register: result
 
     - ansible.builtin.assert:
         that:
-          - result.msg == "Status code':'' 404, Details':'' Record doesn't exist or ACL restricts the record retrieval"
-          
+          - result is failed
+          - "'Record' in result.msg"

--- a/tests/integration/targets/attachment/tasks/main.yml
+++ b/tests/integration/targets/attachment/tasks/main.yml
@@ -445,26 +445,31 @@
     - name: Create a base configuration item with attachment
       servicenow.itsm.configuration_item: *ci-create
       register: result
-
+    
     - name: Create temporary file
       ansible.builtin.tempfile:
         state: file
       register: temp_file
 
-    - name: Download attachment
-      servicenow.itsm.attachment:
+    - name: Download attachment - check mode
+      servicenow.itsm.attachment: &download-attachment
         dest: "{{ temp_file.path }}"
         sys_id: "{{ result.record.attachments[0].sys_id }}"
-      register: result
+      check_mode: yes
+      register: att_result
 
-    - ansible.builtin.assert:
+    - ansible.builtin.assert: &download-attachment-result
         that:
-          - result is changed
-          - result.records.checksum_src == "e867d44768615c88da0b5f7ccff0d14d3f4c06f4"
-          - result.records.checksum_dest == "e867d44768615c88da0b5f7ccff0d14d3f4c06f4"
-          - result.records.msg == "OK"
-          - result.records.size == 210
-          - result.records.status_code == 200
+          - att_result is changed
+          - att_result.record.msg == "OK"
+          - att_result.record.size != 0
+          - att_result.record.status_code == 200
+    
+    - name: Download attachment
+      servicenow.itsm.attachment: *download-attachment
+      register: att_result
+
+    - ansible.builtin.assert: *download-attachment-result
 
     - name: Download attachment with wrong id
       servicenow.itsm.attachment:

--- a/tests/integration/targets/attachment/tasks/main.yml
+++ b/tests/integration/targets/attachment/tasks/main.yml
@@ -436,3 +436,43 @@
       servicenow.itsm.problem: *delete-problem-attachment
 
     - ansible.builtin.assert: *delete-problem-attachment-result
+
+
+    ################################################
+    ############# Get Attachment Tests #############
+    ################################################
+
+    - name: Create a base configuration item with attachment
+      servicenow.itsm.configuration_item: *ci-create
+      register: result
+
+    - name: Create temporary file
+      ansible.builtin.tempfile:
+        state: file
+      register: temp_file
+
+    - name: Download attachment
+      servicenow.itsm.attachment:
+        dest: "{{ temp_file.path }}"
+        sys_id: "{{ result.record.attachments[0].sys_id }}"
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.records.checksum_src == "e867d44768615c88da0b5f7ccff0d14d3f4c06f4"
+          - result.records.checksum_dest == "e867d44768615c88da0b5f7ccff0d14d3f4c06f4"
+          - result.records.msg == "OK"
+          - result.records.size == 210
+          - result.records.status_code == 200
+
+    - name: Download attachment with wrong sys_id
+      servicenow.itsm.attachment:
+        dest: /tmp/sn-attachment
+        sys_id: "wrongid"
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result.msg == "Status code':'' 404, Details':'' Record doesn't exist or ACL restricts the record retrieval"
+          

--- a/tests/unit/plugins/module_utils/test_attachment.py
+++ b/tests/unit/plugins/module_utils/test_attachment.py
@@ -798,7 +798,9 @@ class TestAttachmentUpdateRecords:
 class TestAttachmentGetAttachment:
     def test_get_attachment(self, client):
         client.get.return_value = Response(
-            200, bytes("binary_data", "ascii"), {"headers": "headers"} # preveri če bytes obstaja v 2.7
+            200,
+            bytearray(b"binary_data"),
+            {"headers": "headers"},
         )
         a = attachment.AttachmentClient(client)
 
@@ -808,8 +810,8 @@ class TestAttachmentGetAttachment:
             "api/now/attachment/0061f0c510247200964f77ffeec6c4de/file"
         )
         assert response.status == 200
-        assert response.data == bytes("binary_data", "ascii")
-        assert response.headers == {'headers': 'headers'}
+        assert response.data == bytearray(b"binary_data")
+        assert response.headers == {"headers": "headers"}
 
 
 class TestAttachmentSaveAttachment:
@@ -817,7 +819,7 @@ class TestAttachmentSaveAttachment:
         path = tmp_path / "test.txt"
         a = attachment.AttachmentClient(client)
 
-        a.save_attachment(bytes("test", "ascii"), path)
+        a.save_attachment(bytearray(b"test"), path)
         file = open(path, "r")
         
         assert file.read() == "test"
@@ -826,6 +828,6 @@ class TestAttachmentSaveAttachment:
         a = attachment.AttachmentClient(client)
 
         with pytest.raises(errors.ServiceNowError) as exc:
-            a.save_attachment(bytes("test", "ascii"), "/not/a/path")
+            a.save_attachment(bytearray(b"test"), "/not/a/path")
 
-        assert "Cannot open or write to /not/a/path" in str(exc.value)
+        assert "[Errno 2] No such file or directory: '/not/a/path'" in str(exc.value)

--- a/tests/unit/plugins/module_utils/test_attachment.py
+++ b/tests/unit/plugins/module_utils/test_attachment.py
@@ -792,3 +792,44 @@ class TestAttachmentUpdateRecords:
                 "file_name": "attachment_name.txt",
             },
         ] == sorted(record, key=lambda k: k["file_name"])
+
+
+class TestAttachmentGetAttachment:
+    def test_get_attachment_200(self, client):
+        client.get.return_value = Response(
+            200, 'binary_data', 'headers'
+        )
+        a = attachment.AttachmentClient(client)
+
+        a.get_attachment("0061f0c510247200964f77ffeec6c4de")
+
+        client.get.assert_called_once_with(
+            "api/now/attachment/0061f0c510247200964f77ffeec6c4de/file"
+        )
+
+    def test_get_attachment_404(self):
+        # "msg": "Record doesn't exist or ACL restricts the record retrieval" 
+        pass
+
+    def test_get_attachment_unexpected_response(self):
+        # "msg": "Unexpected response..." 
+        pass
+
+    def test_get_attachment_wrong_auth(self):
+        # "msg": "Failed to authenticate with the instance: 401 Unauthorized" (from client.py _request())
+        pass
+
+    def test_get_attachment_wrong_host(self):
+        # "msg": "[Errno -2] Name or service not known" (from client.py _request())
+        pass
+
+
+class TestAttachmentSaveAttachment:
+    def test_save_attachment(self, tmp_path):  # tmp_path is a built in fixture
+        pass
+
+    def test_save_attachment_bad_dest(self):
+        # "msg": "Cannot open or write to /tmpž/sn-attachment"
+        pass
+
+# stestiraj 0B? je sploh treba to?

--- a/tests/unit/plugins/module_utils/test_attachment.py
+++ b/tests/unit/plugins/module_utils/test_attachment.py
@@ -821,7 +821,7 @@ class TestAttachmentSaveAttachment:
         a = attachment.AttachmentClient(client)
 
         a.save_attachment(to_bytes("test"), path)
-        file = open(path, "r")
+        file = open(str(path), "r")
         b_data = file.read()
 
         assert to_text(b_data) == "test"

--- a/tests/unit/plugins/module_utils/test_attachment.py
+++ b/tests/unit/plugins/module_utils/test_attachment.py
@@ -13,6 +13,7 @@ import pytest
 
 from ansible_collections.servicenow.itsm.plugins.module_utils import errors, attachment
 from ansible_collections.servicenow.itsm.plugins.module_utils.client import Response
+from ansible.module_utils._text import to_bytes, to_text
 
 
 pytestmark = pytest.mark.skipif(
@@ -799,7 +800,7 @@ class TestAttachmentGetAttachment:
     def test_get_attachment(self, client):
         client.get.return_value = Response(
             200,
-            bytearray(b"binary_data"),
+            to_bytes("binary_data"),
             {"headers": "headers"},
         )
         a = attachment.AttachmentClient(client)
@@ -810,7 +811,7 @@ class TestAttachmentGetAttachment:
             "api/now/attachment/0061f0c510247200964f77ffeec6c4de/file"
         )
         assert response.status == 200
-        assert response.data == bytearray(b"binary_data")
+        assert response.data == to_bytes("binary_data")
         assert response.headers == {"headers": "headers"}
 
 
@@ -819,15 +820,16 @@ class TestAttachmentSaveAttachment:
         path = tmp_path / "test.txt"
         a = attachment.AttachmentClient(client)
 
-        a.save_attachment(bytearray(b"test"), path)
+        a.save_attachment(to_bytes("test"), path)
         file = open(path, "r")
+        b_data = file.read()
         
-        assert file.read() == "test"
+        assert to_text(b_data) == "test"
 
     def test_save_attachment_bad_dest(self, client):
         a = attachment.AttachmentClient(client)
 
         with pytest.raises(errors.ServiceNowError) as exc:
-            a.save_attachment(bytearray(b"test"), "/not/a/path")
+            a.save_attachment(to_bytes("test"), "/not/a/path")
 
         assert "[Errno 2] No such file or directory: '/not/a/path'" in str(exc.value)

--- a/tests/unit/plugins/module_utils/test_attachment.py
+++ b/tests/unit/plugins/module_utils/test_attachment.py
@@ -826,10 +826,11 @@ class TestAttachmentSaveAttachment:
 
         assert to_text(b_data) == "test"
 
-    def test_save_attachment_bad_dest(self, client):
+    def test_save_attachment_bad_dest(self, client, tmpdir):
         a = attachment.AttachmentClient(client)
+        nonexisting_path_name = str(tmpdir.join("not", "a", "path"))
 
         with pytest.raises(errors.ServiceNowError) as exc:
-            a.save_attachment(to_bytes("test"), "/not/a/path")
+            a.save_attachment(to_bytes("test"), nonexisting_path_name)
 
-        assert "[Errno 2] No such file or directory: '/not/a/path'" in str(exc.value)
+        assert "[Errno 2] No such file or directory" in str(exc.value)

--- a/tests/unit/plugins/module_utils/test_attachment.py
+++ b/tests/unit/plugins/module_utils/test_attachment.py
@@ -823,7 +823,7 @@ class TestAttachmentSaveAttachment:
         a.save_attachment(to_bytes("test"), path)
         file = open(path, "r")
         b_data = file.read()
-        
+
         assert to_text(b_data) == "test"
 
     def test_save_attachment_bad_dest(self, client):

--- a/tests/unit/plugins/modules/test_attachment_module.py
+++ b/tests/unit/plugins/modules/test_attachment_module.py
@@ -90,8 +90,6 @@ class TestRun:
 
         assert records == {
             "elapsed": 0.0,
-            "checksum_src": "08d1d491223ab3d4460f6dbc0e1948f06adf74b7",
-            "checksum_dest": None,
             "size": 1000,
             "status_code": 200,
             "msg": "OK",
@@ -116,7 +114,7 @@ class TestRun:
         attachment_client.get_attachment.return_value = Response(
             404,
             to_bytes(
-                '{"error":{"message":"No Record found","detail":"Record doesnt exist"},"status":"failure"}'
+                '{"error":{"message":"No Record found","detail":"Record does not exist"},"status":"failure"}'
             ),
             {"headers": "headers"},
         )
@@ -124,4 +122,4 @@ class TestRun:
         with pytest.raises(errors.ServiceNowError) as exc:
             attachment.run(module, attachment_client)
 
-        assert "Status code: 404, Details: Record doesnt exist" in str(exc.value)
+        assert "Status code: 404, Details: Record does not exist" in str(exc.value)

--- a/tests/unit/plugins/modules/test_attachment_module.py
+++ b/tests/unit/plugins/modules/test_attachment_module.py
@@ -14,7 +14,7 @@ import pytest
 from ansible_collections.servicenow.itsm.plugins.modules import attachment
 from ansible_collections.servicenow.itsm.plugins.module_utils import errors
 from ansible_collections.servicenow.itsm.plugins.module_utils.client import Response
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils._text import to_bytes
 
 pytestmark = pytest.mark.skipif(
     sys.version_info < (2, 7), reason="requires python2.7 or higher"
@@ -82,26 +82,16 @@ class TestRun:
             to_bytes("binary_data"),
             {"x-attachment-metadata": '{  "size_bytes" : "1000"}'},
         )
-
-        mocker.patch(
-            "ansible_collections.servicenow.itsm.plugins.modules.attachment.secure_hash_s"
-        ).return_value = "6e642bb8dd5c2e027bf21dd923337cbb4214f827"
-        mocker.patch(
-            "ansible_collections.servicenow.itsm.plugins.modules.attachment.secure_hash"
-        ).return_value = "6e642bb8dd5c2e027bf21dd923337cbb4214f828"
         mocker.patch(
             "ansible_collections.servicenow.itsm.plugins.modules.attachment.time.time"
         ).return_value = 0
-        # mocker.patch(
-        #     "ansible_collections.servicenow.itsm.plugins.modules.attachment.json.loads"
-        # ).return_value = {"size_bytes": "1000"}
 
         records = attachment.run(module, attachment_client)
 
         assert records == {
             "elapsed": 0.0,
-            "checksum_src": "6e642bb8dd5c2e027bf21dd923337cbb4214f827",
-            "checksum_dest": "6e642bb8dd5c2e027bf21dd923337cbb4214f828",
+            "checksum_src": "08d1d491223ab3d4460f6dbc0e1948f06adf74b7",
+            "checksum_dest": None,
             "size": 1000,
             "status_code": 200,
             "msg": "OK",
@@ -130,10 +120,6 @@ class TestRun:
             ),
             {"headers": "headers"},
         )
-        # mocker.patch(
-        #     "ansible_collections.servicenow.itsm.plugins.modules.attachment.json.loads"
-        # ).return_value = {"error": {"detail": "Record doesnt exist"}}
-        # could also patch response.json["error"]["detail"], but how can I do that?
 
         with pytest.raises(errors.ServiceNowError) as exc:
             attachment.run(module, attachment_client)

--- a/tests/unit/plugins/modules/test_attachment_module.py
+++ b/tests/unit/plugins/modules/test_attachment_module.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+# # Copyright: (c) 2022, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+
+import pytest
+
+from ansible_collections.servicenow.itsm.plugins.modules import attachment
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires python2.7 or higher"
+)
+
+
+class TestMain:
+    def test_minimal_set_of_params(self, run_main):
+        params = dict(
+            instance=dict(
+                host="https://my.host.name", username="user", password="pass"
+            ),
+        )
+        success, result = run_main(attachment, params)
+
+        assert success is True
+
+    def test_all_params(self, run_main):
+        params = dict(
+            instance=dict(
+                host="https://my.host.name", username="user", password="pass"
+            ),
+            sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
+        )
+        success, result = run_main(attachment, params)
+
+        assert success is True
+
+    def test_fail(self, run_main):
+        success, result = run_main(attachment)
+
+        assert success is False
+        #   assert "instance" in result["msg"]  ## REPLACE!
+
+
+# class TestRun:
+#     def test_run(self, create_module, table_client, attachment_client):
+#         module = create_module(
+#             params=dict(
+#                 instance=dict(
+#                     host="https://my.host.name", username="user", password="pass"
+#                 ),
+#                 sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
+#                 sys_class_name="cmdb_ci",
+#                 query=None,
+#             )
+#         )
+#         table_client.list_records.return_value = [
+#             dict(p=1, sys_id=1234),
+#             dict(q=2, sys_id=4321),
+#             dict(r=3, sys_id=1212),
+#         ]
+#         attachment_client.list_records.side_effect = [
+#             [
+#                 {
+#                     "content_type": "text/plain",
+#                     "file_name": "sample_file",
+#                     "table_name": "change_request",
+#                     "table_sys_id": 1234,
+#                     "sys_id": 4444,
+#                 },
+#             ],
+#             [],
+#             [],
+#         ]
+
+#         records = configuration_item_info.run(module, table_client, attachment_client)
+
+#         table_client.list_records.assert_called_once_with(
+#             "cmdb_ci", dict(sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3")
+#         )
+#         attachment_client.list_records.assert_any_call(
+#             {"table_name": "cmdb_ci", "table_sys_id": 1234}
+#         )
+#         attachment_client.list_records.assert_any_call(
+#             {"table_name": "cmdb_ci", "table_sys_id": 4321}
+#         )
+#         attachment_client.list_records.assert_any_call(
+#             {"table_name": "cmdb_ci", "table_sys_id": 1212}
+#         )
+#         assert attachment_client.list_records.call_count == 3
+#         assert records == [
+#             dict(
+#                 p=1,
+#                 sys_id=1234,
+#                 attachments=[
+#                     {
+#                         "content_type": "text/plain",
+#                         "file_name": "sample_file",
+#                         "table_name": "change_request",
+#                         "table_sys_id": 1234,
+#                         "sys_id": 4444,
+#                     },
+#                 ],
+#             ),
+#             dict(q=2, sys_id=4321, attachments=[]),
+#             dict(r=3, sys_id=1212, attachments=[]),
+#         ]
+
+
+
+
+
+
+# def test_get_attachment_404(self):
+#         # "msg": "Record doesn't exist or ACL restricts the record retrieval" 
+#         pass
+
+#     def test_get_attachment_unexpected_response(self):
+#         # "msg": "Unexpected response..." 
+#         pass
+
+#     def test_get_attachment_wrong_auth(self):
+#         # "msg": "Failed to authenticate with the instance: 401 Unauthorized" (from client.py _request())
+#         pass
+
+#     def test_get_attachment_wrong_host(self):
+#         # "msg": "[Errno -2] Name or service not known" (from client.py _request())
+#         pass

--- a/tests/unit/plugins/modules/test_attachment_module.py
+++ b/tests/unit/plugins/modules/test_attachment_module.py
@@ -85,10 +85,10 @@ class TestRun:
 
         mocker.patch(
             "ansible_collections.servicenow.itsm.plugins.modules.attachment.secure_hash_s"
-        ).return_value = 17
+        ).return_value = "6e642bb8dd5c2e027bf21dd923337cbb4214f827"
         mocker.patch(
             "ansible_collections.servicenow.itsm.plugins.modules.attachment.secure_hash"
-        ).return_value = 17
+        ).return_value = "6e642bb8dd5c2e027bf21dd923337cbb4214f828"
         mocker.patch(
             "ansible_collections.servicenow.itsm.plugins.modules.attachment.time.time"
         ).return_value = 0
@@ -99,10 +99,10 @@ class TestRun:
         records = attachment.run(module, attachment_client)
 
         assert records == {
-            "elapsed": "0.0",
-            "checksum_src": 17,
-            "checksum_dest": 17,
-            "size": "1000",
+            "elapsed": 0.0,
+            "checksum_src": "6e642bb8dd5c2e027bf21dd923337cbb4214f827",
+            "checksum_dest": "6e642bb8dd5c2e027bf21dd923337cbb4214f828",
+            "size": 1000,
             "status_code": 200,
             "msg": "OK",
         }

--- a/tests/unit/plugins/modules/test_attachment_module.py
+++ b/tests/unit/plugins/modules/test_attachment_module.py
@@ -125,4 +125,4 @@ class TestRun:
         with pytest.raises(errors.ServiceNowError) as exc:
             attachment.run(module, attachment_client)
         # could also patch response.json["error"]["detail"], but how can I do that?
-        assert str(exc.value).find("Status code: 404, Details: Record doesnt exist") != -1
+        assert "Status code: 404, Details: Record doesnt exist" in str(exc.value)

--- a/tests/unit/plugins/modules/test_attachment_module.py
+++ b/tests/unit/plugins/modules/test_attachment_module.py
@@ -106,7 +106,7 @@ class TestRun:
             to_bytes("binary_data"), "tmp"
         )
 
-    def test_run_404(self, create_module, attachment_client):
+    def test_run_404(self, create_module, attachment_client, mocker):
         module = create_module(
             params=dict(
                 instance=dict(
@@ -118,11 +118,11 @@ class TestRun:
         )
         attachment_client.get_attachment.return_value = Response(
             404,
-            {"error": {"detail": "Record doesn't exist or ACL restricts the record retrieval"}},
+            to_bytes('{\"error\":{\"message\":\"No Record found\",\"detail\":\"Record doesnt exist\"},\"status\":\"failure\"}'),
             {"headers": "headers"},
         )
 
         with pytest.raises(errors.ServiceNowError) as exc:
             attachment.run(module, attachment_client)
         # could also patch response.json["error"]["detail"], but how can I do that?
-        assert str(exc.value).find("Status code: 404, Details: Record doesn't exist") != -1
+        assert str(exc.value).find("Status code: 404, Details: Record doesnt exist") != -1

--- a/tests/unit/plugins/modules/test_attachment_module.py
+++ b/tests/unit/plugins/modules/test_attachment_module.py
@@ -80,14 +80,21 @@ class TestRun:
         attachment_client.get_attachment.return_value = Response(
             200,
             to_bytes("binary_data"),
-            {"x-attachment-metadata": "{  \"size_bytes\" : \"106879\"}"},
+            {"x-attachment-metadata": '{  "size_bytes" : "1000"}'},
         )
 
-        mocker.patch("ansible_collections.servicenow.itsm.plugins.modules.attachment.secure_hash_s").return_value = 17
-        mocker.patch("ansible_collections.servicenow.itsm.plugins.modules.attachment.secure_hash").return_value = 17
-        mocker.patch("ansible_collections.servicenow.itsm.plugins.modules.attachment.time.time").return_value = 0
-        # we don't need this anymore, but still, how can I patch json.loads?
-        #mocker.patch("ansible_collections.servicenow.itsm.plugins.modules.attachment.json.loads").return_value = 1000
+        mocker.patch(
+            "ansible_collections.servicenow.itsm.plugins.modules.attachment.secure_hash_s"
+        ).return_value = 17
+        mocker.patch(
+            "ansible_collections.servicenow.itsm.plugins.modules.attachment.secure_hash"
+        ).return_value = 17
+        mocker.patch(
+            "ansible_collections.servicenow.itsm.plugins.modules.attachment.time.time"
+        ).return_value = 0
+        # mocker.patch(
+        #     "ansible_collections.servicenow.itsm.plugins.modules.attachment.json.loads"
+        # ).return_value = {"size_bytes": "1000"}
 
         records = attachment.run(module, attachment_client)
 
@@ -95,7 +102,7 @@ class TestRun:
             "elapsed": "0.0",
             "checksum_src": 17,
             "checksum_dest": 17,
-            "size": "106879",
+            "size": "1000",
             "status_code": 200,
             "msg": "OK",
         }
@@ -118,11 +125,17 @@ class TestRun:
         )
         attachment_client.get_attachment.return_value = Response(
             404,
-            to_bytes('{\"error\":{\"message\":\"No Record found\",\"detail\":\"Record doesnt exist\"},\"status\":\"failure\"}'),
+            to_bytes(
+                '{"error":{"message":"No Record found","detail":"Record doesnt exist"},"status":"failure"}'
+            ),
             {"headers": "headers"},
         )
+        # mocker.patch(
+        #     "ansible_collections.servicenow.itsm.plugins.modules.attachment.json.loads"
+        # ).return_value = {"error": {"detail": "Record doesnt exist"}}
+        # could also patch response.json["error"]["detail"], but how can I do that?
 
         with pytest.raises(errors.ServiceNowError) as exc:
             attachment.run(module, attachment_client)
-        # could also patch response.json["error"]["detail"], but how can I do that?
+
         assert "Status code: 404, Details: Record doesnt exist" in str(exc.value)

--- a/tests/unit/plugins/modules/test_attachment_module.py
+++ b/tests/unit/plugins/modules/test_attachment_module.py
@@ -48,22 +48,15 @@ class TestMain:
 
 
 # class TestRun:
-#     def test_run(self, create_module, table_client, attachment_client):
+#     def test_run(self, create_module, attachment_client):
 #         module = create_module(
 #             params=dict(
 #                 instance=dict(
 #                     host="https://my.host.name", username="user", password="pass"
 #                 ),
 #                 sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
-#                 sys_class_name="cmdb_ci",
-#                 query=None,
 #             )
 #         )
-#         table_client.list_records.return_value = [
-#             dict(p=1, sys_id=1234),
-#             dict(q=2, sys_id=4321),
-#             dict(r=3, sys_id=1212),
-#         ]
 #         attachment_client.list_records.side_effect = [
 #             [
 #                 {
@@ -78,7 +71,7 @@ class TestMain:
 #             [],
 #         ]
 
-#         records = configuration_item_info.run(module, table_client, attachment_client)
+#         records = attachment.run(module, attachment_client)
 
 #         table_client.list_records.assert_called_once_with(
 #             "cmdb_ci", dict(sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3")


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1591

##### SUMMARY
A module that users can use to download attachments to specified file using attachment's sys_id.

Fixes #107 

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
Added:
- plugins/modules/attachment.py
- tests/unit/plugins/modules/test_attachment_module.py

Updated: 
- plugins/module_utils/attachment.py
- tests/unit/plugins/module_utils/test_attachment.py
- tests/integration/targets/attachment/tasks/main.yml
