### PR TITLE
Enhance `servicenow.itsm.now` and `servicenow.itsm.*_info` modules by adding alternative way to filter out the results

### DIFF
--- a/changelogs/fragments/190_add_alternative_way_to_filter_results.yml
+++ b/changelogs/fragments/190_add_alternative_way_to_filter_results.yml
@@ -1,4 +1,4 @@
 ---
 minor_changes:
 - \*_info modules - Added field sysparm_query, which represents an encoded query string used to filter the results as an alternative to C(query) (https://github.com/ansible-collections/servicenow.itsm/pull/190).
-- now - Added field sysparm_query, which represents an encoded query string used to filter the results as an alternative to C(query).
+- now - Added field sysparm_query, which represents an encoded query string used to filter the results as an alternative to C(query) (https://github.com/ansible-collections/servicenow.itsm/pull/190).

--- a/changelogs/fragments/190_add_alternative_way_to_filter_results.yml
+++ b/changelogs/fragments/190_add_alternative_way_to_filter_results.yml
@@ -1,4 +1,4 @@
 ---
 minor_changes:
-- \*_info modules - Added field sysparm_query, which represents an encoded query string used to filter the results as an alternative to C(query).
+- \*_info modules - Added field sysparm_query, which represents an encoded query string used to filter the results as an alternative to C(query) (https://github.com/ansible-collections/servicenow.itsm/pull/190).
 - now - Added field sysparm_query, which represents an encoded query string used to filter the results as an alternative to C(query).

--- a/changelogs/fragments/190_add_alternative_way_to_filter_results.yml
+++ b/changelogs/fragments/190_add_alternative_way_to_filter_results.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+- \*_info modules - Added field sysparm_query, which represents an encoded query string used to filter the results as an alternative to C(query).
+- now - Added field sysparm_query, which represents an encoded query string used to filter the results as an alternative to C(query).

--- a/plugins/doc_fragments/query.py
+++ b/plugins/doc_fragments/query.py
@@ -25,7 +25,7 @@ options:
       - An encoded query string used to filter the results as an alternative to C(query).
       - Refer to the ServiceNow Available Filters Queries documentation at
         U(https://docs.servicenow.com/bundle/quebec-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html).
-      - If not set, the value of the C(SN_FILTER_RESULTS) environment, if specified.
+      - If not set, the value of the C(SN_SYSPARM_QUERY) environment, if specified.
       - Mutually exclusive with C(query).
     type: str
 """

--- a/plugins/doc_fragments/query.py
+++ b/plugins/doc_fragments/query.py
@@ -25,7 +25,7 @@ options:
       - An encoded query string used to filter the results. as an alternative to C(query).
       - Refer to the ServiceNow Available Filters Queries documentation at
         U(https://docs.servicenow.com/bundle/quebec-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html).
-      - If not set, the value of the C(SN_FILTER_RESULTS) environment, if specified. 
+      - If not set, the value of the C(SN_FILTER_RESULTS) environment, if specified.
       - Mutually exclusive with C(query).
     type: str
 """

--- a/plugins/doc_fragments/query.py
+++ b/plugins/doc_fragments/query.py
@@ -28,4 +28,5 @@ options:
       - If not set, the value of the C(SN_SYSPARM_QUERY) environment, if specified.
       - Mutually exclusive with C(query).
     type: str
+    version_added: 2.0.0
 """

--- a/plugins/doc_fragments/query.py
+++ b/plugins/doc_fragments/query.py
@@ -17,6 +17,15 @@ options:
       - The data type of a field determines what operators are available for it.
         Refer to the ServiceNow Available Filters Queries documentation at
         U(https://docs.servicenow.com/bundle/quebec-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html).
+      - Mutually exclusive with C(sysparm_query).
     type: list
     elements: dict
+  sysparm_query:
+    description:
+      - An encoded query string used to filter the results. as an alternative to C(query).
+      - Refer to the ServiceNow Available Filters Queries documentation at
+        U(https://docs.servicenow.com/bundle/quebec-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html).
+      - If not set, the value of the C(SN_FILTER_RESULTS) environment, if specified. 
+      - Mutually exclusive with C(query).
+    type: str
 """

--- a/plugins/doc_fragments/query.py
+++ b/plugins/doc_fragments/query.py
@@ -22,7 +22,7 @@ options:
     elements: dict
   sysparm_query:
     description:
-      - An encoded query string used to filter the results. as an alternative to C(query).
+      - An encoded query string used to filter the results as an alternative to C(query).
       - Refer to the ServiceNow Available Filters Queries documentation at
         U(https://docs.servicenow.com/bundle/quebec-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html).
       - If not set, the value of the C(SN_FILTER_RESULTS) environment, if specified.

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -721,12 +721,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 "exclusive."
             )
 
+        # TODO: Insert caching here once we remove deprecated functionality
         if sysparm_query:
             records = fetch_records(table_client, table, query, raw_input=True)
         else:
             records = fetch_records(table_client, table, query)
 
-        # TODO: Insert caching here once we remove deprecated functionality
         if enhanced:
             rel_records = fetch_records(
                 table_client, REL_TABLE, REL_QUERY, fields=REL_FIELDS

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -453,14 +453,16 @@ def construct_sysparm_query(query):
     return serialize_query(parsed)
 
 
-def fetch_records(table_client, table, query, fields=None):
+def fetch_records(table_client, table, query, fields=None, raw_input=False):
     snow_query = dict(
         # Make references and choice fields human-readable
         sysparm_display_value=True,
     )
     if query:
-        snow_query["sysparm_query"] = construct_sysparm_query(query)
-
+        if raw_input:
+            snow_query["sysparm_query"] = query
+        else:
+            snow_query["sysparm_query"] = construct_sysparm_query(query)
     if fields:
         snow_query["sysparm_fields"] = ",".join(fields)
 
@@ -711,10 +713,20 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             return
 
         query = self.get_option("query")
+        sysparm_query = self.get_option("sysparm_query")
+
+        if query and sysparm_query:
+            raise AnsibleParserError(
+                "Invalid configuration: 'query' and 'sysparm_query' are mutually "
+                "exclusive."
+            )
+
+        if sysparm_query:
+            records = fetch_records(table_client, table, query, raw_input=True)
+        else:
+            records = fetch_records(table_client, table, query)
 
         # TODO: Insert caching here once we remove deprecated functionality
-        records = fetch_records(table_client, table, query)
-
         if enhanced:
             rel_records = fetch_records(
                 table_client, REL_TABLE, REL_QUERY, fields=REL_FIELDS

--- a/plugins/module_utils/arguments.py
+++ b/plugins/module_utils/arguments.py
@@ -127,6 +127,10 @@ SHARED_SPECS = dict(
     sys_id=dict(type="str"),
     number=dict(type="str"),
     query=dict(type="list", elements="dict"),
+    sysparm_query=dict(
+        type="str",
+        fallback=(env_fallback, ["SN_FILTER_RESULTS"]),
+    ),
     attachments=dict(
         type="list",
         elements="dict",

--- a/plugins/module_utils/arguments.py
+++ b/plugins/module_utils/arguments.py
@@ -129,7 +129,7 @@ SHARED_SPECS = dict(
     query=dict(type="list", elements="dict"),
     sysparm_query=dict(
         type="str",
-        fallback=(env_fallback, ["SN_FILTER_RESULTS"]),
+        fallback=(env_fallback, ["SN_SYSPARM_QUERY"]),
     ),
     attachments=dict(
         type="list",

--- a/plugins/modules/change_request_info.py
+++ b/plugins/modules/change_request_info.py
@@ -306,8 +306,8 @@ def main():
             ("sys_id", "query"),
             ("number", "query"),
             ("sysparm_query", "query"),
-    ("sys_id", "sysparm_query"),
-    ("number", "sysparm_query")
+            ("sys_id", "sysparm_query"),
+            ("number", "sysparm_query"),
         ],
     )
 

--- a/plugins/modules/change_request_info.py
+++ b/plugins/modules/change_request_info.py
@@ -306,6 +306,8 @@ def main():
             ("sys_id", "query"),
             ("number", "query"),
             ("sysparm_query", "query"),
+    ("sys_id", "sysparm_query"),
+    ("number", "sysparm_query")
         ],
     )
 

--- a/plugins/modules/change_request_info.py
+++ b/plugins/modules/change_request_info.py
@@ -54,7 +54,7 @@ EXAMPLES = r"""
     query:
       - short_description: LIKE SAP
   register: result
-  
+
 - name: Retrieve change requests that contain SAP in its short description by using field sysparm_query
   servicenow.itsm.change_request_info:
     sysparm_query: short_descriptionLIKESAP

--- a/plugins/modules/change_request_info.py
+++ b/plugins/modules/change_request_info.py
@@ -49,10 +49,15 @@ EXAMPLES = r"""
     number: PRB0007601
   register: result
 
-- name: Retrieve change requests that contain SAP in its short description
+- name: Retrieve change requests that contain SAP in its short description by using field query
   servicenow.itsm.change_request_info:
     query:
       - short_description: LIKE SAP
+  register: result
+  
+- name: Retrieve change requests that contain SAP in its short description by using field sysparm_query
+  servicenow.itsm.change_request_info:
+    sysparm_query: short_descriptionLIKESAP
   register: result
 
 - name: Retrieve new change requests assigned to abel.tuter or bertie.luby

--- a/plugins/modules/change_request_info.py
+++ b/plugins/modules/change_request_info.py
@@ -256,6 +256,8 @@ def run(module, table_client, attachment_client):
 
     if module.params["query"]:
         query = {"sysparm_query": sysparms_query(module, table_client, mapper)}
+    elif module.params["sysparm_query"]:
+        query = {"sysparm_query": module.params["sysparm_query"]}
     else:
         query = utils.filter_dict(module.params, "sys_id", "number")
 
@@ -275,10 +277,19 @@ def main():
         supports_check_mode=True,
         argument_spec=dict(
             arguments.get_spec(
-                "instance", "sys_id", "number", "query", "change_request_mapping"
+                "instance",
+                "sys_id",
+                "number",
+                "query",
+                "change_request_mapping",
+                "sysparm_query",
             ),
         ),
-        mutually_exclusive=[("sys_id", "query"), ("number", "query")],
+        mutually_exclusive=[
+            ("sys_id", "query"),
+            ("number", "query"),
+            ("sysparm_query", "query"),
+        ],
     )
 
     try:

--- a/plugins/modules/change_request_task_info.py
+++ b/plugins/modules/change_request_task_info.py
@@ -256,6 +256,8 @@ def main():
             ("sys_id", "query"),
             ("number", "query"),
             ("sysparm_query", "query"),
+     ("sys_id", "sysparm_query"),
+     ("number", "sysparm_query")
         ],
     )
 

--- a/plugins/modules/change_request_task_info.py
+++ b/plugins/modules/change_request_task_info.py
@@ -256,8 +256,8 @@ def main():
             ("sys_id", "query"),
             ("number", "query"),
             ("sysparm_query", "query"),
-     ("sys_id", "sysparm_query"),
-     ("number", "sysparm_query")
+            ("sys_id", "sysparm_query"),
+            ("number", "sysparm_query"),
         ],
     )
 

--- a/plugins/modules/change_request_task_info.py
+++ b/plugins/modules/change_request_task_info.py
@@ -211,6 +211,8 @@ def run(module, table_client):
 
     if module.params["query"]:
         query = {"sysparm_query": sysparms_query(module, table_client, mapper)}
+    elif module.params["sysparm_query"]:
+        query = {"sysparm_query": module.params["sysparm_query"]}
     else:
         query = utils.filter_dict(module.params, "sys_id", "number")
 
@@ -225,10 +227,19 @@ def main():
         supports_check_mode=True,
         argument_spec=dict(
             arguments.get_spec(
-                "instance", "sys_id", "number", "query", "change_request_task_mapping"
+                "instance",
+                "sys_id",
+                "number",
+                "query",
+                "change_request_task_mapping",
+                "sysparm_query",
             ),
         ),
-        mutually_exclusive=[("sys_id", "query"), ("number", "query")],
+        mutually_exclusive=[
+            ("sys_id", "query"),
+            ("number", "query"),
+            ("sysparm_query", "query"),
+        ],
     )
 
     try:

