### PR TITLE
force click==8.0.4 to fix sanity check error, fix #196

### DIFF
--- a/sanity.requirements
+++ b/sanity.requirements
@@ -1,2 +1,3 @@
+click==8.0.4
 black<=21.12b0  # as long as we need to support Python 2.7
 flake8


### PR DESCRIPTION
##### SUMMARY
Fix error for sanity check
##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION
after this click version has been forced I could run sanity checks, rigth now workin with this env.

```
ansible-base==2.10.17
black==21.12b0
cffi==1.15.1
click==8.0.4
cryptography==37.0.4
flake8==5.0.4
Jinja2==3.1.2
MarkupSafe==2.1.1
mccabe==0.7.0
mypy-extensions==0.4.3
packaging==21.3
pathspec==0.9.0
platformdirs==2.5.2
pycodestyle==2.9.1
pycparser==2.21
pyflakes==2.5.0
pyparsing==3.0.9
PyYAML==6.0
tomli==1.2.3
typing-extensions==4.3.0
```
