### PR TITLE
Configuration_item module: implement idempotence (issue #71)

### DIFF
--- a/changelogs/fragments/71_configuration_item_implement_idempotence.yml
+++ b/changelogs/fragments/71_configuration_item_implement_idempotence.yml
@@ -1,0 +1,5 @@
+---
+breaking_changes:
+- configuration_item - Add name as a unique identifier. This breaks a task where a new record is created using existing name in CMDB. Now an existing record is updated (https://github.com/ansible-collections/servicenow.itsm/pull/192)
+minor_changes:
+- configuration_item_info - Add option name 

--- a/changelogs/fragments/71_configuration_item_implement_idempotence.yml
+++ b/changelogs/fragments/71_configuration_item_implement_idempotence.yml
@@ -1,5 +1,5 @@
 ---
 breaking_changes:
-- configuration_item - Add name as a unique identifier. This breaks a task where a new record is created using existing name in CMDB. Now an existing record is updated (https://github.com/ansible-collections/servicenow.itsm/pull/192)
+- configuration_item - Added name as a unique identifier. This means that the idempotence is based on name, while previously there was no idempotence (except for sys_id). When state=present if a configuration item with given name does not exist, the item is created. If it already exists, it is updated. (https://github.com/ansible-collections/servicenow.itsm/pull/192)
 minor_changes:
-- configuration_item_info - Add option name 
+- configuration_item_info - Added option name to simplify queries based on that parameter.

--- a/plugins/modules/configuration_item.py
+++ b/plugins/modules/configuration_item.py
@@ -359,7 +359,9 @@ def ensure_present(module, table_client, attachment_client):
 
     else:
         # Get existing record using provided sys_id
-        old = mapper.to_ansible(table_client.get_record("cmdb_ci", query_sys_id, must_exist=True))
+        old = mapper.to_ansible(
+            table_client.get_record("cmdb_ci", query_sys_id, must_exist=True)
+        )
         # Check if provided name already exists
         if query_name:
             configuration_item = table_client.get_record("cmdb_ci", query_name)
@@ -367,14 +369,18 @@ def ensure_present(module, table_client, attachment_client):
                 old2 = mapper.to_ansible(table_client.get_record("cmdb_ci", query_name))
                 if old["sys_id"] != old2["sys_id"]:
                     raise errors.ServiceNowError(
-                        "Record with the name {0} already exists.".format(module.params["name"])
+                        "Record with the name {0} already exists.".format(
+                            module.params["name"]
+                        )
                     )
     # Update existing record
     cmdb_table = old["sys_class_name"]
     # If necessary, fetch the record from the table for the extended CI class
     if cmdb_table != "cmdb_ci":
         old = mapper.to_ansible(
-            table_client.get_record(cmdb_table, query_sys_id or query_name, must_exist=True)
+            table_client.get_record(
+                cmdb_table, query_sys_id or query_name, must_exist=True
+            )
         )
 
     old["attachments"] = attachment_client.list_records(
@@ -466,7 +472,12 @@ def main():
     module = AnsibleModule(
         argument_spec=module_args,
         supports_check_mode=True,
-        required_one_of=[("sys_id", "name", ), ],
+        required_one_of=[
+            (
+                "sys_id",
+                "name",
+            ),
+        ],
     )
 
     try:

--- a/plugins/modules/configuration_item.py
+++ b/plugins/modules/configuration_item.py
@@ -24,10 +24,10 @@ short_description: Manage ServiceNow configuration items
 description:
   - Create, delete or update a ServiceNow configuration item.
   - Configuration items can be managed using sys_id or name.
-  - When creating a new configuration item, a check will be made if the configuration item with provided name already exists
-    and in this case existing configuration item will be updated.
+  - Operations create and delete are idempotent on parameter C(name).
+  - When C(state) is set to C(present), a record identified by C(name) is only created once. Further invocations will update the record.
   - For more information, refer to the ServiceNow configuration management documentation at
-    U(https://docs.servicenow.com/bundle/paris-servicenow-platform/page/product/configuration-management/reference/cmdb-table-property-descriptions.html).
+    U(https://docs.servicenow.com/bundle/tokyo-servicenow-platform/page/product/configuration-management/reference/cmdb-table-property-descriptions.html).
 version_added: 1.0.0
 extends_documentation_fragment:
   - servicenow.itsm.instance
@@ -355,7 +355,7 @@ def ensure_present(module, table_client, attachment_client):
 
         else:
             # Get existing record using provided name
-            old = mapper.to_ansible(table_client.get_record("cmdb_ci", query_name))
+            old = mapper.to_ansible(configuration_item)
 
     else:
         # Get existing record using provided sys_id
@@ -366,7 +366,7 @@ def ensure_present(module, table_client, attachment_client):
         if query_name:
             configuration_item = table_client.get_record("cmdb_ci", query_name)
             if configuration_item:
-                old2 = mapper.to_ansible(table_client.get_record("cmdb_ci", query_name))
+                old2 = mapper.to_ansible(configuration_item)
                 if old["sys_id"] != old2["sys_id"]:
                     raise errors.ServiceNowError(
                         "Record with the name {0} already exists.".format(

--- a/plugins/modules/configuration_item.py
+++ b/plugins/modules/configuration_item.py
@@ -350,23 +350,27 @@ def ensure_present(module, table_client, attachment_client):
             return True, new, dict(before=None, after=new)
 
         else:
-            # Update existing record
+            # Get existing record using provided name
             old = mapper.to_ansible(table_client.get_record("cmdb_ci", query_name))
 
     else:
+        # Get existing record using provided sys_id
         old = mapper.to_ansible(table_client.get_record("cmdb_ci", query_sys_id, must_exist=True))
+        # Check if provided name already exists
         if query_name:
-            old2 = mapper.to_ansible(table_client.get_record("cmdb_ci", query_name))
-            if old["sys_id"] != old2["sys_id"]:
-                raise errors.ServiceNowError(
-                    "Record with the name {0} already exists.".format(module.params["name"])
-                )
-
+            configuration_item = table_client.get_record("cmdb_ci", query_name)
+            if configuration_item:
+                old2 = mapper.to_ansible(table_client.get_record("cmdb_ci", query_name))
+                if old["sys_id"] != old2["sys_id"]:
+                    raise errors.ServiceNowError(
+                        "Record with the name {0} already exists.".format(module.params["name"])
+                    )
+    # Update existing record
     cmdb_table = old["sys_class_name"]
     # If necessary, fetch the record from the table for the extended CI class
     if cmdb_table != "cmdb_ci":
         old = mapper.to_ansible(
-            table_client.get_record(cmdb_table, query_sys_id, must_exist=True)
+            table_client.get_record(cmdb_table, query_sys_id or query_name, must_exist=True)
         )
 
     old["attachments"] = attachment_client.list_records(
@@ -458,9 +462,6 @@ def main():
     module = AnsibleModule(
         argument_spec=module_args,
         supports_check_mode=True,
-        # required_if=[
-        #     ["state", "absent", ("sys_id", "name", ), True],
-        # ],
         required_one_of=[("sys_id", "name", ), ],
     )
 

--- a/plugins/modules/configuration_item.py
+++ b/plugins/modules/configuration_item.py
@@ -284,11 +284,7 @@ DIRECT_PAYLOAD_FIELDS = (
 
 def ensure_absent(module, table_client, attachment_client):
     mapper = get_mapper(module, "configuration_item_mapping", PAYLOAD_FIELDS_MAPPING)
-
-    query = utils.filter_dict(module.params, "sys_id")
-    if query == []:
-        query = utils.filter_dict(module.params, "name")
-
+    query = utils.filter_dict(module.params, "sys_id", "name")
     configuration_item = table_client.get_record("cmdb_ci", query)
 
     if configuration_item:
@@ -453,13 +449,9 @@ def main():
         argument_spec=module_args,
         supports_check_mode=True,
         required_if=[
-            ("state", "absent", ("sys_id", "name", )),
+            ["state", "absent", ("sys_id", "name", ), True],
         ],
     )
-        # required_if: List of lists of ``[parameter, value, [parameters]]`` where
-        #             one of ``[parameters]`` is required if ``parameter == value``.
-        #         :type required_if: list
-
 
     try:
         snow_client = client.Client(**module.params["instance"])

--- a/plugins/modules/configuration_item.py
+++ b/plugins/modules/configuration_item.py
@@ -284,7 +284,11 @@ DIRECT_PAYLOAD_FIELDS = (
 
 def ensure_absent(module, table_client, attachment_client):
     mapper = get_mapper(module, "configuration_item_mapping", PAYLOAD_FIELDS_MAPPING)
+
     query = utils.filter_dict(module.params, "sys_id")
+    if query == []:
+        query = utils.filter_dict(module.params, "name")
+
     configuration_item = table_client.get_record("cmdb_ci", query)
 
     if configuration_item:
@@ -449,9 +453,13 @@ def main():
         argument_spec=module_args,
         supports_check_mode=True,
         required_if=[
-            ("state", "absent", ("sys_id",)),
+            ("state", "absent", ("sys_id", "name", )),
         ],
     )
+        # required_if: List of lists of ``[parameter, value, [parameters]]`` where
+        #             one of ``[parameters]`` is required if ``parameter == value``.
+        #         :type required_if: list
+
 
     try:
         snow_client = client.Client(**module.params["instance"])

--- a/plugins/modules/configuration_item.py
+++ b/plugins/modules/configuration_item.py
@@ -285,7 +285,7 @@ DIRECT_PAYLOAD_FIELDS = (
 def ensure_absent(module, table_client, attachment_client):
     mapper = get_mapper(module, "configuration_item_mapping", PAYLOAD_FIELDS_MAPPING)
     query = utils.filter_dict(module.params, "sys_id", "name")
-    configuration_item = table_client.get_record("cmdb_ci", query) # SHOULD I SET must_exist=True?
+    configuration_item = table_client.get_record("cmdb_ci", query)
 
     if configuration_item:
         cmdb_table = configuration_item["sys_class_name"]

--- a/plugins/modules/configuration_item.py
+++ b/plugins/modules/configuration_item.py
@@ -17,11 +17,15 @@ author:
   - Miha Dolinar (@mdolin)
   - Tadej Borovsak (@tadeboro)
   - Matej Pevec (@mysteriouswolf)
+  - Polona Mihalič (@PolonaM)
 
 short_description: Manage ServiceNow configuration items
 
 description:
   - Create, delete or update a ServiceNow configuration item.
+  - Configuration items can be managed using sys_id or name.
+  - When creating a new configuration item, a check will be made if the configuration item with provided name already exists
+    and in this case existing configuration item will be updated.
   - For more information, refer to the ServiceNow configuration management documentation at
     U(https://docs.servicenow.com/bundle/paris-servicenow-platform/page/product/configuration-management/reference/cmdb-table-property-descriptions.html).
 version_added: 1.0.0

--- a/plugins/modules/configuration_item_info.py
+++ b/plugins/modules/configuration_item_info.py
@@ -40,7 +40,9 @@ options:
   name:
     description:
       - Unique identifier of the record to retrieve.
+      - Mutually exclusive with C(query) and C(sys_id).
     type: str
+    version_added: 2.0.0
   sys_class_name:
     description:
       - ServiceNow configuration item class.
@@ -250,7 +252,9 @@ def run(module, table_client, attachment_client):
         }
 
     else:
-        query = utils.filter_dict(module.params, "sys_id", "name", "sysparm_query", "sysparm_display_value")
+        query = utils.filter_dict(
+            module.params, "sys_id", "name", "sysparm_query", "sysparm_display_value"
+        )
 
     return [
         dict(

--- a/plugins/modules/configuration_item_info.py
+++ b/plugins/modules/configuration_item_info.py
@@ -18,6 +18,7 @@ author:
   - Miha Dolinar (@mdolin)
   - Tadej Borovsak (@tadeboro)
   - Matej Pevec (@mysteriouswolf)
+  - Polona Mihalič (@PolonaM)
 
 short_description: List ServiceNow configuration item
 
@@ -36,6 +37,10 @@ seealso:
   - module: servicenow.itsm.configuration_item
 
 options:
+  name:
+    description:
+      - Unique identifier of the record to retrieve.
+    type: str
   sys_class_name:
     description:
       - ServiceNow configuration item class.
@@ -53,9 +58,14 @@ EXAMPLES = r"""
   servicenow.itsm.configuration_item_info:
   register: result
 
-- name: Retrieve a specific configuration item by its sys_id
+- name: Retrieve a specific configuration item by it's sys_id
   servicenow.itsm.configuration_item_info:
     sys_id: 01a9ec0d3790200044e0bfc8bcbe5dc3
+  register: result
+
+- name: Retrieve a specific configuration item by it's name
+  servicenow.itsm.configuration_item_info:
+    name: my-configuration-item
   register: result
 
 - name: Retrieve all hardare configuration items by using field query
@@ -238,10 +248,9 @@ def run(module, table_client, attachment_client):
             "sysparm_query": sysparms_query(module, table_client, mapper),
             "sysparm_display_value": module.params["sysparm_display_value"],
         }
-    elif module.params["sysparm_query"]:
-        query = {"sysparm_query": module.params["sysparm_query"]}
+
     else:
-        query = utils.filter_dict(module.params, "sys_id", "sysparm_display_value")
+        query = utils.filter_dict(module.params, "sys_id", "name", "sysparm_query", "sysparm_display_value")
 
     return [
         dict(
@@ -266,15 +275,14 @@ def main():
                 "sysparm_query",
                 "sysparm_display_value",
             ),
+            name=dict(
+                type="str",
+            ),
             sys_class_name=dict(
                 type="str",
             ),
         ),
-        mutually_exclusive=[
-            ("sys_id", "query"),
-            ("sysparm_query", "query"),
-            ("sys_id", "sysparm_query"),
-        ],
+        mutually_exclusive=[("sys_id", "query", "name", "sysparm_query")],
     )
 
     try:

--- a/plugins/modules/configuration_item_info.py
+++ b/plugins/modules/configuration_item_info.py
@@ -60,12 +60,12 @@ EXAMPLES = r"""
   servicenow.itsm.configuration_item_info:
   register: result
 
-- name: Retrieve a specific configuration item by it's sys_id
+- name: Retrieve a specific configuration item by sys_id
   servicenow.itsm.configuration_item_info:
     sys_id: 01a9ec0d3790200044e0bfc8bcbe5dc3
   register: result
 
-- name: Retrieve a specific configuration item by it's name
+- name: Retrieve a specific configuration item by name
   servicenow.itsm.configuration_item_info:
     name: my-configuration-item
   register: result

--- a/tests/integration/targets/configuration_item/tasks/main.yml
+++ b/tests/integration/targets/configuration_item/tasks/main.yml
@@ -1,10 +1,25 @@
 ---
-- environment:
-    SN_HOST: "{{ sn_host }}"
-    SN_USERNAME: "{{ sn_username }}"
-    SN_PASSWORD: "{{ sn_password }}"
+# - environment:
+#     SN_HOST: "{{ sn_host }}"
+#     SN_USERNAME: "{{ sn_username }}"
+#     SN_PASSWORD: "{{ sn_password }}"
 
-  block:
+#   block:
+
+- name: Download examples
+  hosts: localhost
+  #hosts: all
+  vars:
+    sn_host: https://dev108430.service-now.com
+    sn_username: admin
+    sn_password: H+CDzg%gJ03r
+    # sn_attachment_id: 003a3ef24ff1120031577d2ca310c74b
+  # - environment:
+  #   SN_HOST: "{{ sn_host }}"
+  #   SN_USERNAME: "{{ sn_username }}"
+  #   SN_PASSWORD: "{{ sn_password }}"
+
+  tasks:
     - name: Retrieve configuration item records
       servicenow.itsm.configuration_item_info:
       register: initial
@@ -49,8 +64,15 @@
     - ansible.builtin.assert:
         that:
           - result.records | length == initial.records | length + 1
+    
+    - name: Create a base configuration item using existing name (idempotence)
+      servicenow.itsm.configuration_item: *ci-create
+      register: result
+    - ansible.builtin.assert:
+        that:
+          - result is not changed
 
-    - name: Create a base configuration item (idempotence)
+    - name: Create a base configuration item using existing sys_id (idempotence)
       servicenow.itsm.configuration_item:
         <<: *ci-create
         sys_id: "{{ base_ci.record.sys_id }}"
@@ -58,12 +80,12 @@
     - ansible.builtin.assert:
         that:
           - result is not changed
-
+    
     - name: Update the configuration item (check mode)
       servicenow.itsm.configuration_item: &ci-update
         sys_id: "{{ base_ci.record.sys_id }}"
         sys_class_name: cmdb_ci_computer
-        name: my-computer
+        name: my-configuration-item
         short_description: short-description
         asset_tag: P22896
         install_status: installed
@@ -81,7 +103,7 @@
           - updated_ci is changed
           - updated_ci.record.sys_id == base_ci.record.sys_id
           - updated_ci.record.sys_class_name == "cmdb_ci_computer"
-          - updated_ci.record.name == "my-computer"
+          - updated_ci.record.name == "my-configuration-item"
           - updated_ci.record.asset_tag == "P22896"
           - updated_ci.record.install_status == "installed"
           - updated_ci.record.operational_status == "ready"
@@ -108,12 +130,36 @@
       register: updated_ci
     - ansible.builtin.assert: *ci-update-assertions
 
-    - name: Update the configuration item (idempotence)
-      servicenow.itsm.configuration_item: *ci-update
+    - name: Update the configuration item using only name (idempotence)
+      servicenow.itsm.configuration_item: 
+        <<: *ci-update
+        sys_id: nonexistent
       register: result
     - ansible.builtin.assert:
         that:
           - result is not changed
+    
+    - name: Update configuration item's name
+      servicenow.itsm.configuration_item:
+        sys_id: "{{ base_ci.record.sys_id }}"
+        name: my-computer
+      register: updated_ci
+    - ansible.builtin.assert:
+        that:
+          - updated_ci is changed
+          - updated_ci.record.name == "my-computer"
+    
+    - name: Create configuration item without sys_id or name
+      servicenow.itsm.configuration_item:
+        <<: *ci-create
+        sys_id: nonexistent
+        name: nonexistent
+      ignore_errors: true
+      register: result
+    - ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'one of the following is required: sys_id, name' in result.msg"
 
     - name: Get specific configuration item info by sysparm query
       servicenow.itsm.configuration_item_info:
@@ -130,7 +176,6 @@
            mac_address: = a1:b2:c3:d4:e5
            assigned_to: = admin
       register: result
-
     - ansible.builtin.assert:
         that:
           - result.records | length == 1
@@ -177,7 +222,6 @@
          - sys_class_name: = cmdb_ci_server
            name: = test-server
       register: result
-
     - ansible.builtin.assert:
         that:
           - result.records.0.name == "test-server"
@@ -194,6 +238,27 @@
           - result is failed
           - "'No sys_user records match' in result.msg"
 
+    - name: Create another configuration item
+      servicenow.itsm.configuration_item:
+        <<: *ci-create
+        name: my-new-configuration-item
+        register: another_base_ci
+    - ansible.builtin.assert:
+        that:
+          - another_base_ci is changed
+          - another_base_ci.record.name == "my-new-configuration-item"
+    
+    - name: Update another configuration item's name with existing one (idempotence)
+      servicenow.itsm.configuration_item:
+        sys_id: "{{ another_base_ci.record.sys_id }}"
+        name: my-computer
+      ignore_errors: true
+      register: updated_ci
+    - ansible.builtin.assert:
+        that:
+          - updated_ci is failed
+          - "'Record with the name' in updated_ci.msg"
+    
     - name: Delete a configuration item (check mode)
       servicenow.itsm.configuration_item: &ci-delete
         sys_id: "{{ base_ci.record.sys_id }}"
@@ -211,8 +276,28 @@
     - ansible.builtin.assert:
         that:
           - result.records | length == 1
+    
+    - name: Delete configuration item using sys_id and wrong name
+      servicenow.itsm.configuration_item:
+        sys_id: "{{ base_ci.record.sys_id }}"
+        name: "wrong_name"
+        state: absent
+      register: result
+    - ansible.builtin.assert:
+        that:
+          - result is not changed
 
-    - name: Delete a configuration item
+    - name: Delete configuration item using name and wrong sys_id
+      servicenow.itsm.configuration_item:
+        sys_id: "wrong_sys_id"
+        name: "{{ base_ci.record.name }}"
+        state: absent
+      register: result
+    - ansible.builtin.assert:
+        that:
+          - result is not changed
+
+    - name: Delete a configuration item using sys_id
       servicenow.itsm.configuration_item: *ci-delete
       register: result
     - ansible.builtin.assert:
@@ -234,6 +319,14 @@
         that:
           - result is not changed
 
+    - name: Delete another configuration item using name
+      servicenow.itsm.configuration_item:
+        name: my-new-configuration-item
+        state: absent
+      register: result
+    - ansible.builtin.assert:
+        that:
+          - result is changed
 
     - name: Test bad parameter combinator (sys_id + query)
       servicenow.itsm.configuration_item_info:
@@ -242,12 +335,10 @@
          - name: = lnux101
       ignore_errors: true
       register: result
-
     - ansible.builtin.assert:
         that:
           - result is failed
           - "'parameters are mutually exclusive: sys_id|query' in result.msg"
-
 
     - name: Test invalid operator detection
       servicenow.itsm.configuration_item_info:
@@ -255,23 +346,19 @@
          - name: == lnux101
       ignore_errors: true
       register: result
-
     - ansible.builtin.assert:
         that:
           - result is failed
           - "'Invalid condition' in result.msg"
-
 
     - name: Get configuration item info by sysparm query - name
       servicenow.itsm.configuration_item_info:
         query:
          - name: = lnux101
       register: result
-
     - ansible.builtin.assert:
         that:
           - "'lnux101' in result.records[0].name"
-
 
     - name: Test unary operator with argument detection
       servicenow.itsm.configuration_item_info:
@@ -279,19 +366,16 @@
          - short_description: ISEMPTY SAP
       ignore_errors: true
       register: result
-
     - ansible.builtin.assert:
         that:
           - result is failed
           - "'Operator ISEMPTY does not take any arguments' in result.msg"
-
 
     - name: Test sysparm query unary operator - short_description
       servicenow.itsm.configuration_item_info:
         query:
          - short_description: ISNOTEMPTY
       register: result
-
     - ansible.builtin.assert:
         that:
           - result.records[0].short_description != ""

--- a/tests/integration/targets/configuration_item/tasks/main.yml
+++ b/tests/integration/targets/configuration_item/tasks/main.yml
@@ -99,7 +99,7 @@
           - updated_ci.record.short_description == "short-description"
           - updated_ci.record.assigned_to != ""
 
-    - name: Verify modification in check mode did not update the record
+    - name: Verify modification in check mode did not update the record - use sys_id
       servicenow.itsm.configuration_item_info:
         sys_id: "{{ base_ci.record.sys_id }}"
       register: result
@@ -127,11 +127,11 @@
       servicenow.itsm.configuration_item:
         sys_id: "{{ base_ci.record.sys_id }}"
         name: my-computer
-      register: updated_ci
+      register: base_ci
     - ansible.builtin.assert:
         that:
-          - updated_ci is changed
-          - updated_ci.record.name == "my-computer"
+          - base_ci is changed
+          - base_ci.record.name == "my-computer"
     
     - name: Create configuration item without sys_id or name
       servicenow.itsm.configuration_item:
@@ -240,9 +240,9 @@
         that:
           - result is changed
 
-    - name: Verify deletion in check mode did not remove the record
+    - name: Verify deletion in check mode did not remove the record - use name
       servicenow.itsm.configuration_item_info:
-        sys_id: "{{ base_ci.record.sys_id }}"
+        name: "{{ base_ci.record.name }}"
       register: result
     - ansible.builtin.assert:
         that:
@@ -309,7 +309,7 @@
     - ansible.builtin.assert:
         that:
           - result is failed
-          - "'parameters are mutually exclusive: sys_id|query' in result.msg"
+          - "'parameters are mutually exclusive: sys_id|query|name' in result.msg"
 
     - name: Test invalid operator detection
       servicenow.itsm.configuration_item_info:

--- a/tests/integration/targets/configuration_item/tasks/main.yml
+++ b/tests/integration/targets/configuration_item/tasks/main.yml
@@ -123,7 +123,7 @@
         that:
           - result is not changed
     
-    - name: Update configuration item's name
+    - name: Rename configuration item
       servicenow.itsm.configuration_item:
         sys_id: "{{ base_ci.record.sys_id }}"
         name: my-computer

--- a/tests/integration/targets/configuration_item/tasks/main.yml
+++ b/tests/integration/targets/configuration_item/tasks/main.yml
@@ -1,25 +1,10 @@
 ---
-# - environment:
-#     SN_HOST: "{{ sn_host }}"
-#     SN_USERNAME: "{{ sn_username }}"
-#     SN_PASSWORD: "{{ sn_password }}"
+- environment:
+    SN_HOST: "{{ sn_host }}"
+    SN_USERNAME: "{{ sn_username }}"
+    SN_PASSWORD: "{{ sn_password }}"
 
-#   block:
-
-- name: Download examples
-  hosts: localhost
-  #hosts: all
-  vars:
-    sn_host: https://dev108430.service-now.com
-    sn_username: admin
-    sn_password: H+CDzg%gJ03r
-    # sn_attachment_id: 003a3ef24ff1120031577d2ca310c74b
-  # - environment:
-  #   SN_HOST: "{{ sn_host }}"
-  #   SN_USERNAME: "{{ sn_username }}"
-  #   SN_PASSWORD: "{{ sn_password }}"
-
-  tasks:
+  block:
     - name: Retrieve configuration item records
       servicenow.itsm.configuration_item_info:
       register: initial
@@ -132,8 +117,7 @@
 
     - name: Update the configuration item using only name (idempotence)
       servicenow.itsm.configuration_item: 
-        <<: *ci-update
-        sys_id: nonexistent
+        name: my-configuration-item
       register: result
     - ansible.builtin.assert:
         that:
@@ -151,9 +135,6 @@
     
     - name: Create configuration item without sys_id or name
       servicenow.itsm.configuration_item:
-        <<: *ci-create
-        sys_id: nonexistent
-        name: nonexistent
       ignore_errors: true
       register: result
     - ansible.builtin.assert:
@@ -215,6 +196,17 @@
           - server is changed
           - server.record.name == "test-server"
           - server.record.classification == "Development"
+    
+    - name: Update test-server's name with existing one (idempotence)
+      servicenow.itsm.configuration_item:
+        sys_id: "{{ server.record.sys_id }}"
+        name: my-computer
+      ignore_errors: true
+      register: result
+    - ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'Record with the name' in result.msg"
 
     - name: Get configuration item info by sysparm query - sys_class_name and name
       servicenow.itsm.configuration_item_info:
@@ -237,27 +229,6 @@
         that:
           - result is failed
           - "'No sys_user records match' in result.msg"
-
-    - name: Create another configuration item
-      servicenow.itsm.configuration_item:
-        <<: *ci-create
-        name: my-new-configuration-item
-        register: another_base_ci
-    - ansible.builtin.assert:
-        that:
-          - another_base_ci is changed
-          - another_base_ci.record.name == "my-new-configuration-item"
-    
-    - name: Update another configuration item's name with existing one (idempotence)
-      servicenow.itsm.configuration_item:
-        sys_id: "{{ another_base_ci.record.sys_id }}"
-        name: my-computer
-      ignore_errors: true
-      register: updated_ci
-    - ansible.builtin.assert:
-        that:
-          - updated_ci is failed
-          - "'Record with the name' in updated_ci.msg"
     
     - name: Delete a configuration item (check mode)
       servicenow.itsm.configuration_item: &ci-delete
@@ -319,9 +290,9 @@
         that:
           - result is not changed
 
-    - name: Delete another configuration item using name
+    - name: Delete test-server using name
       servicenow.itsm.configuration_item:
-        name: my-new-configuration-item
+        name: test-server
         state: absent
       register: result
     - ansible.builtin.assert:

--- a/tests/unit/plugins/modules/test_configuration_item.py
+++ b/tests/unit/plugins/modules/test_configuration_item.py
@@ -794,17 +794,11 @@ class TestMain:
 
         assert success is True
 
-    def test_fail_missing_required_parameters(self, run_main):
+    def test_fail(self, run_main):
         success, result = run_main(configuration_item)
 
         assert success is False
         assert "one of the following is required: sys_id, name" in result["msg"]
-
-    def test_fail_no_instance(self, run_main):
-        success, result = run_main(configuration_item)
-
-        assert success is False
-        assert "instance" in result["msg"]
 
 
 class TestRun:

--- a/tests/unit/plugins/modules/test_configuration_item.py
+++ b/tests/unit/plugins/modules/test_configuration_item.py
@@ -43,7 +43,9 @@ class TestEnsureAbsent:
             module, table_client, attachment_client
         )
 
-        table_client.get_record.assert_called_once_with("cmdb_ci", {"sys_id": "01a9ec0d3790200044e0bfc8bcbe5dc3"})
+        table_client.get_record.assert_called_once_with(
+            "cmdb_ci", {"sys_id": "01a9ec0d3790200044e0bfc8bcbe5dc3"}
+        )
         table_client.delete_record.assert_called_once()
         assert result == (
             True,
@@ -71,7 +73,9 @@ class TestEnsureAbsent:
             )
         )
         table_client.get_record.return_value = dict(
-            sys_class_name="cmdb_ci", name="my_name", sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3"
+            sys_class_name="cmdb_ci",
+            name="my_name",
+            sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
         )
 
         result = configuration_item.ensure_absent(
@@ -85,7 +89,9 @@ class TestEnsureAbsent:
             None,
             dict(
                 before=dict(
-                    sys_class_name="cmdb_ci", name="my_name", sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3"
+                    sys_class_name="cmdb_ci",
+                    name="my_name",
+                    sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
                 ),
                 after=None,
             ),
@@ -106,21 +112,27 @@ class TestEnsureAbsent:
             )
         )
         table_client.get_record.return_value = dict(
-            sys_class_name="cmdb_ci", name="my_name", sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3"
+            sys_class_name="cmdb_ci",
+            name="my_name",
+            sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
         )
 
         result = configuration_item.ensure_absent(
             module, table_client, attachment_client
         )
 
-        table_client.get_record.assert_called_once_with("cmdb_ci", {"name": "my_name", "sys_id": "01a9ec0d3790200044e0bfc8bcbe5dc3"})
+        table_client.get_record.assert_called_once_with(
+            "cmdb_ci", {"name": "my_name", "sys_id": "01a9ec0d3790200044e0bfc8bcbe5dc3"}
+        )
         table_client.delete_record.assert_called_once()
         assert result == (
             True,
             None,
             dict(
                 before=dict(
-                    sys_class_name="cmdb_ci", name="my_name", sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3"
+                    sys_class_name="cmdb_ci",
+                    name="my_name",
+                    sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
                 ),
                 after=None,
             ),
@@ -302,7 +314,9 @@ class TestEnsurePresent:
             module, table_client, attachment_client
         )
 
-        table_client.get_record.assert_called_once_with("cmdb_ci", {"name": "test.name"})
+        table_client.get_record.assert_called_once_with(
+            "cmdb_ci", {"name": "test.name"}
+        )
         table_client.create_record.assert_called_once()
         assert result == (
             True,
@@ -655,17 +669,17 @@ class TestEnsurePresent:
         payload_mocker.return_value = dict(
             sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
             sys_class_name="cmdb_ci",
-            name="my_new_name"
+            name="my_new_name",
         )
         table_client.get_record.return_value = dict(
             sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
             sys_class_name="cmdb_ci",
-            name="my_name"
+            name="my_name",
         )
         table_client.update_record.return_value = dict(
             sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
             sys_class_name="cmdb_ci",
-            name="my_new_name"
+            name="my_new_name",
         )
         attachment_client.update_records.return_value = []
         attachment_client.list_records.return_value = []
@@ -733,14 +747,15 @@ class TestEnsurePresent:
                     name="my_new_name",
                 )
             return dict(
-                    sys_id="different_sys_id",
-                    name="my_new_name",
-                )
+                sys_id="different_sys_id",
+                name="my_new_name",
+            )
 
         table_client.get_record.side_effect = get_record_side_effect
 
         with pytest.raises(
-            errors.ServiceNowError, match="Record with the name my_new_name already exists."
+            errors.ServiceNowError,
+            match="Record with the name my_new_name already exists.",
         ):
             configuration_item.ensure_present(module, table_client, attachment_client)
 

--- a/tests/unit/plugins/modules/test_configuration_item.py
+++ b/tests/unit/plugins/modules/test_configuration_item.py
@@ -610,8 +610,80 @@ class TestMain:
 
         assert success is True
 
-    def test_fail(self, run_main):
+    def test_fail_missing_required_parameters(self, run_main):
         success, result = run_main(configuration_item)
 
         assert success is False
         assert "one of the following is required: sys_id, name" in result["msg"]
+
+    def test_fail_no_instance(self, run_main):
+        success, result = run_main(configuration_item)
+
+        assert success is False
+        assert "instance" in result["msg"]
+
+
+class TestRun:
+    def test_run_absent(self, mocker, create_module, table_client, attachment_client):
+        module = create_module(
+            params=dict(
+                instance=dict(
+                    host="https://my.host.name", username="user", password="pass"
+                ),
+                state="absent",
+                sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
+                name=None,
+                short_description=None,
+                sys_class_name="cmdb_ci",
+                assigned_to=None,
+                asset_tag=None,
+                install_status="installed",
+                operational_status="ready",
+                serial_number=None,
+                ip_address=None,
+                mac_address=None,
+                category=None,
+                environment=None,
+                other=None,
+                attachments=None,
+            ),
+        )
+        mocker.patch(
+            "ansible_collections.servicenow.itsm.plugins.modules.configuration_item.ensure_absent"
+        ).return_value = "ensure_absent"
+
+        ensure = configuration_item.run(module, table_client, attachment_client)
+
+        assert ensure == "ensure_absent"
+
+    def test_run_present(self, mocker, create_module, table_client, attachment_client):
+        module = create_module(
+            params=dict(
+                instance=dict(
+                    host="https://my.host.name", username="user", password="pass"
+                ),
+                state="present",
+                sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
+                name=None,
+                short_description=None,
+                sys_class_name="cmdb_ci",
+                assigned_to=None,
+                asset_tag=None,
+                install_status="installed",
+                operational_status="ready",
+                serial_number=None,
+                ip_address=None,
+                mac_address=None,
+                category=None,
+                environment=None,
+                other=None,
+                attachments=None,
+            ),
+        )
+        mocker.patch(
+            "ansible_collections.servicenow.itsm.plugins.modules.configuration_item.ensure_present"
+        ).return_value = "ensure_present"
+
+        ensure = configuration_item.run(module, table_client, attachment_client)
+
+        assert ensure == "ensure_present"

--- a/tests/unit/plugins/modules/test_configuration_item.py
+++ b/tests/unit/plugins/modules/test_configuration_item.py
@@ -294,7 +294,7 @@ class TestEnsurePresent:
             ),
         )
 
-    def test_ensure_present_nothing_to_do(
+    def test_ensure_present_nothing_to_do_query_by_sys_id(
         self, create_module, table_client, attachment_client
     ):
         module = create_module(
@@ -361,7 +361,74 @@ class TestEnsurePresent:
             ),
         )
 
-    def test_ensure_present_update(
+    def test_ensure_present_nothing_to_do_query_by_name(
+        self, create_module, table_client, attachment_client
+    ):
+        module = create_module(
+            params=dict(
+                instance=dict(
+                    host="https://my.host.name", username="user", password="pass"
+                ),
+                state="present",
+                sys_id=None,
+                name="test.name",
+                short_description="Test configuration item",
+                sys_class_name="cmdb_ci_computer",
+                assigned_to=None,
+                asset_tag=None,
+                install_status=None,
+                operational_status=None,
+                serial_number=None,
+                ip_address=None,
+                mac_address=None,
+                category=None,
+                environment=None,
+                other=None,
+                attachments=None,
+            ),
+        )
+        table_client.get_record.return_value = dict(
+            sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
+            name="test.name",
+            short_description="Test configuration item",
+            sys_class_name="cmdb_ci_computer",
+        )
+        attachment_client.update_records.return_value = []
+        attachment_client.list_records.return_value = []
+
+        result = configuration_item.ensure_present(
+            module, table_client, attachment_client
+        )
+
+        table_client.get_record.assert_called()
+        assert result == (
+            False,
+            dict(
+                sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
+                name="test.name",
+                short_description="Test configuration item",
+                sys_class_name="cmdb_ci_computer",
+                attachments=[],
+            ),
+            dict(
+                before=dict(
+                    sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
+                    name="test.name",
+                    short_description="Test configuration item",
+                    sys_class_name="cmdb_ci_computer",
+                    attachments=[],
+                ),
+                after=dict(
+                    sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
+                    name="test.name",
+                    short_description="Test configuration item",
+                    sys_class_name="cmdb_ci_computer",
+                    attachments=[],
+                ),
+            ),
+        )
+
+    def test_ensure_present_update_query_by_sys_id(
         self, mocker, create_module, table_client, attachment_client
     ):
         module = create_module(
@@ -433,6 +500,92 @@ class TestEnsurePresent:
                 ),
                 after=dict(
                     sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
+                    sys_class_name="cmdb_ci",
+                    install_status="installed",
+                    operational_status="ready",
+                    attachments=[],
+                ),
+            ),
+        )
+
+    def test_ensure_present_update_query_by_name(
+        self, mocker, create_module, table_client, attachment_client
+    ):
+        module = create_module(
+            params=dict(
+                instance=dict(
+                    host="https://my.host.name", username="user", password="pass"
+                ),
+                state="present",
+                sys_id=None,
+                name="test.name",
+                short_description=None,
+                sys_class_name="cmdb_ci",
+                assigned_to=None,
+                asset_tag=None,
+                install_status="installed",
+                operational_status="ready",
+                serial_number=None,
+                ip_address=None,
+                mac_address=None,
+                category=None,
+                environment=None,
+                other=None,
+                attachments=None,
+            ),
+        )
+        payload_mocker = mocker.patch.object(configuration_item, "build_payload")
+        payload_mocker.return_value = dict(
+            sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
+            name="test.name",
+            sys_class_name="cmdb_ci",
+            install_status="installed",
+            operational_status="ready",
+        )
+        table_client.get_record.return_value = dict(
+            sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
+            name="test.name",
+            sys_class_name="cmdb_ci",
+            install_status="",
+            operational_status="",
+        )
+        table_client.update_record.return_value = dict(
+            sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
+            name="test.name",
+            sys_class_name="cmdb_ci",
+            install_status="1",
+            operational_status="5",
+        )
+        attachment_client.update_records.return_value = []
+        attachment_client.list_records.return_value = []
+
+        result = configuration_item.ensure_present(
+            module, table_client, attachment_client
+        )
+
+        table_client.update_record.assert_called_once()
+        assert result == (
+            True,
+            dict(
+                sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
+                name="test.name",
+                sys_class_name="cmdb_ci",
+                install_status="installed",
+                operational_status="ready",
+                attachments=[],
+            ),
+            dict(
+                before=dict(
+                    sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
+                    name="test.name",
+                    sys_class_name="cmdb_ci",
+                    install_status="",
+                    operational_status="",
+                    attachments=[],
+                ),
+                after=dict(
+                    sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
+                    name="test.name",
                     sys_class_name="cmdb_ci",
                     install_status="installed",
                     operational_status="ready",

--- a/tests/unit/plugins/modules/test_configuration_item.py
+++ b/tests/unit/plugins/modules/test_configuration_item.py
@@ -30,7 +30,6 @@ class TestEnsureAbsent:
                     host="https://my.host.name", username="user", password="pass"
                 ),
                 state="absent",
-                number=None,
                 name=None,
                 sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
                 sys_class_name="cmdb_ci",
@@ -66,7 +65,6 @@ class TestEnsureAbsent:
                     host="https://my.host.name", username="user", password="pass"
                 ),
                 state="absent",
-                number=None,
                 name="my_name",
                 sys_id=None,
                 sys_class_name="cmdb_ci",
@@ -93,6 +91,41 @@ class TestEnsureAbsent:
             ),
         )
 
+    def test_delete_configuration_item_using_sys_id_and_name(
+        self, create_module, table_client, attachment_client
+    ):
+        module = create_module(
+            params=dict(
+                instance=dict(
+                    host="https://my.host.name", username="user", password="pass"
+                ),
+                state="absent",
+                name="my_name",
+                sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
+                sys_class_name="cmdb_ci",
+            )
+        )
+        table_client.get_record.return_value = dict(
+            sys_class_name="cmdb_ci", name="my_name", sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3"
+        )
+
+        result = configuration_item.ensure_absent(
+            module, table_client, attachment_client
+        )
+
+        table_client.get_record.assert_called_once_with("cmdb_ci", {"name": "my_name", "sys_id": "01a9ec0d3790200044e0bfc8bcbe5dc3"})
+        table_client.delete_record.assert_called_once()
+        assert result == (
+            True,
+            None,
+            dict(
+                before=dict(
+                    sys_class_name="cmdb_ci", name="my_name", sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3"
+                ),
+                after=None,
+            ),
+        )
+
     def test_delete_configuration_item_none_cmdb_ci(
         self, create_module, table_client, attachment_client
     ):
@@ -102,7 +135,6 @@ class TestEnsureAbsent:
                     host="https://my.host.name", username="user", password="pass"
                 ),
                 state="absent",
-                number=None,
                 name=None,
                 sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
                 sys_class_name="cmdb_ci_computer",
@@ -138,7 +170,6 @@ class TestEnsureAbsent:
                     host="https://my.host.name", username="user", password="pass"
                 ),
                 state="absent",
-                number=None,
                 name=None,
                 sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
                 sys_class_name="cmdb_ci",

--- a/tests/unit/plugins/modules/test_configuration_item_info.py
+++ b/tests/unit/plugins/modules/test_configuration_item_info.py
@@ -82,7 +82,7 @@ class TestMain:
             sys_id=sys_id_value,
             name=name_value,
             query=query_value,
-            sysparm=sysparm_query_value,
+            sysparm_query=sysparm_query_value,
             sys_class_name="cmdb_ci",
         )
         success, result = run_main(configuration_item_info, params)

--- a/tests/unit/plugins/modules/test_configuration_item_info.py
+++ b/tests/unit/plugins/modules/test_configuration_item_info.py
@@ -70,7 +70,7 @@ class TestMain:
             ),
             sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
             sys_class_name="cmdb_ci",
-            name="test.name"
+            name="test.name",
         )
         success, result = run_main(configuration_item_info, params)
 