--- a/plugins/modules/change_request_task_info.py
+++ b/plugins/modules/change_request_task_info.py
@@ -52,7 +52,7 @@ EXAMPLES = r"""
     query:
       - short_description: LIKE SAP
   register: result
-  
+
 - name: Retrieve change request tasks that contain SAP in their short description by using field sysparm-query
   servicenow.itsm.change_request_task_info:
     sysparm_query: short_descriptionLIKESAP

--- a/plugins/modules/change_request_task_info.py
+++ b/plugins/modules/change_request_task_info.py
@@ -224,7 +224,7 @@ def run(module, table_client):
         query = {
             "sysparm_query": sysparms_query(module, table_client, mapper),
             "sysparm_display_value": module.params["sysparm_display_value"],
-        }        
+        }
     elif module.params["sysparm_query"]:
         query = {"sysparm_query": module.params["sysparm_query"]}
     else:

--- a/plugins/modules/change_request_task_info.py
+++ b/plugins/modules/change_request_task_info.py
@@ -47,10 +47,15 @@ EXAMPLES = r"""
     number: CTASK0000001
   register: result
 
-- name: Retrieve change request tasks that contain SAP in their short description
+- name: Retrieve change request tasks that contain SAP in their short description by using field query
   servicenow.itsm.change_request_task_info:
     query:
       - short_description: LIKE SAP
