### PR TITLE
Fix sanity error in test_api

### DIFF
--- a/changelogs/fragments/test_api_remove_unused_import.yml
+++ b/changelogs/fragments/test_api_remove_unused_import.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- test_api - Remove unused import which caused sanity error. (https://github.com/ansible-collections/servicenow.itsm/pull/204)

--- a/tests/unit/plugins/modules/test_api.py
+++ b/tests/unit/plugins/modules/test_api.py
@@ -12,7 +12,6 @@ import sys
 import pytest
 
 from ansible_collections.servicenow.itsm.plugins.modules import api
-from ansible_collections.servicenow.itsm.plugins.module_utils import errors
 
 pytestmark = pytest.mark.skipif(
     sys.version_info < (2, 7), reason="requires python2.7 or higher"


### PR DESCRIPTION
##### SUMMARY
From test_api.py removed unused import which caused sanity error.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
test_api.py