@@ -181,7 +181,7 @@ class TestRun:
                     host="https://my.host.name", username="user", password="pass"
                 ),
                 sys_class_name="cmdb_ci",
-                query=[{"category": "= Hardware"}]
+                query=[{"category": "= Hardware"}],
             )
         )
         table_client.list_records.return_value = []
@@ -190,5 +190,5 @@ class TestRun:
         configuration_item_info.run(module, table_client, attachment_client)
 
         table_client.list_records.assert_called_once_with(
-            "cmdb_ci", {'sysparm_query': 'category=Hardware'}
+            "cmdb_ci", {"sysparm_query": "category=Hardware"}
         )

--- a/tests/unit/plugins/modules/test_configuration_item_info.py
+++ b/tests/unit/plugins/modules/test_configuration_item_info.py
@@ -163,6 +163,7 @@ class TestRun:
                 name="test.name",
                 sys_class_name="cmdb_ci",
                 query=None,
+                sysparm_display_value="true",
             )
         )
         table_client.list_records.return_value = []
@@ -182,6 +183,7 @@ class TestRun:
                 ),
                 sys_class_name="cmdb_ci",
                 query=[{"category": "= Hardware"}],
+                sysparm_display_value="true",
             )
         )
         table_client.list_records.return_value = []
@@ -190,5 +192,5 @@ class TestRun:
         configuration_item_info.run(module, table_client, attachment_client)
 
         table_client.list_records.assert_called_once_with(
-            "cmdb_ci", {"sysparm_query": "category=Hardware"}
+            "cmdb_ci", {"sysparm_query": "category=Hardware", "sysparm_display_value": "true"}
         )