+  register: result
+  
+- name: Retrieve change request tasks that contain SAP in their short description by using field sysparm-query
+  servicenow.itsm.change_request_task_info:
+    sysparm_query: short_descriptionLIKESAP
   register: result
 
 - name: Retrieve new change requests assigned to abel.tuter or bertie.luby

--- a/plugins/modules/configuration_item_info.py
+++ b/plugins/modules/configuration_item_info.py
@@ -57,10 +57,15 @@ EXAMPLES = r"""
     sys_id: 01a9ec0d3790200044e0bfc8bcbe5dc3
   register: result
 
-- name: Retrieve all hardare configuration items
+- name: Retrieve all hardare configuration items by using field query
   servicenow.itsm.configuration_item_info:
     query:
       - category: = Hardware
+  register: result
+
+- name: Retrieve all hardare configuration items by using field sysparm_query
+  servicenow.itsm.configuration_item_info:
+    sysparm_query: category=Hardware
   register: result
 
 - name: Retrieve configuration items in hardware category assigned to abel.tuter or bertie.luby

--- a/plugins/modules/configuration_item_info.py
+++ b/plugins/modules/configuration_item_info.py
@@ -270,7 +270,11 @@ def main():
                 type="str",
             ),
         ),
-        mutually_exclusive=[("sys_id", "query"), ("sysparm_query", "query"), ("sys"id", "sysparm_query")],
+        mutually_exclusive=[
+            ("sys_id", "query"),
+            ("sysparm_query", "query"),
+            ("sys_id", "sysparm_query"),
+        ],
     )
 
     try:

--- a/plugins/modules/configuration_item_info.py
+++ b/plugins/modules/configuration_item_info.py
@@ -237,7 +237,7 @@ def run(module, table_client, attachment_client):
         query = {
             "sysparm_query": sysparms_query(module, table_client, mapper),
             "sysparm_display_value": module.params["sysparm_display_value"],
-        }  
+        }
     elif module.params["sysparm_query"]:
         query = {"sysparm_query": module.params["sysparm_query"]}
     else:

--- a/plugins/modules/configuration_item_info.py
+++ b/plugins/modules/configuration_item_info.py
@@ -224,6 +224,8 @@ def run(module, table_client, attachment_client):
 
     if module.params["query"]:
         query = {"sysparm_query": sysparms_query(module, table_client, mapper)}
+    elif module.params["sysparm_query"]:
+        query = {"sysparm_query": module.params["sysparm_query"]}
     else:
         query = utils.filter_dict(module.params, "sys_id")
 
@@ -243,13 +245,17 @@ def main():
         supports_check_mode=True,
         argument_spec=dict(
             arguments.get_spec(
-                "instance", "sys_id", "query", "configuration_item_mapping"
+                "instance",
+                "sys_id",
+                "query",
+                "configuration_item_mapping",
+                "sysparm_query",
             ),
             sys_class_name=dict(
                 type="str",
             ),
         ),
-        mutually_exclusive=[("sys_id", "query")],
+        mutually_exclusive=[("sys_id", "query"), ("sysparm_query", "query")],
     )
 
     try:

--- a/plugins/modules/configuration_item_info.py
+++ b/plugins/modules/configuration_item_info.py
@@ -270,7 +270,7 @@ def main():
                 type="str",
             ),
         ),
-        mutually_exclusive=[("sys_id", "query"), ("sysparm_query", "query")],
+        mutually_exclusive=[("sys_id", "query"), ("sysparm_query", "query"), ("sys"id", "sysparm_query")],
     )
 
     try:

--- a/plugins/modules/incident_info.py
+++ b/plugins/modules/incident_info.py
@@ -48,10 +48,15 @@ EXAMPLES = r"""
     number: INC0000039
   register: result
 
