### PR TITLE
Adapt integration tests for attachment module due to changes on PR 192 (configuration item idempotency)

### DIFF
--- a/changelogs/fragments/adapt_attachment_integration_tests.yml
+++ b/changelogs/fragments/adapt_attachment_integration_tests.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- attachment integration tests - Adapt integration tests for attachment module due to changes on PR 192 (https://github.com/ansible-collections/servicenow.itsm/pull/193)

--- a/tests/integration/targets/attachment/tasks/main.yml
+++ b/tests/integration/targets/attachment/tasks/main.yml
@@ -482,3 +482,13 @@
         that:
           - result is failed
           - "'Record' in result.msg"
+
+    - name: Delete configuration item
+      servicenow.itsm.configuration_item:
+        name: my-configuration-item
+        state: absent
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result is changed


### PR DESCRIPTION
##### SUMMARY
Since PR 192 implements name as a unique identifier in configuration_item module, existing attachment integration test needed to be updated for the following configuration_item integration test to pass. Deletion of the configuration item was added at the end of the attachment integration test.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Attachment integration test (main.yml)