--- a/tests/unit/plugins/modules/test_configuration_item_info.py
+++ b/tests/unit/plugins/modules/test_configuration_item_info.py
@@ -192,5 +192,6 @@ class TestRun:
         configuration_item_info.run(module, table_client, attachment_client)
 
         table_client.list_records.assert_called_once_with(
-            "cmdb_ci", {"sysparm_query": "category=Hardware", "sysparm_display_value": "true"}
+            "cmdb_ci",
+            {"sysparm_query": "category=Hardware", "sysparm_display_value": "true"},
         )


### PR DESCRIPTION
##### SUMMARY
Currently, the sys_id is the only parameter used to determine if we should be operating on one of the existing records or create a new one. In this PR the name parameter is added to also serve as a unique identifier of the record. As a consequence, it is impossible to insert two different CMDB items with the same name using Ansible. This breaks a task where a new record is created using existing name in CMDB. Instead, an existing record is updated (as opposed to before when a new record was created).

Accordingly, `configuration_item_info` module was updated with option "name".

Fixes #71 

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
`servicenow.itsm.configuration_item`
`servicenow.itsm.configuration_item_info`
Also updated unit and integration tests for the modules

##### ADDITIONAL INFORMATION
###### `configuration_item` module before/after:
Running the task:
```yaml
- name: update CMDB
  servicenow.itsm.configuration_item:
    name: "{{ inventory_hostname }}"
    sys_class_name: cmdb_ci_server
    other:
        monitor: true
  delegate_to: localhost
```

**before**: the task results in 2 changes adding 2 identical records to the *cmdb*
**after**: the first run will show *changed* and 2nd change will show *ok*

###### `configuration_item_info` module before/after:
**before:** query by name was done only like this: 
```yaml
- name: Query CMDB by name
  servicenow.itsm.configuration_item_info:
    query:
    - name: = lnux101
```

**after:** query by name can also be done like this: 
```yaml
- name: Query CMDB by name
  servicenow.itsm.configuration_item_info:
    name: = lnux101
```