-- name: Retrieve all incidents that contain SAP in its short description
+- name: Retrieve all incidents that contain SAP in its short description by using field query
   servicenow.itsm.incident_info:
     query:
       - short_description: LIKE SAP
+  register: result
+
+- name: Retrieve all incidents that contain SAP in its short description by using field sysparm_query
+  servicenow.itsm.incident_info:
+    sysparm_query: short_descriptionLIKESAP
   register: result
 
 - name: Retrieve new incidents reported by abel.tuter or bertie.luby

--- a/plugins/modules/incident_info.py
+++ b/plugins/modules/incident_info.py
@@ -274,8 +274,8 @@ def main():
             ("sys_id", "query"),
             ("number", "query"),
             ("sysparm_query", "query"),
-     ("sys_id", "sysparm_query"),
-     ("number", "sysparm_query")
+            ("sys_id", "sysparm_query"),
+            ("number", "sysparm_query"),
         ],
     )
 

--- a/plugins/modules/incident_info.py
+++ b/plugins/modules/incident_info.py
@@ -274,6 +274,8 @@ def main():
             ("sys_id", "query"),
             ("number", "query"),
             ("sysparm_query", "query"),
+     ("sys_id", "sysparm_query"),
+     ("number", "sysparm_query")
         ],
     )
 

