### PR TITLE
Control sysparm_display_value behavior in *_info modules

### DIFF
--- a/changelogs/fragments/188_control_sysparm_display_value_in_info_modules.yml
+++ b/changelogs/fragments/188_control_sysparm_display_value_in_info_modules.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-- \*_info modules - Added additional field sysparm_query, which enables the user to see sys_tags if set to true.
+- \*_info modules - Added additional module parameter sysparm_display_value to all info modules, which, if set to either true or all, enables the user to see the values of sys_tags.

--- a/changelogs/fragments/188_control_sysparm_display_value_in_info_modules.yml
+++ b/changelogs/fragments/188_control_sysparm_display_value_in_info_modules.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- \*_info modules - Added additional field sysparm_query, which enables the user to see sys_tags if set to true.

--- a/plugins/doc_fragments/sysparm_display_value.py
+++ b/plugins/doc_fragments/sysparm_display_value.py
@@ -13,8 +13,9 @@ class ModuleDocFragment(object):
 options:
   sysparm_display_value:
     description:
-      - Return field display values C(true), actual values C(false), or both C(all). Added in version 2.0.0.
+      - Return field display values C(true), actual values C(false), or both C(all).
     type: str
     choices: ["true", "false", "all"]
     default: 'false'
+    version_added: '2.0.0'
 """

--- a/plugins/doc_fragments/sysparm_display_value.py
+++ b/plugins/doc_fragments/sysparm_display_value.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2022, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+class ModuleDocFragment(object):
+    DOCUMENTATION = r"""
+options:
+  sysparm_display_value:
+    description:
+      - "Return field display values (true), actual values (false), or both (all) (default: false)."
+    type: str
+    choices: ["true", "false", "all"]
+    default: 'false'
+"""

--- a/plugins/doc_fragments/sysparm_display_value.py
+++ b/plugins/doc_fragments/sysparm_display_value.py
@@ -13,7 +13,7 @@ class ModuleDocFragment(object):
 options:
   sysparm_display_value:
     description:
-      - "Return field display values (true), actual values (false), or both (all) (default: false)."
+      - Return field display values C(true), actual values C(false), or both C(all). Added in version 2.0.0.
     type: str
     choices: ["true", "false", "all"]
     default: 'false'

--- a/plugins/module_utils/arguments.py
+++ b/plugins/module_utils/arguments.py
@@ -143,12 +143,22 @@ SHARED_SPECS = dict(
             ),
         ),
     ),
+    field_display_value=dict(
+        type="str",
+        choices=[
+            "true",
+            "false",
+            "all",
+        ],
+        default="false",
+    ),
     incident_mapping=INCIDENT_MAPPING_SPEC,
     change_request_mapping=CHANGE_REQUEST_MAPPING_SPEC,
     change_request_task_mapping=CHANGE_REQUEST_TASK_MAPPING_SPEC,
     configuration_item_mapping=CONFIGURATION_ITEM_MAPPING_SPEC,
     problem_mapping=PROBLEM_MAPPING_SPEC,
     problem_task_mapping=PROBLEM_TASK_MAPPING_SPEC,
+
 )
 
 

--- a/plugins/module_utils/arguments.py
+++ b/plugins/module_utils/arguments.py
@@ -143,7 +143,7 @@ SHARED_SPECS = dict(
             ),
         ),
     ),
-    field_display_value=dict(
+    sysparm_display_value=dict(
         type="str",
         choices=[
             "true",

--- a/plugins/module_utils/arguments.py
+++ b/plugins/module_utils/arguments.py
@@ -158,7 +158,6 @@ SHARED_SPECS = dict(
     configuration_item_mapping=CONFIGURATION_ITEM_MAPPING_SPEC,
     problem_mapping=PROBLEM_MAPPING_SPEC,
     problem_task_mapping=PROBLEM_TASK_MAPPING_SPEC,
-
 )
 
 

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -42,14 +42,14 @@ def get_choices(module, mapping_field, default_payload_fields_mapping):
     return clone
 
 
-def get_mapper(module, mapping_field, default_payload_fields_mapping):
+def get_mapper(module, mapping_field, default_payload_fields_mapping, field_display_value="false"):
     choices = get_choices(module, mapping_field, default_payload_fields_mapping)
-    mapper = PayloadMapper(choices, module.warn)
+    mapper = PayloadMapper(choices, module.warn, field_display_value)
     return mapper
 
 
 class PayloadMapper:
-    def __init__(self, mapping, unknown_value_handler=None):
+    def __init__(self, mapping, unknown_value_handler=None, field_display_value="false"):
         # Convert
         #   dict(a=[("s1", "a1"), ("s2", "a2")], b=[("s3", "a3")])
         # to
@@ -62,6 +62,7 @@ class PayloadMapper:
         self._to_ansible = {}
         self._to_snow = {}
         self.unknown_value_handler = unknown_value_handler
+        self.field_display_value = field_display_value
 
         for key, value_map in mapping.items():
             if isinstance(value_map, dict):
@@ -98,7 +99,15 @@ class PayloadMapper:
         return result
 
     def to_ansible(self, snow_data):
+        # If field_display_value is set to "true" or "all", no need to transform as field display values are already
+        # returned.
+        if self.field_display_value != "false":  # is equal to either "all" or "true"
+            return snow_data
         return self._transform(self._to_ansible, snow_data)
 
     def to_snow(self, ansible_data):
+        # If field_display_value is set to "true" or "all", no need to transform as field display values are already
+        # returned.
+        if self.field_display_value != "false":  # is equal to either "all" or "true"
+            return ansible_data
         return self._transform(self._to_snow, ansible_data)

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -42,14 +42,14 @@ def get_choices(module, mapping_field, default_payload_fields_mapping):
     return clone
 
 
-def get_mapper(module, mapping_field, default_payload_fields_mapping, field_display_value="false"):
+def get_mapper(module, mapping_field, default_payload_fields_mapping, sysparm_display_value="false"):
     choices = get_choices(module, mapping_field, default_payload_fields_mapping)
-    mapper = PayloadMapper(choices, module.warn, field_display_value)
+    mapper = PayloadMapper(choices, module.warn, sysparm_display_value)
     return mapper
 
 
 class PayloadMapper:
-    def __init__(self, mapping, unknown_value_handler=None, field_display_value="false"):
+    def __init__(self, mapping, unknown_value_handler=None, sysparm_display_value="false"):
         # Convert
         #   dict(a=[("s1", "a1"), ("s2", "a2")], b=[("s3", "a3")])
         # to
@@ -62,7 +62,7 @@ class PayloadMapper:
         self._to_ansible = {}
         self._to_snow = {}
         self.unknown_value_handler = unknown_value_handler
-        self.field_display_value = field_display_value
+        self.sysparm_display_value = sysparm_display_value
 
         for key, value_map in mapping.items():
             if isinstance(value_map, dict):
@@ -99,15 +99,15 @@ class PayloadMapper:
         return result
 
     def to_ansible(self, snow_data):
-        # If field_display_value is set to "true" or "all", no need to transform as field display values are already
+        # If sysparm_display_value is set to "true" or "all", no need to transform as field display values are already
         # returned.
-        if self.field_display_value != "false":  # is equal to either "all" or "true"
+        if self.sysparm_display_value != "false":  # is equal to either "all" or "true"
             return snow_data
         return self._transform(self._to_ansible, snow_data)
 
     def to_snow(self, ansible_data):
-        # If field_display_value is set to "true" or "all", no need to transform as field display values are already
+        # If sysparm_display_value is set to "true" or "all", no need to transform as field display values are already
         # returned.
-        if self.field_display_value != "false":  # is equal to either "all" or "true"
+        if self.sysparm_display_value != "false":  # is equal to either "all" or "true"
             return ansible_data
         return self._transform(self._to_snow, ansible_data)

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -42,14 +42,18 @@ def get_choices(module, mapping_field, default_payload_fields_mapping):
     return clone
 
 
-def get_mapper(module, mapping_field, default_payload_fields_mapping, sysparm_display_value="false"):
+def get_mapper(
+    module, mapping_field, default_payload_fields_mapping, sysparm_display_value="false"
+):
     choices = get_choices(module, mapping_field, default_payload_fields_mapping)
     mapper = PayloadMapper(choices, module.warn, sysparm_display_value)
     return mapper
 
 
 class PayloadMapper:
-    def __init__(self, mapping, unknown_value_handler=None, sysparm_display_value="false"):
+    def __init__(
+        self, mapping, unknown_value_handler=None, sysparm_display_value="false"
+    ):
         # Convert
         #   dict(a=[("s1", "a1"), ("s2", "a2")], b=[("s3", "a3")])
         # to

--- a/plugins/modules/change_request_info.py
+++ b/plugins/modules/change_request_info.py
@@ -252,12 +252,19 @@ def sysparms_query(module, table_client, mapper):
 
 
 def run(module, table_client, attachment_client):
-    mapper = get_mapper(module, "change_request_mapping", PAYLOAD_FIELDS_MAPPING)
+    mapper = get_mapper(
+        module, "change_request_mapping",
+        PAYLOAD_FIELDS_MAPPING,
+        sysparm_display_value=module.params["sysparm_display_value"],
+    )
 
     if module.params["query"]:
-        query = {"sysparm_query": sysparms_query(module, table_client, mapper)}
+        query = {
+            "sysparm_query": sysparms_query(module, table_client, mapper),
+            "sysparm_display_value": module.params["sysparm_display_value"],
+        }
     else:
-        query = utils.filter_dict(module.params, "sys_id", "number")
+        query = utils.filter_dict(module.params, "sys_id", "number", "sysparm_display_value")
 
     return [
         dict(
@@ -275,7 +282,7 @@ def main():
         supports_check_mode=True,
         argument_spec=dict(
             arguments.get_spec(
-                "instance", "sys_id", "number", "query", "change_request_mapping"
+                "instance", "sys_id", "number", "query", "change_request_mapping", "sysparm_display_value",
             ),
         ),
         mutually_exclusive=[("sys_id", "query"), ("number", "query")],

--- a/plugins/modules/change_request_info.py
+++ b/plugins/modules/change_request_info.py
@@ -30,6 +30,7 @@ extends_documentation_fragment:
   - servicenow.itsm.number.info
   - servicenow.itsm.query
   - servicenow.itsm.change_request_mapping
+  - servicenow.itsm.sysparm_display_value
 seealso:
   - module: servicenow.itsm.change_request
 """

