### PR TITLE
add return_fields parmeter to the configuration_item_info module

### DIFF
--- a/changelogs/fragments/configuration_item_info_return_fields.yml
+++ b/changelogs/fragments/configuration_item_info_return_fields.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - configuration_item_info - allow user to specify limited return fields for the specified configuration item (https://github.com/ansible-collections/servicenow.itsm/pull/208).


### PR DESCRIPTION
##### SUMMARY

add return_fields parmeter to the configuration_item_info module, needed for choose only needed information   It will speed considerably the response. and the returned data to process. It will be needed to build data maintentance proceses with heavily loaded classes. 

Implements #100 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
configuration_item_info

##### ADDITIONAL INFORMATION

Consider a data process to update info only some ci's with operational_status="opeational" , you need first query the complete class and after do something in a loop with the sys_id of each CI.

```yaml
    - name: get info
      servicenow.itsm.configuration_item_info:
        sys_class_name: cmdb_ci_appl_ora_tns
        return_fields:
          - name
          - sys_id
          - operational_status
      register: result

    - name: Debug info
      debug:
        var: result
```
Time taken  to execute this playbook with "return_fields" : 4.405 seconds

Time taken to execute this playbook  without "return_fields" : 11.94 seconds ( only with 6 ci's !!!) 

we can guess what will happend when exected this query on a class with 100K registers.

*result with return_fields*

```json
{
        "changed": false,
        "failed": false,
        "records": [
            {
                "name": "AAACDB3-PDB21-OTHER2",
                "operational_status": "operational",
                "sys_id": "68520d8197651110968b74400153af66"
            },
            {
                "name": "AAACDB2-PDB22-KKNEW",
                "operational_status": "operational",
                "sys_id": "6a29040107a01110befff6fd7c1ed070"
            },
            {
                "name": "AAACDB1-PDB11-ABEL",
                "operational_status": "operational",
                "sys_id": "9bb1fee807241110befff6fd7c1ed089"
            },
            {
                "name": "AAACDB2-PDB22-TEST1",
                "operational_status": "operational",
                "sys_id": "d16a945e07815110befff6fd7c1ed0a4"
            },
            {
                "name": "AAACDB3-PDB21-OTHER",
                "operational_status": "operational",
                "sys_id": "f16a945e07815110befff6fd7c1ed0a7"
            },
            {
                "name": "AAACDB1-PDB12-TEST2",
                "operational_status": "operational",
                "sys_id": "fac2be2c07241110befff6fd7c1ed0a9"
            }
        ]
    }
```

*result without return_fields*

```json

        "changed": false,
        "failed": false,
        "records": [
            {
                "asset": "",
                "asset_tag": "",
                "assigned": "",
                "assigned_to": "",
                "assignment_group": "",
                "attachments": [],
                "attestation_score": "",
                "attested": "false",
                "attested_by": "",
                "attested_date": "",
                "attributes": "",
                "business_unit": "",
                "can_print": "false",
                "category": "",
                "change_control": "",
                "checked_in": "",
                "checked_out": "",
                "cl_port": "",
                "classifier": "",
                "comments": "",
                "company": "",
                "config_directory": "",
                "config_file": "",
                "correlation_id": "",
                "cost": "",
                "cost_cc": "USD",
                "cost_center": "",
                "delivery_date": "",
                "department": "",
                "discovery_source": "",
                "dns_domain": "",
                "due": "",
                "due_in": "",
                "duplicate_of": "",
                "edition": "",
                "environment": "",
                "fault_count": "0",
                "first_discovered": "",
                "fqdn": "",
                "gl_account": "",
                "install_date": "",
                "install_directory": "",
                "install_status": "installed",
                "invoice_number": "",
                "ip_address": "",
                "is_clustered": "false",
                "justification": "",
                "last_discovered": "",
                "lease_id": "",
                "life_cycle_stage": "",
                "life_cycle_stage_status": "",
                "location": "",
                "mac_address": "",
                "maintenance_schedule": "",
                "managed_by": "",
                "managed_by_group": "",
                "manufacturer": "",
                "model_id": "",
                "model_number": "",
                "monitor": "false",
                "name": "AAACDB3-PDB21-OTHER2",
                "operational_status": "operational",
                "order_date": "",
                "owned_by": "",
                "pid": "",
                "po_number": "",
                "purchase_date": "",
                "rp_command_hash": "",
                "rp_key_parameters_hash": "",
                "running_process": "",
                "running_process_command": "",
                "running_process_key_parameters": "",
                "schedule": "",
                "serial_number": "",
                "short_description": "",
                "skip_sync": "false",
                "start_date": "",
                "subcategory": "",
                "support_group": "",
                "supported_by": "",
                "sys_class_name": "cmdb_ci_appl_ora_tns",
                "sys_class_path": "/!!/!(/!|",
                "sys_created_by": "admin",
                "sys_created_on": "2022-08-24 12:52:05",
                "sys_domain": "global",
                "sys_domain_path": "/",
                "sys_id": "68520d8197651110968b74400153af66",
                "sys_mod_count": "0",
                "sys_tags": "",
                "sys_updated_by": "admin",
                "sys_updated_on": "2022-08-24 12:52:05",
                "tcp_port": "",
                "u_tns_content": "AAACDB3-PDB21-OTHER2.WORLD=\n  (DESCRIPTION=\n    (ADDRESS=\n      (COMMUNITY=tcp.world)\n      (PROTOCOL=TCP)\n      (HOST=localhost)\n      (PORT=23)\n    )\n    (CONNECT_DATA=\n      (SID=TEST1)\n    )\n  )\n",
                "unverified": "false",
                "used_for": "Production",
                "vendor": "",
                "version": "",
                "warranty_expiration": ""
            },
            {
                "asset": "",
                "asset_tag": "",
                "assigned": "",
                "assigned_to": "",
                "assignment_group": "",
                "attachments": [],
                "attestation_score": "",
                "attested": "false",
                "attested_by": "",
                "attested_date": "",
                "attributes": "",
                "business_unit": "",
                "can_print": "false",
                "category": "",
                "change_control": "",
                "checked_in": "",
                "checked_out": "",
                "cl_port": "",
                "classifier": "",
                "comments": "",
                "company": "",
                "config_directory": "",
                "config_file": "",
                "correlation_id": "",
                "cost": "",
                "cost_cc": "USD",
                "cost_center": "",
                "delivery_date": "",
                "department": "",
                "discovery_source": "",
                "dns_domain": "",
                "due": "",
                "due_in": "",
                "duplicate_of": "",
                "edition": "",
                "environment": "",
                "fault_count": "0",
                "first_discovered": "",
                "fqdn": "",
                "gl_account": "",
                "install_date": "",
                "install_directory": "",
                "install_status": "installed",
                "invoice_number": "",
                "ip_address": "",
                "is_clustered": "false",
                "justification": "",
                "last_discovered": "",
                "lease_id": "",
                "life_cycle_stage": "",
                "life_cycle_stage_status": "",
                "location": "",
                "mac_address": "",
                "maintenance_schedule": "",
                "managed_by": "",
                "managed_by_group": "",
                "manufacturer": "",
                "model_id": "",
                "model_number": "",
                "monitor": "false",
                "name": "AAACDB2-PDB22-KKNEW",
                "operational_status": "operational",
                "order_date": "",
                "owned_by": "",
                "pid": "",
                "po_number": "",
                "purchase_date": "",
                "rp_command_hash": "",
                "rp_key_parameters_hash": "",
                "running_process": "",
                "running_process_command": "",
                "running_process_key_parameters": "",
                "schedule": "",
                "serial_number": "",
                "short_description": "",
                "skip_sync": "false",
                "start_date": "",
                "subcategory": "",
                "support_group": "",
                "supported_by": "",
                "sys_class_name": "cmdb_ci_appl_ora_tns",
                "sys_class_path": "/!!/!(/!|",
                "sys_created_by": "admin",
                "sys_created_on": "2022-07-05 15:39:46",
                "sys_domain": "global",
                "sys_domain_path": "/",
                "sys_id": "6a29040107a01110befff6fd7c1ed070",
                "sys_mod_count": "14",
                "sys_tags": "",
                "sys_updated_by": "admin",
                "sys_updated_on": "2022-08-03 13:24:15",
                "tcp_port": "",
                "u_tns_content": "AAACDB2-PDB22-KKNEW.WORLD=\n  (DESCRIPTION=\n    (ADDRESS=\n      (COMMUNITY=tcp.world)\n      (PROTOCOL=TCP)\n      (HOST=localhost)\n      (PORT=23)\n    )\n    (CONNECT_DATA=\n      (SID=TEST1)\n    )\n  )\n",
                "unverified": "false",
                "used_for": "Production",
                "vendor": "",
                "version": "aSDf",
                "warranty_expiration": ""
            },
            {
                "asset": "",
                "asset_tag": "",
                "assigned": "",
                "assigned_to": "",
                "assignment_group": "",
                "attachments": [],
                "attestation_score": "",
                "attested": "false",
                "attested_by": "",
                "attested_date": "",
                "attributes": "",
                "business_unit": "",
                "can_print": "false",
                "category": "",
                "change_control": "",
                "checked_in": "",
                "checked_out": "",
                "cl_port": "",
                "classifier": "",
                "comments": "",
                "company": "",
                "config_directory": "",
                "config_file": "",
                "correlation_id": "",
                "cost": "",
                "cost_cc": "USD",
                "cost_center": "",
                "delivery_date": "",
                "department": "",
                "discovery_source": "",
                "dns_domain": "",
                "due": "",
                "due_in": "",
                "duplicate_of": "",
                "edition": "",
                "environment": "",
                "fault_count": "0",
                "first_discovered": "",
                "fqdn": "",
                "gl_account": "",
                "install_date": "",
                "install_directory": "",
                "install_status": "installed",
                "invoice_number": "",
                "ip_address": "",
                "is_clustered": "false",
                "justification": "",
                "last_discovered": "",
                "lease_id": "",
                "life_cycle_stage": "",
                "life_cycle_stage_status": "",
                "location": "",
                "mac_address": "",
                "maintenance_schedule": "",
                "managed_by": "",
                "managed_by_group": "",
                "manufacturer": "",
                "model_id": "",
                "model_number": "",
                "monitor": "false",
                "name": "AAACDB1-PDB11-ABEL",
                "operational_status": "operational",
                "order_date": "",
                "owned_by": "",
                "pid": "",
                "po_number": "",
                "purchase_date": "",
                "rp_command_hash": "",
                "rp_key_parameters_hash": "",
                "running_process": "",
                "running_process_command": "",
                "running_process_key_parameters": "",
                "schedule": "",
                "serial_number": "",
                "short_description": "",
                "skip_sync": "false",
                "start_date": "",
                "subcategory": "",
                "support_group": "",
                "supported_by": "",
                "sys_class_name": "cmdb_ci_appl_ora_tns",
                "sys_class_path": "/!!/!(/!|",
                "sys_created_by": "admin",
                "sys_created_on": "2022-07-04 14:39:08",
                "sys_domain": "global",
                "sys_domain_path": "/",
                "sys_id": "9bb1fee807241110befff6fd7c1ed089",
                "sys_mod_count": "27",
                "sys_tags": "",
                "sys_updated_by": "admin",
                "sys_updated_on": "2022-08-24 09:33:37",
                "tcp_port": "",
                "u_tns_content": "AAACDB1-PDB11-ABEL.WORLD=\n  (DESCRIPTION=\n    (ADDRESS=\n      (COMMUNITY=tcp.world)\n      (PROTOCOL=TCP)\n      (HOST=localhost)\n      (PORT=22)\n    )\n    (CONNECT_DATA=\n      (SID=TEST1)\n    )\n  )\n",
                "unverified": "false",
                "used_for": "Production",
                "vendor": "",
                "version": "aa",
                "warranty_expiration": ""
            },
            {
                "asset": "",
                "asset_tag": "",
                "assigned": "",
                "assigned_to": "",
                "assignment_group": "",
                "attachments": [],
                "attestation_score": "",
                "attested": "false",
                "attested_by": "",
                "attested_date": "",
                "attributes": "",
                "business_unit": "",
                "can_print": "false",
                "category": "",
                "change_control": "",
                "checked_in": "",
                "checked_out": "",
                "cl_port": "",
                "classifier": "",
                "comments": "",
                "company": "",
                "config_directory": "",
                "config_file": "",
                "correlation_id": "",
                "cost": "",
                "cost_cc": "USD",
                "cost_center": "",
                "delivery_date": "",
                "department": "",
                "discovery_source": "",
                "dns_domain": "",
                "due": "",
                "due_in": "",
                "duplicate_of": "",
                "edition": "",
                "environment": "",
                "fault_count": "0",
                "first_discovered": "",
                "fqdn": "",
                "gl_account": "",
                "install_date": "",
                "install_directory": "",
                "install_status": "installed",
                "invoice_number": "",
                "ip_address": "",
                "is_clustered": "false",
                "justification": "",
                "last_discovered": "",
                "lease_id": "",
                "life_cycle_stage": "",
                "life_cycle_stage_status": "",
                "location": "",
                "mac_address": "",
                "maintenance_schedule": "",
                "managed_by": "",
                "managed_by_group": "",
                "manufacturer": "",
                "model_id": "",
                "model_number": "",
                "monitor": "false",
                "name": "AAACDB2-PDB22-TEST1",
                "operational_status": "operational",
                "order_date": "",
                "owned_by": "",
                "pid": "",
                "po_number": "",
                "purchase_date": "",
                "rp_command_hash": "",
                "rp_key_parameters_hash": "",
                "running_process": "",
                "running_process_command": "",
                "running_process_key_parameters": "",
                "schedule": "",
                "serial_number": "",
                "short_description": "",
                "skip_sync": "false",
                "start_date": "",
                "subcategory": "",
                "support_group": "",
                "supported_by": "",
                "sys_class_name": "cmdb_ci_appl_ora_tns",
                "sys_class_path": "/!!/!(/!|",
                "sys_created_by": "admin",
                "sys_created_on": "2022-08-03 10:38:40",
                "sys_domain": "global",
                "sys_domain_path": "/",
                "sys_id": "d16a945e07815110befff6fd7c1ed0a4",
                "sys_mod_count": "1",
                "sys_tags": "",
                "sys_updated_by": "admin",
                "sys_updated_on": "2022-08-03 12:25:13",
                "tcp_port": "",
                "u_tns_content": "AAACDB2-PDB22-TEST1.WORLD=\n  (DESCRIPTION=\n    (ADDRESS=\n      (COMMUNITY=tcp.world)\n      (PROTOCOL=TCP)\n      (HOST=localhost)\n      (PORT=23)\n    )\n    (CONNECT_DATA=\n      (SID=TEST1)\n    )\n  )\n",
                "unverified": "false",
                "used_for": "Production",
                "vendor": "",
                "version": "",
                "warranty_expiration": ""
            },
            {
                "asset": "",
                "asset_tag": "",
                "assigned": "",
                "assigned_to": "",
                "assignment_group": "",
                "attachments": [],
                "attestation_score": "",
                "attested": "false",
                "attested_by": "",
                "attested_date": "",
                "attributes": "",
                "business_unit": "",
                "can_print": "false",
                "category": "",
                "change_control": "",
                "checked_in": "",
                "checked_out": "",
                "cl_port": "",
                "classifier": "",
                "comments": "",
                "company": "",
                "config_directory": "",
                "config_file": "",
                "correlation_id": "",
                "cost": "",
                "cost_cc": "USD",
                "cost_center": "",
                "delivery_date": "",
                "department": "",
                "discovery_source": "",
                "dns_domain": "",
                "due": "",
                "due_in": "",
                "duplicate_of": "",
                "edition": "",
                "environment": "",
                "fault_count": "0",
                "first_discovered": "",
                "fqdn": "",
                "gl_account": "",
                "install_date": "",
                "install_directory": "",
                "install_status": "installed",
                "invoice_number": "",
                "ip_address": "",
                "is_clustered": "false",
                "justification": "",
                "last_discovered": "",
                "lease_id": "",
                "life_cycle_stage": "",
                "life_cycle_stage_status": "",
                "location": "",
                "mac_address": "",
                "maintenance_schedule": "",
                "managed_by": "",
                "managed_by_group": "",
                "manufacturer": "",
                "model_id": "",
                "model_number": "",
                "monitor": "false",
                "name": "AAACDB3-PDB21-OTHER",
                "operational_status": "operational",
                "order_date": "",
                "owned_by": "",
                "pid": "",
                "po_number": "",
                "purchase_date": "",
                "rp_command_hash": "",
                "rp_key_parameters_hash": "",
                "running_process": "",
                "running_process_command": "",
                "running_process_key_parameters": "",
                "schedule": "",
                "serial_number": "",
                "short_description": "",
                "skip_sync": "false",
                "start_date": "",
                "subcategory": "",
                "support_group": "",
                "supported_by": "",
                "sys_class_name": "cmdb_ci_appl_ora_tns",
                "sys_class_path": "/!!/!(/!|",
                "sys_created_by": "admin",
                "sys_created_on": "2022-08-03 10:38:42",
                "sys_domain": "global",
                "sys_domain_path": "/",
                "sys_id": "f16a945e07815110befff6fd7c1ed0a7",
                "sys_mod_count": "1",
                "sys_tags": "",
                "sys_updated_by": "admin",
                "sys_updated_on": "2022-08-03 12:25:15",
                "tcp_port": "",
                "u_tns_content": "AAACDB3-PDB21-OTHER.WORLD=\n  (DESCRIPTION=\n    (ADDRESS=\n      (COMMUNITY=tcp.world)\n      (PROTOCOL=TCP)\n      (HOST=localhost)\n      (PORT=23)\n    )\n    (CONNECT_DATA=\n      (SID=TEST1)\n    )\n  )\n",
                "unverified": "false",
                "used_for": "Production",
                "vendor": "",
                "version": "",
                "warranty_expiration": ""
            },
            {
                "asset": "",
                "asset_tag": "",
                "assigned": "",
                "assigned_to": "",
                "assignment_group": "",
                "attachments": [],
                "attestation_score": "",
                "attested": "false",
                "attested_by": "",
                "attested_date": "",
                "attributes": "",
                "business_unit": "",
                "can_print": "false",
                "category": "",
                "change_control": "",
                "checked_in": "",
                "checked_out": "",
                "cl_port": "",
                "classifier": "",
                "comments": "",
                "company": "",
                "config_directory": "",
                "config_file": "",
                "correlation_id": "",
                "cost": "",
                "cost_cc": "USD",
                "cost_center": "",
                "delivery_date": "",
                "department": "",
                "discovery_source": "",
                "dns_domain": "",
                "due": "",
                "due_in": "",
                "duplicate_of": "",
                "edition": "",
                "environment": "",
                "fault_count": "0",
                "first_discovered": "",
                "fqdn": "",
                "gl_account": "",
                "install_date": "",
                "install_directory": "",
                "install_status": "installed",
                "invoice_number": "",
                "ip_address": "",
                "is_clustered": "false",
                "justification": "",
                "last_discovered": "",
                "lease_id": "",
                "life_cycle_stage": "",
                "life_cycle_stage_status": "",
                "location": "",
                "mac_address": "",
                "maintenance_schedule": "",
                "managed_by": "",
                "managed_by_group": "",
                "manufacturer": "",
                "model_id": "",
                "model_number": "",
                "monitor": "false",
                "name": "AAACDB1-PDB12-TEST2",
                "operational_status": "operational",
                "order_date": "",
                "owned_by": "",
                "pid": "",
                "po_number": "",
                "purchase_date": "",
                "rp_command_hash": "",
                "rp_key_parameters_hash": "",
                "running_process": "",
                "running_process_command": "",
                "running_process_key_parameters": "",
                "schedule": "",
                "serial_number": "",
                "short_description": "",
                "skip_sync": "false",
                "start_date": "",
                "subcategory": "",
                "support_group": "",
                "supported_by": "",
                "sys_class_name": "cmdb_ci_appl_ora_tns",
                "sys_class_path": "/!!/!(/!|",
                "sys_created_by": "admin",
                "sys_created_on": "2022-07-04 14:43:45",
                "sys_domain": "global",
                "sys_domain_path": "/",
                "sys_id": "fac2be2c07241110befff6fd7c1ed0a9",
                "sys_mod_count": "14",
                "sys_tags": "",
                "sys_updated_by": "admin",
                "sys_updated_on": "2022-08-03 13:24:13",
                "tcp_port": "",
                "u_tns_content": "AAACDB1-PDB12-TEST2.WORLD=\n (DESCRIPTION_LIST=\n  (LOAD_BALANCE=off)\n  (FAILOVER=on)\n  (DESCRIPTION=\n   (CONNECT_TIMEOUT=5)\n   (RETRY_COUNT=3)\n   (RETRY_DELAY=1)\n   (TRANSPORT_CONNECT_TIMEOUT=3)\n   (ADDRESS_LIST=\n    (LOAD_BALANCE=on)\n  (ADDRESS=\n   (PROTOCOL=TCP)\n   (HOST=localhost)(PORT=21)))\n   (CONNECT_DATA=(SERVICE_NAME=FIN01_P_AP))\n   )\n   (DESCRIPTION=\n    (CONNECT_TIMEOUT=5)\n  (RETRY_COUNT=3)\n  (RETRY_DELAY=1)\n  (TRANSPORT_CONNECT_TIMEOUT=3)\n  (ADDRESS_LIST=\n   (LOAD_BALANCE=on)\n   (ADDRESS=\n    (PROTOCOL=TCP)\n    (HOST=localhost)(PORT=22)))\n    (CONNECT_DATA=(SERVICE_NAME=FIN01_P_AP))\n   )\n   (DESCRIPTION=\n    (CONNECT_TIMEOUT=5)\n  (RETRY_COUNT=3)\n  (RETRY_DELAY=1)\n  (TRANSPORT_CONNECT_TIMEOUT=3)\n  (ADDRESS_LIST=\n   (LOAD_BALANCE=on)\n   (ADDRESS=\n    (PROTOCOL=TCP)\n    (HOST=localhost)(PORT=23)))\n    (CONNECT_DATA=(SERVICE_NAME=FIN01_P_AP))\n   )\n )\n",
                "unverified": "false",
                "used_for": "Production",
                "vendor": "",
                "version": "v1",
                "warranty_expiration": ""
            }
        ]
    }
```