--- a/plugins/modules/incident_info.py
+++ b/plugins/modules/incident_info.py
@@ -234,7 +234,7 @@ def run(module, table_client, attachment_client):
         query = {
             "sysparm_query": sysparms_query(module, table_client, mapper),
             "sysparm_display_value": module.params["sysparm_display_value"],
-        }  
+        }
     elif module.params["sysparm_query"]:
         query = {"sysparm_query": module.params["sysparm_query"]}
     else:

--- a/plugins/modules/incident_info.py
+++ b/plugins/modules/incident_info.py
@@ -221,6 +221,8 @@ def run(module, table_client, attachment_client):
 
     if module.params["query"]:
         query = {"sysparm_query": sysparms_query(module, table_client, mapper)}
+    elif module.params["sysparm_query"]:
+        query = {"sysparm_query": module.params["sysparm_query"]}
     else:
         query = utils.filter_dict(module.params, "sys_id", "number")
 
@@ -242,10 +244,19 @@ def main():
         supports_check_mode=True,
         argument_spec=dict(
             arguments.get_spec(
-                "instance", "sys_id", "number", "query", "incident_mapping"
+                "instance",
+                "sys_id",
+                "number",
+                "query",
+                "incident_mapping",
+                "sysparm_query",
             ),
         ),
-        mutually_exclusive=[("sys_id", "query"), ("number", "query")],
+        mutually_exclusive=[
+            ("sys_id", "query"),
+            ("number", "query"),
+            ("sysparm_query", "query"),
+        ],
     )
 
     try:

--- a/plugins/modules/problem_info.py
+++ b/plugins/modules/problem_info.py
@@ -235,6 +235,8 @@ def run(module, table_client, attachment_client):
 
     if module.params["query"]:
         query = {"sysparm_query": sysparms_query(module, table_client, mapper)}
+    elif module.params["sysparm_query"]:
+        query = {"sysparm_query": module.params["sysparm_query"]}
     else:
         query = utils.filter_dict(module.params, "sys_id", "number")
 