--- a/plugins/modules/change_request_info.py
+++ b/plugins/modules/change_request_info.py
@@ -253,7 +253,8 @@ def sysparms_query(module, table_client, mapper):
 
 def run(module, table_client, attachment_client):
     mapper = get_mapper(
-        module, "change_request_mapping",
+        module,
+        "change_request_mapping",
         PAYLOAD_FIELDS_MAPPING,
         sysparm_display_value=module.params["sysparm_display_value"],
     )
@@ -264,7 +265,9 @@ def run(module, table_client, attachment_client):
             "sysparm_display_value": module.params["sysparm_display_value"],
         }
     else:
-        query = utils.filter_dict(module.params, "sys_id", "number", "sysparm_display_value")
+        query = utils.filter_dict(
+            module.params, "sys_id", "number", "sysparm_display_value"
+        )
 
     return [
         dict(
@@ -282,7 +285,12 @@ def main():
         supports_check_mode=True,
         argument_spec=dict(
             arguments.get_spec(
-                "instance", "sys_id", "number", "query", "change_request_mapping", "sysparm_display_value",
+                "instance",
+                "sys_id",
+                "number",
+                "query",
+                "change_request_mapping",
+                "sysparm_display_value",
             ),
         ),
         mutually_exclusive=[("sys_id", "query"), ("number", "query")],

--- a/plugins/modules/change_request_task_info.py
+++ b/plugins/modules/change_request_task_info.py
@@ -222,8 +222,6 @@ def run(module, table_client):
     else:
         query = utils.filter_dict(module.params, "sys_id", "number", "sysparm_display_value")
 
-    # raise errors.ServiceNowError(query)  # table_client.list_records("change_task", query))
-
     return [
         mapper.to_ansible(record)
         for record in table_client.list_records("change_task", query)

--- a/plugins/modules/change_request_task_info.py
+++ b/plugins/modules/change_request_task_info.py
@@ -220,7 +220,9 @@ def run(module, table_client):
             "sysparm_display_value": module.params["sysparm_display_value"],
         }
     else:
-        query = utils.filter_dict(module.params, "sys_id", "number", "sysparm_display_value")
+        query = utils.filter_dict(
+            module.params, "sys_id", "number", "sysparm_display_value"
+        )
 
     return [
         mapper.to_ansible(record)
@@ -233,7 +235,12 @@ def main():
         supports_check_mode=True,
         argument_spec=dict(
             arguments.get_spec(
-                "instance", "sys_id", "number", "query", "change_request_task_mapping", "sysparm_display_value"
+                "instance",
+                "sys_id",
+                "number",
+                "query",
+                "change_request_task_mapping",
+                "sysparm_display_value",
             ),
         ),
         mutually_exclusive=[("sys_id", "query"), ("number", "query")],

--- a/plugins/modules/change_request_task_info.py
+++ b/plugins/modules/change_request_task_info.py
@@ -207,12 +207,22 @@ def sysparms_query(module, table_client, mapper):
 
 
 def run(module, table_client):
-    mapper = get_mapper(module, "change_request_task_mapping", PAYLOAD_FIELDS_MAPPING)
+    mapper = get_mapper(
+        module,
+        "change_request_task_mapping",
+        PAYLOAD_FIELDS_MAPPING,
+        sysparm_display_value=module.params["sysparm_display_value"],
+    )
 
     if module.params["query"]:
-        query = {"sysparm_query": sysparms_query(module, table_client, mapper)}
+        query = {
+            "sysparm_query": sysparms_query(module, table_client, mapper),
+            "sysparm_display_value": module.params["sysparm_display_value"],
+        }
     else:
-        query = utils.filter_dict(module.params, "sys_id", "number")
+        query = utils.filter_dict(module.params, "sys_id", "number", "sysparm_display_value")
+
+    # raise errors.ServiceNowError(query)  # table_client.list_records("change_task", query))
 
     return [
         mapper.to_ansible(record)
@@ -225,7 +235,7 @@ def main():
         supports_check_mode=True,
         argument_spec=dict(
             arguments.get_spec(
-                "instance", "sys_id", "number", "query", "change_request_task_mapping"
+                "instance", "sys_id", "number", "query", "change_request_task_mapping", "sysparm_display_value"
             ),
         ),
         mutually_exclusive=[("sys_id", "query"), ("number", "query")],

--- a/plugins/modules/change_request_task_info.py
+++ b/plugins/modules/change_request_task_info.py
@@ -28,6 +28,7 @@ extends_documentation_fragment:
   - servicenow.itsm.number.info
   - servicenow.itsm.query
   - servicenow.itsm.change_request_task_mapping
+  - servicenow.itsm.sysparm_display_value
 seealso:
   - module: servicenow.itsm.change_request_task
 """

--- a/plugins/modules/configuration_item_info.py
+++ b/plugins/modules/configuration_item_info.py
@@ -251,7 +251,11 @@ def main():
         supports_check_mode=True,
         argument_spec=dict(
             arguments.get_spec(
-                "instance", "sys_id", "query", "configuration_item_mapping", "sysparm_display_value",
+                "instance",
+                "sys_id",
+                "query",
+                "configuration_item_mapping",
+                "sysparm_display_value",
             ),
             sys_class_name=dict(
                 type="str",

--- a/plugins/modules/configuration_item_info.py
+++ b/plugins/modules/configuration_item_info.py
@@ -31,9 +31,10 @@ extends_documentation_fragment:
   - servicenow.itsm.sys_id.info
   - servicenow.itsm.query
   - servicenow.itsm.configuration_item_mapping
+  - servicenow.itsm.sysparm_display_value
 seealso:
   - module: servicenow.itsm.configuration_item
-x
+
 options:
   sys_class_name:
     description:

--- a/plugins/modules/configuration_item_info.py
+++ b/plugins/modules/configuration_item_info.py
@@ -33,7 +33,7 @@ extends_documentation_fragment:
   - servicenow.itsm.configuration_item_mapping
 seealso:
   - module: servicenow.itsm.configuration_item
-
+x
 options:
   sys_class_name:
     description:
@@ -220,12 +220,20 @@ def sysparms_query(module, table_client, mapper):
 
 def run(module, table_client, attachment_client):
     cmdb_table = module.params["sys_class_name"] or "cmdb_ci"
-    mapper = get_mapper(module, "configuration_item_mapping", PAYLOAD_FIELDS_MAPPING)
+    mapper = get_mapper(
+        module,
+        "configuration_item_mapping",
+        PAYLOAD_FIELDS_MAPPING,
+        sysparm_display_value=module.params["sysparm_display_value"],
+    )
 
     if module.params["query"]:
-        query = {"sysparm_query": sysparms_query(module, table_client, mapper)}
+        query = {
+            "sysparm_query": sysparms_query(module, table_client, mapper),
+            "sysparm_display_value": module.params["sysparm_display_value"],
+        }
     else:
-        query = utils.filter_dict(module.params, "sys_id")
+        query = utils.filter_dict(module.params, "sys_id", "sysparm_display_value")
 
     return [
         dict(
@@ -243,7 +251,7 @@ def main():
         supports_check_mode=True,
         argument_spec=dict(
             arguments.get_spec(
-                "instance", "sys_id", "query", "configuration_item_mapping"
+                "instance", "sys_id", "query", "configuration_item_mapping", "sysparm_display_value",
             ),
             sys_class_name=dict(
                 type="str",

--- a/plugins/modules/incident_info.py
+++ b/plugins/modules/incident_info.py
@@ -217,14 +217,20 @@ def sysparms_query(module, table_client, mapper):
 
 
 def run(module, table_client, attachment_client):
-    mapper = get_mapper(module, "incident_mapping", PAYLOAD_FIELDS_MAPPING)
+    mapper = get_mapper(
+        module, "incident_mapping", PAYLOAD_FIELDS_MAPPING, sysparm_display_value=module.params["sysparm_display_value"]
+    )
 
     if module.params["query"]:
-        query = {"sysparm_query": sysparms_query(module, table_client, mapper)}
+        query = {
+            "sysparm_query": sysparms_query(module, table_client, mapper),
+            "sysparm_display_value": module.params["sysparm_display_value"],
+        }
     else:
-        query = utils.filter_dict(module.params, "sys_id", "number")
+        query = utils.filter_dict(module.params, "sys_id", "number", "sysparm_display_value")
 
     records = table_client.list_records("incident", query)
+
     result = [
         dict(
             mapper.to_ansible(record),
@@ -242,7 +248,7 @@ def main():
         supports_check_mode=True,
         argument_spec=dict(
             arguments.get_spec(
-                "instance", "sys_id", "number", "query", "incident_mapping"
+                "instance", "sys_id", "number", "query", "incident_mapping", "sysparm_display_value",
             ),
         ),
         mutually_exclusive=[("sys_id", "query"), ("number", "query")],

--- a/plugins/modules/incident_info.py
+++ b/plugins/modules/incident_info.py
@@ -218,7 +218,10 @@ def sysparms_query(module, table_client, mapper):
 
 def run(module, table_client, attachment_client):
     mapper = get_mapper(
-        module, "incident_mapping", PAYLOAD_FIELDS_MAPPING, sysparm_display_value=module.params["sysparm_display_value"]
+        module,
+        "incident_mapping",
+        PAYLOAD_FIELDS_MAPPING,
+        sysparm_display_value=module.params["sysparm_display_value"],
     )
 
     if module.params["query"]:
@@ -227,7 +230,9 @@ def run(module, table_client, attachment_client):
             "sysparm_display_value": module.params["sysparm_display_value"],
         }
     else:
-        query = utils.filter_dict(module.params, "sys_id", "number", "sysparm_display_value")
+        query = utils.filter_dict(
+            module.params, "sys_id", "number", "sysparm_display_value"
+        )
 
     records = table_client.list_records("incident", query)
 
@@ -248,7 +253,12 @@ def main():
         supports_check_mode=True,
         argument_spec=dict(
             arguments.get_spec(
-                "instance", "sys_id", "number", "query", "incident_mapping", "sysparm_display_value",
+                "instance",
+                "sys_id",
+                "number",
+                "query",
+                "incident_mapping",
+                "sysparm_display_value",
             ),
         ),
         mutually_exclusive=[("sys_id", "query"), ("number", "query")],

--- a/plugins/modules/incident_info.py
+++ b/plugins/modules/incident_info.py
@@ -29,6 +29,7 @@ extends_documentation_fragment:
   - servicenow.itsm.number.info
   - servicenow.itsm.query
   - servicenow.itsm.incident_mapping
+  - servicenow.itsm.sysparm_display_value
 seealso:
   - module: servicenow.itsm.incident
 """

--- a/plugins/modules/problem_info.py
+++ b/plugins/modules/problem_info.py
@@ -231,12 +231,20 @@ def sysparms_query(module, table_client, mapper):
 
 
 def run(module, table_client, attachment_client):
-    mapper = get_mapper(module, "problem_mapping", PAYLOAD_FIELDS_MAPPING)
+    mapper = get_mapper(
+        module,
+        "problem_mapping",
+        PAYLOAD_FIELDS_MAPPING,
+        sysparm_display_value=module.params["sysparm_display_value"],
+    )
 
     if module.params["query"]:
-        query = {"sysparm_query": sysparms_query(module, table_client, mapper)}
+        query = {
+            "sysparm_query": sysparms_query(module, table_client, mapper),
+            "sysparm_display_value": module.params["sysparm_display_value"],
+        }
     else:
-        query = utils.filter_dict(module.params, "sys_id", "number")
+        query = utils.filter_dict(module.params, "sys_id", "number", "sysparm_display_value")
 
     return [
         dict(
@@ -253,7 +261,7 @@ def main():
     module = AnsibleModule(
         supports_check_mode=True,
         argument_spec=dict(
-            arguments.get_spec("instance", "sys_id", "number", "query"),
+            arguments.get_spec("instance", "sys_id", "number", "query", "sysparm_display_value"),
         ),
         mutually_exclusive=[("sys_id", "query"), ("number", "query")],
     )

--- a/plugins/modules/problem_info.py
+++ b/plugins/modules/problem_info.py
@@ -28,6 +28,7 @@ extends_documentation_fragment:
   - servicenow.itsm.sys_id.info
   - servicenow.itsm.number.info
   - servicenow.itsm.query
+  - servicenow.itsm.sysparm_display_value
 seealso:
   - module: servicenow.itsm.problem
   - module: servicenow.itsm.problem_task

--- a/plugins/modules/problem_info.py
+++ b/plugins/modules/problem_info.py
@@ -244,7 +244,9 @@ def run(module, table_client, attachment_client):
             "sysparm_display_value": module.params["sysparm_display_value"],
         }
     else:
-        query = utils.filter_dict(module.params, "sys_id", "number", "sysparm_display_value")
+        query = utils.filter_dict(
+            module.params, "sys_id", "number", "sysparm_display_value"
+        )
 
     return [
         dict(
@@ -261,7 +263,9 @@ def main():
     module = AnsibleModule(
         supports_check_mode=True,
         argument_spec=dict(
-            arguments.get_spec("instance", "sys_id", "number", "query", "sysparm_display_value"),
+            arguments.get_spec(
+                "instance", "sys_id", "number", "query", "sysparm_display_value"
+            ),
         ),
         mutually_exclusive=[("sys_id", "query"), ("number", "query")],
     )

--- a/plugins/modules/problem_task_info.py
+++ b/plugins/modules/problem_task_info.py
@@ -27,6 +27,7 @@ extends_documentation_fragment:
   - servicenow.itsm.sys_id.info
   - servicenow.itsm.number.info
   - servicenow.itsm.query
+  - servicenow.itsm.sysparm_display_value
 seealso:
   - module: servicenow.itsm.problem_task
   - module: servicenow.itsm.problem

--- a/plugins/modules/problem_task_info.py
+++ b/plugins/modules/problem_task_info.py
@@ -209,7 +209,9 @@ def run(module, table_client):
             "sysparm_display_value": module.params["sysparm_display_value"],
         }
     else:
-        query = utils.filter_dict(module.params, "sys_id", "number", "sysparm_display_value")
+        query = utils.filter_dict(
+            module.params, "sys_id", "number", "sysparm_display_value"
+        )
 
     return [
         mapper.to_ansible(record)
@@ -221,7 +223,9 @@ def main():
     module = AnsibleModule(
         supports_check_mode=True,
         argument_spec=dict(
-            arguments.get_spec("instance", "sys_id", "number", "query", "sysparm_display_value"),
+            arguments.get_spec(
+                "instance", "sys_id", "number", "query", "sysparm_display_value"
+            ),
         ),
         mutually_exclusive=[("sys_id", "query"), ("number", "query")],
     )

--- a/plugins/modules/problem_task_info.py
+++ b/plugins/modules/problem_task_info.py
@@ -196,12 +196,20 @@ def sysparms_query(module, table_client, mapper):
 
 
 def run(module, table_client):
-    mapper = get_mapper(module, "problem_task_mapping", PAYLOAD_FIELDS_MAPPING)
+    mapper = get_mapper(
+        module,
+        "problem_task_mapping",
+        PAYLOAD_FIELDS_MAPPING,
+        sysparm_display_value=module.params["sysparm_display_value"],
+    )
 
     if module.params["query"]:
-        query = {"sysparm_query": sysparms_query(module, table_client, mapper)}
+        query = {
+            "sysparm_query": sysparms_query(module, table_client, mapper),
+            "sysparm_display_value": module.params["sysparm_display_value"],
+        }
     else:
-        query = utils.filter_dict(module.params, "sys_id", "number")
+        query = utils.filter_dict(module.params, "sys_id", "number", "sysparm_display_value")
 
     return [
         mapper.to_ansible(record)
@@ -213,7 +221,7 @@ def main():
     module = AnsibleModule(
         supports_check_mode=True,
         argument_spec=dict(
-            arguments.get_spec("instance", "sys_id", "number", "query"),
+            arguments.get_spec("instance", "sys_id", "number", "query", "sysparm_display_value"),
         ),
         mutually_exclusive=[("sys_id", "query"), ("number", "query")],
     )

--- a/tests/unit/plugins/modules/test_change_request_info.py
+++ b/tests/unit/plugins/modules/test_change_request_info.py
@@ -91,6 +91,7 @@ class TestRun:
                 sys_id=None,
                 number="n",
                 query=None,
+                sysparm_display_value="true",
             )
         )
         table_client.list_records.return_value = [
@@ -117,7 +118,7 @@ class TestRun:
         )
 
         table_client.list_records.assert_called_once_with(
-            "change_request", dict(number="n")
+            "change_request", dict(number="n", sysparm_display_value="true")
         )
 
         attachment_client.list_records.assert_any_call(

--- a/tests/unit/plugins/modules/test_change_request_task_info.py
+++ b/tests/unit/plugins/modules/test_change_request_task_info.py
@@ -118,6 +118,7 @@ class TestRun:
                 sys_id=None,
                 number="n",
                 query=None,
+                sysparm_display_value="true",
             )
         )
         table_client.list_records.return_value = [dict(p=1), dict(q=2), dict(r=3)]
@@ -125,6 +126,6 @@ class TestRun:
         change_requests = change_request_task_info.run(module, table_client)
 
         table_client.list_records.assert_called_once_with(
-            "change_task", dict(number="n")
+            "change_task", dict(number="n", sysparm_display_value="true")
         )
         assert change_requests == [dict(p=1), dict(q=2), dict(r=3)]

--- a/tests/unit/plugins/modules/test_configuration_item_info.py
+++ b/tests/unit/plugins/modules/test_configuration_item_info.py
@@ -80,6 +80,7 @@ class TestRun:
                 sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
                 sys_class_name="cmdb_ci",
                 query=None,
+                sysparm_display_value="true",
             )
         )
         table_client.list_records.return_value = [
@@ -104,7 +105,10 @@ class TestRun:
         records = configuration_item_info.run(module, table_client, attachment_client)
 
         table_client.list_records.assert_called_once_with(
-            "cmdb_ci", dict(sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3")
+            "cmdb_ci",
+            dict(
+                sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3", sysparm_display_value="true"
+            ),
         )
         attachment_client.list_records.assert_any_call(
             {"table_name": "cmdb_ci", "table_sys_id": 1234}

--- a/tests/unit/plugins/modules/test_incident_info.py
+++ b/tests/unit/plugins/modules/test_incident_info.py
@@ -75,6 +75,7 @@ class TestRun:
                 sys_id=None,
                 number="INC001",
                 query=None,
+                sysparm_display_value="true",
             )
         )
         table_client.list_records.return_value = [
@@ -99,7 +100,7 @@ class TestRun:
         records = incident_info.run(module, table_client, attachment_client)
 
         table_client.list_records.assert_called_once_with(
-            "incident", dict(number="INC001")
+            "incident", dict(number="INC001", sysparm_display_value="true")
         )
 
         attachment_client.list_records.assert_any_call(

--- a/tests/unit/plugins/modules/test_problem_info.py
+++ b/tests/unit/plugins/modules/test_problem_info.py
@@ -79,6 +79,7 @@ class TestRun:
                 sys_id=None,
                 number="n",
                 query=None,
+                sysparm_display_value="true",
             )
         )
         table_client.list_records.return_value = [
@@ -102,7 +103,9 @@ class TestRun:
 
         problems = problem_info.run(module, table_client, attachment_client)
 
-        table_client.list_records.assert_called_once_with("problem", dict(number="n"))
+        table_client.list_records.assert_called_once_with(
+            "problem", dict(number="n", sysparm_display_value="true")
+        )
         attachment_client.list_records.assert_any_call(
             {"table_name": "problem", "table_sys_id": 1234}
         )

--- a/tests/unit/plugins/modules/test_problem_task_info.py
+++ b/tests/unit/plugins/modules/test_problem_task_info.py
@@ -79,6 +79,7 @@ class TestRun:
                 sys_id=None,
                 number="n",
                 query=None,
+                sysparm_display_value="true",
             )
         )
         table_client.list_records.return_value = [dict(p=1), dict(q=2), dict(r=3)]
@@ -86,6 +87,6 @@ class TestRun:
         problems = problem_task_info.run(module, table_client)
 
         table_client.list_records.assert_called_once_with(
-            "problem_task", dict(number="n")
+            "problem_task", dict(number="n", sysparm_display_value="true")
         )
         assert problems == [dict(p=1), dict(q=2), dict(r=3)]


### PR DESCRIPTION
##### SUMMARY
This PR resolves #155 by providing additional module parameter `sysparm_display_value` to all "`*_info`" modules. 

For detailed description on why `sysparm_display_value` is needed, please refer to https://github.com/ansible-collections/servicenow.itsm/issues/155#issuecomment-1190992547. Also, [ServiceNow's docs regarding sysparm_display_value](https://docs.servicenow.com/en-US/bundle/sandiego-platform-administration/page/administer/exporting-data/concept/query-parameters-display-value.html) is relevant to understand how the query if changed if setting this attribute to either `true`, `false` or `all`.

Also, changes in `PayloadMapper` were made by adding additional field `sysparm_display_value`, which, if set to either `true` or `all`, does not use mapper as mapper basically maps ServiceNow numbers to explanations what they mean in words. This is already done via display value.

After this PR, `sys_tags` may be seen by setting value of `sysparm_display_value` to either `true` or `all`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`*_info` modules.

##### ADDITIONAL INFORMATION
This resolves https://github.com/ansible-collections/servicenow.itsm/issues/155.