@@ -253,9 +255,15 @@ def main():
     module = AnsibleModule(
         supports_check_mode=True,
         argument_spec=dict(
-            arguments.get_spec("instance", "sys_id", "number", "query"),
+            arguments.get_spec(
+                "instance", "sys_id", "number", "query", "sysparm_query"
+            ),
         ),
-        mutually_exclusive=[("sys_id", "query"), ("number", "query")],
+        mutually_exclusive=[
+            ("sys_id", "query"),
+            ("number", "query"),
+            ("sysparm_query", "query"),
+        ],
     )
 
     try:

--- a/plugins/modules/problem_info.py
+++ b/plugins/modules/problem_info.py
@@ -49,10 +49,15 @@ EXAMPLES = r"""
     number: PRB0007601
   register: result
 
-- name: Retrieve problems that do not contain SAP in its short description
+- name: Retrieve problems that do not contain SAP in its short description by using field query
   servicenow.itsm.problem_info:
     query:
       - short_description: NOT LIKE SAP
+  register: result
+
+- name: Retrieve problems that do not contain SAP in its short description by using field sysparm_query
+  servicenow.itsm.problem_info:
+    sysparm_query: short_descriptionNOT LIKESAP
   register: result
 
 - name: Retrieve new problems assigned to abel.tuter or bertie.luby

--- a/plugins/modules/problem_info.py
+++ b/plugins/modules/problem_info.py
@@ -284,6 +284,8 @@ def main():
             ("sys_id", "query"),
             ("number", "query"),
             ("sysparm_query", "query"),
+     ("sys_id", "sysparm_query"),
+     ("number", "sysparm_query")
         ],
     )
 

--- a/plugins/modules/problem_info.py
+++ b/plugins/modules/problem_info.py
@@ -284,8 +284,8 @@ def main():
             ("sys_id", "query"),
             ("number", "query"),
             ("sysparm_query", "query"),
-     ("sys_id", "sysparm_query"),
-     ("number", "sysparm_query")
+            ("sys_id", "sysparm_query"),
+            ("number", "sysparm_query"),
         ],
     )
 

--- a/plugins/modules/problem_info.py
+++ b/plugins/modules/problem_info.py
@@ -248,7 +248,7 @@ def run(module, table_client, attachment_client):
         query = {
             "sysparm_query": sysparms_query(module, table_client, mapper),
             "sysparm_display_value": module.params["sysparm_display_value"],
-        }  
+        }
     elif module.params["sysparm_query"]:
         query = {"sysparm_query": module.params["sysparm_query"]}
     else:
@@ -272,10 +272,10 @@ def main():
         supports_check_mode=True,
         argument_spec=dict(
             arguments.get_spec(
-                "instance", 
-                "sys_id", 
-                "number", 
-                "query", 
+                "instance",
+                "sys_id",
+                "number",
+                "query",
                 "sysparm_display_value",
                 "sysparm_query",
             ),

--- a/plugins/modules/problem_task_info.py
+++ b/plugins/modules/problem_task_info.py
@@ -244,6 +244,8 @@ def main():
             ("sys_id", "query"),
             ("number", "query"),
             ("sysparm_query", "query"),
+     ("sys_id", "sysparm_query"),
+     ("number", "sysparm_query")
         ],
     )
 

--- a/plugins/modules/problem_task_info.py
+++ b/plugins/modules/problem_task_info.py
@@ -48,10 +48,15 @@ EXAMPLES = r"""
     number: PTASK0007601
   register: result
 
-- name: Retrieve problem tasks that do not contain SAP in its short description
+- name: Retrieve problem tasks that do not contain SAP in its short description by using field query
   servicenow.itsm.problem_task_info:
     query:
       - short_description: NOT LIKE SAP
+  register: result
+
+- name: Retrieve problem tasks that do not contain SAP in its short description by using field sysparm_query
+  servicenow.itsm.problem_task_info:
+    sysparm_query: short_descriptionNOT LIKESAP
   register: result
 
 - name: Retrieve new problem tasks assigned to abel.tuter or bertie.luby

--- a/plugins/modules/problem_task_info.py
+++ b/plugins/modules/problem_task_info.py
@@ -244,8 +244,8 @@ def main():
             ("sys_id", "query"),
             ("number", "query"),
             ("sysparm_query", "query"),
-     ("sys_id", "sysparm_query"),
-     ("number", "sysparm_query")
+            ("sys_id", "sysparm_query"),
+            ("number", "sysparm_query"),
         ],
     )
 

--- a/plugins/modules/problem_task_info.py
+++ b/plugins/modules/problem_task_info.py
@@ -200,6 +200,8 @@ def run(module, table_client):
 
     if module.params["query"]:
         query = {"sysparm_query": sysparms_query(module, table_client, mapper)}
+    elif module.params["sysparm_query"]:
+        query = {"sysparm_query": module.params["sysparm_query"]}
     else:
         query = utils.filter_dict(module.params, "sys_id", "number")
 
@@ -213,9 +215,19 @@ def main():
     module = AnsibleModule(
         supports_check_mode=True,
         argument_spec=dict(
-            arguments.get_spec("instance", "sys_id", "number", "query"),
+            arguments.get_spec(
+                "instance",
+                "sys_id",
+                "number",
+                "query",
+                "sysparm_query",
+            ),
         ),
-        mutually_exclusive=[("sys_id", "query"), ("number", "query")],
+        mutually_exclusive=[
+            ("sys_id", "query"),
+            ("number", "query"),
+            ("sysparm_query", "query"),
+        ],
     )
 
     try:

--- a/tests/unit/plugins/modules/test_change_request_info.py
+++ b/tests/unit/plugins/modules/test_change_request_info.py
@@ -91,6 +91,7 @@ class TestRun:
                 sys_id=None,
                 number="n",
                 query=None,
+                sysparm_query=None,
             )
         )
         table_client.list_records.return_value = [

--- a/tests/unit/plugins/modules/test_change_request_task_info.py
+++ b/tests/unit/plugins/modules/test_change_request_task_info.py
@@ -118,6 +118,7 @@ class TestRun:
                 sys_id=None,
                 number="n",
                 query=None,
+                sysparm_query=None,
             )
         )
         table_client.list_records.return_value = [dict(p=1), dict(q=2), dict(r=3)]

--- a/tests/unit/plugins/modules/test_configuration_item_info.py
+++ b/tests/unit/plugins/modules/test_configuration_item_info.py
@@ -80,6 +80,7 @@ class TestRun:
                 sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
                 sys_class_name="cmdb_ci",
                 query=None,
+                sysparm_query=None,
             )
         )
         table_client.list_records.return_value = [

--- a/tests/unit/plugins/modules/test_incident_info.py
+++ b/tests/unit/plugins/modules/test_incident_info.py
@@ -75,6 +75,7 @@ class TestRun:
                 sys_id=None,
                 number="INC001",
                 query=None,
+                sysparm_query=None,
             )
         )
         table_client.list_records.return_value = [

--- a/tests/unit/plugins/modules/test_problem_info.py
+++ b/tests/unit/plugins/modules/test_problem_info.py
@@ -79,6 +79,7 @@ class TestRun:
                 sys_id=None,
                 number="n",
                 query=None,
+                sysparm_query=None,
             )
         )
         table_client.list_records.return_value = [

--- a/tests/unit/plugins/modules/test_problem_task_info.py
+++ b/tests/unit/plugins/modules/test_problem_task_info.py
@@ -79,6 +79,7 @@ class TestRun:
                 sys_id=None,
                 number="n",
                 query=None,
+                sysparm_query=None,
             )
         )
         table_client.list_records.return_value = [dict(p=1), dict(q=2), dict(r=3)]


### PR DESCRIPTION
##### SUMMARY

This PR enhances `*_info` modules and inventory plugin by adding additional attribute `sysparm_query`, which may be filled out by exporting environment variable `SN_SYSPARM_QUERY`.  `sysparm_query` is an alternative way to filter out the query results to `query` from before.

This PR resolved https://github.com/ansible-collections/servicenow.itsm/issues/102.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`servicenow.itsm.now` && `servicenow.itsm.*_info` modules.
