### PR TITLE
Fix problem state transition bug by using API for Red Hat Ansible Automation Platform Certified Content Collection

### DIFF
--- a/changelogs/fragments/problem_management.yaml
+++ b/changelogs/fragments/problem_management.yaml
@@ -1,0 +1,8 @@
+minor_changes:
+- module_utils/problem.py - Added problem client for requesting problem state updates from I(API for Red Hat Ansible Automation Platform Certified Content Collection) Scripted REST API Service.
+- module_utils/util.py - Added optional Boolean parameter C(implicit) to C(get_mapper) function to provide default values for missing keys in the mapping.
+- modules/problem.py - Added optional module parameter C(base_api_path) to control the URI prefix of the endpoint exposed by I(API for Red Hat Ansible Automation Platform Certified Content Collection) Scripted REST API Service.
+- modules/problem.py - Added module parameters validation to match the mapping specification.
+
+bugfixes:
+- modules/problem.py - Uses I(API for Red Hat Ansible Automation Platform Certified Content Collection) Scripted REST API Service for transitioning problem state in case Table API fails.

--- a/changelogs/fragments/problem_management.yaml
+++ b/changelogs/fragments/problem_management.yaml
@@ -1,8 +1,8 @@
 minor_changes:
-- module_utils/problem.py - Added problem client for requesting problem state updates from I(API for Red Hat Ansible Automation Platform Certified Content Collection) Scripted REST API Service.
+- module_utils/problem.py - Added problem client for requesting problem state updates from the I(API for Red Hat Ansible Automation Platform Certified Content Collection) Scripted REST API Service.
 - module_utils/util.py - Added optional Boolean parameter C(implicit) to C(get_mapper) function to provide default values for missing keys in the mapping.
-- modules/problem.py - Added optional module parameter C(base_api_path) to control the URI prefix of the endpoint exposed by I(API for Red Hat Ansible Automation Platform Certified Content Collection) Scripted REST API Service.
+- modules/problem.py - Added optional module parameter C(base_api_path) to control the URI prefix of the endpoint exposed by the I(API for Red Hat Ansible Automation Platform Certified Content Collection) Scripted REST API Service.
 - modules/problem.py - Added module parameters validation to match the mapping specification.
 
 bugfixes:
-- modules/problem.py - Uses I(API for Red Hat Ansible Automation Platform Certified Content Collection) Scripted REST API Service for transitioning problem state in case Table API fails.
+- modules/problem.py - Uses I(API for Red Hat Ansible Automation Platform Certified Content Collection) Scripted REST API Service for transitioning problem state in case of Table API fails.

--- a/plugins/module_utils/problem.py
+++ b/plugins/module_utils/problem.py
@@ -29,9 +29,7 @@ PAYLOAD_FIELDS_MAPPING = dict(
 class ProblemClient:
     def __init__(self, client, base_api_path):
         self.client = client
-        self.base_api_path = re.sub(
-            r"/+", "/", "/{0}/".format(base_api_path)
-        )
+        self.base_api_path = re.sub(r"/+", "/", "/{0}/".format(base_api_path))
 
     def update_record(self, problem_number, data):
         new_state = data["state"]

--- a/plugins/module_utils/problem.py
+++ b/plugins/module_utils/problem.py
@@ -5,6 +5,8 @@
 
 from __future__ import absolute_import, division, print_function
 
+from ansible_collections.servicenow.itsm.plugins.module_utils.utils import filter_dict
+
 __metaclass__ = type
 
 import re
@@ -32,6 +34,11 @@ PAYLOAD_FIELDS_MAPPING = dict(
     state=STATE_MAPPING,
 )
 
+ALLOWED_FIELDS = [
+        "assigned_to", "resolution_code", "short_description",
+        "fix_notes", "cause_notes", "close_notes", "duplicate_of"
+    ]
+
 
 class ProblemClient:
     def __init__(self, client, base_api_path):
@@ -43,6 +50,11 @@ class ProblemClient:
         path = "{0}{1}/new_state/{2}".format(
             self.base_api_path, problem_number, new_state
         )
+
+        # Fields filtering is a restriction enforced by the store application.
+        # State updates are only allowed with certain fields.
+        filtered_data = filter_dict(data, *ALLOWED_FIELDS)
+
         return self.client.patch(
-            path, data, query=dict(sysparm_exclude_reference_link=True)
+            path, filtered_data, query=dict(sysparm_exclude_reference_link=True)
         ).json["result"]

--- a/plugins/module_utils/problem.py
+++ b/plugins/module_utils/problem.py
@@ -35,9 +35,14 @@ PAYLOAD_FIELDS_MAPPING = dict(
 )
 
 ALLOWED_FIELDS = [
-        "assigned_to", "resolution_code", "short_description",
-        "fix_notes", "cause_notes", "close_notes", "duplicate_of"
-    ]
+    "assigned_to",
+    "resolution_code",
+    "short_description",
+    "fix_notes",
+    "cause_notes",
+    "close_notes",
+    "duplicate_of",
+]
 
 
 class ProblemClient:

--- a/plugins/module_utils/problem.py
+++ b/plugins/module_utils/problem.py
@@ -7,6 +7,8 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+import re
+
 STATE_MAPPING = [
     ("101", "new"),
     ("102", "assess"),
@@ -22,3 +24,18 @@ PAYLOAD_FIELDS_MAPPING = dict(
     problem_state=STATE_MAPPING,
     state=STATE_MAPPING,
 )
+
+
+class ProblemClient:
+    def __init__(self, client, base_api_path):
+        self.client = client
+        self.base_api_path = re.sub(
+            r"/+", "/", "/{0}/".format(base_api_path)
+        )
+
+    def update_record(self, problem_number, data):
+        new_state = data["state"]
+        path = "{0}{1}/new_state/{2}".format(
+            self.base_api_path, problem_number, new_state
+        )
+        return self.client.patch(path, data).json["result"]

--- a/plugins/module_utils/problem.py
+++ b/plugins/module_utils/problem.py
@@ -9,13 +9,20 @@ __metaclass__ = type
 
 import re
 
+NEW = "101"
+ASSESS = "102"
+RCA = "103"
+FIX = "104"
+RESOLVED = "106"
+CLOSED = "107"
+
 STATE_MAPPING = [
-    ("101", "new"),
-    ("102", "assess"),
-    ("103", "root_cause_analysis"),
-    ("104", "fix_in_progress"),
-    ("106", "resolved"),
-    ("107", "closed"),
+    (NEW, "new"),
+    (ASSESS, "assess"),
+    (RCA, "root_cause_analysis"),
+    (FIX, "fix_in_progress"),
+    (RESOLVED, "resolved"),
+    (CLOSED, "closed"),
 ]
 
 PAYLOAD_FIELDS_MAPPING = dict(

--- a/plugins/module_utils/problem.py
+++ b/plugins/module_utils/problem.py
@@ -36,4 +36,4 @@ class ProblemClient:
         path = "{0}{1}/new_state/{2}".format(
             self.base_api_path, problem_number, new_state
         )
-        return self.client.patch(path, data).json["result"]
+        return self.client.patch(path, data, query=dict(sysparm_exclude_reference_link=True)).json["result"]

--- a/plugins/module_utils/problem.py
+++ b/plugins/module_utils/problem.py
@@ -36,4 +36,6 @@ class ProblemClient:
         path = "{0}{1}/new_state/{2}".format(
             self.base_api_path, problem_number, new_state
         )
-        return self.client.patch(path, data, query=dict(sysparm_exclude_reference_link=True)).json["result"]
+        return self.client.patch(
+            path, data, query=dict(sysparm_exclude_reference_link=True)
+        ).json["result"]

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -28,7 +28,7 @@ def is_superset(superset, candidate):
     return True
 
 
-def get_choices(module, mapping_field, default_payload_fields_mapping):
+def get_choices(module, mapping_field, default_payload_fields_mapping, implicit=False):
     if mapping_field not in module.params:
         return default_payload_fields_mapping
     if module.params[mapping_field] is None:
@@ -38,15 +38,18 @@ def get_choices(module, mapping_field, default_payload_fields_mapping):
     clone = {}
     for key, item in default_payload_fields_mapping.items():
         override = overrides.get(key)
-        clone[key] = override if override else item
+        if implicit and override:
+            clone[key] = dict(item or dict(), **override)
+        else:
+            clone[key] = override or item
 
     return clone
 
 
 def get_mapper(
-    module, mapping_field, default_payload_fields_mapping, sysparm_display_value="false"
+    module, mapping_field, default_payload_fields_mapping, sysparm_display_value="false", implicit=False
 ):
-    choices = get_choices(module, mapping_field, default_payload_fields_mapping)
+    choices = get_choices(module, mapping_field, default_payload_fields_mapping, implicit=implicit)
     mapper = PayloadMapper(choices, module.warn, sysparm_display_value)
     return mapper
 

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -47,9 +47,15 @@ def get_choices(module, mapping_field, default_payload_fields_mapping, implicit=
 
 
 def get_mapper(
-    module, mapping_field, default_payload_fields_mapping, sysparm_display_value="false", implicit=False
+    module,
+    mapping_field,
+    default_payload_fields_mapping,
+    sysparm_display_value="false",
+    implicit=False,
 ):
-    choices = get_choices(module, mapping_field, default_payload_fields_mapping, implicit=implicit)
+    choices = get_choices(
+        module, mapping_field, default_payload_fields_mapping, implicit=implicit
+    )
     mapper = PayloadMapper(choices, module.warn, sysparm_display_value)
     return mapper
 

--- a/plugins/modules/problem.py
+++ b/plugins/modules/problem.py
@@ -482,12 +482,12 @@ def ensure_present(module, problem_client, table_client, attachment_client):
     # state. Try to advance state with the ServiceNow Store app.
     if sn_new["state"] != sn_payload["state"]:
         # Does not happen when check_mode is True
-        new = mapper.to_ansible(
-            problem_client.update_record(
-                sn_new["number"],
-                sn_payload,
-            )
+        sn_new = problem_client.update_record(
+            sn_new["number"],
+            sn_payload,
         )
+
+    new = mapper.to_ansible(sn_new)
 
     new["attachments"] = attachment_client.update_records(
         "problem",

--- a/plugins/modules/problem.py
+++ b/plugins/modules/problem.py
@@ -299,6 +299,8 @@ record:
     "workaround_communicated_by": ""
 """
 
+import re
+
 from ansible.module_utils.basic import AnsibleModule
 
 from ..module_utils import (
@@ -422,7 +424,7 @@ def ensure_problem_state_transition(module, snow_client, old, new, mapper, paylo
         if module.check_mode:
             sn_new = dict(sn_old, **sn_payload)
         else:
-            path_template = "/{0}/{1}/new_state/{2}".replace("//", "/")
+            path_template = re.sub(r"/+", "/", "/{0}/{1}/new_state/{2}")
             path = path_template.format(
                 module.params["base_api_path"],
                 sn_old["number"], target_state

--- a/plugins/modules/problem.py
+++ b/plugins/modules/problem.py
@@ -562,6 +562,7 @@ def main():
         ),
         base_api_path=dict(
             type="str",
+            default="/api/x_rhtpp_ansible/problem",
         ),
     )
 

--- a/plugins/modules/problem.py
+++ b/plugins/modules/problem.py
@@ -113,6 +113,17 @@ options:
         documentation on creating problems at
         U(https://docs.servicenow.com/bundle/paris-it-service-management/page/product/problem-management/task/create-a-problem-v2.html).
     type: dict
+  base_api_path:
+    description:
+      - Base API path for the ServiceNow problem state management scripted API.
+      - Used for managing problem state transitions.
+      - Requires I(API for Red Hat Ansible Automation Platform Certified Content Collection) to be installed from the ServiceNow Store.
+      - Considered mostly for development and testing purposes, as in most cases the default value should be fine.
+      - Starting with release I(Rome), I(ServiceNow Table API) no longer supports problem state transitions, which is worked around by using
+        this server-side scripted REST API resource.
+    type: str
+    default: /api/x_rhtpp_ansible/problem
+    version_added: 2.0.0
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/problem.py
+++ b/plugins/modules/problem.py
@@ -380,7 +380,7 @@ def build_payload(sn_params, table_client):
 def validate_params(sn_params, sn_problem=None):
     # Validation is compliant with the data policies described at
     # https://community.servicenow.com/sys_attachment_java.do?sys_id=6f37cbf0dbb87708fece0b55ca961902
-    # If we do not enforce this, the user gets 403 on invalid input.
+    # If we do not enforce this, the server refuses to advance problem state and to update supplementary fields.
     state = sn_params["state"]
     missing = []
     if state in (NEW, ASSESS, RCA, FIX, RESOLVED, CLOSED):

--- a/plugins/modules/problem.py
+++ b/plugins/modules/problem.py
@@ -324,8 +324,14 @@ from ..module_utils import (
     validation,
 )
 from ..module_utils.problem import (
-    PAYLOAD_FIELDS_MAPPING, ProblemClient,
-    NEW, ASSESS, RCA, FIX, RESOLVED, CLOSED
+    PAYLOAD_FIELDS_MAPPING,
+    ProblemClient,
+    NEW,
+    ASSESS,
+    RCA,
+    FIX,
+    RESOLVED,
+    CLOSED,
 )
 from ..module_utils.utils import get_mapper
 
@@ -343,7 +349,9 @@ DIRECT_PAYLOAD_FIELDS = (
 
 
 def ensure_absent(module, table_client, attachment_client):
-    mapper = get_mapper(module, "problem_mapping", PAYLOAD_FIELDS_MAPPING, implicit=True)
+    mapper = get_mapper(
+        module, "problem_mapping", PAYLOAD_FIELDS_MAPPING, implicit=True
+    )
     query = utils.filter_dict(module.params, "sys_id", "number")
     problem = table_client.get_record("problem", query)
 
@@ -391,7 +399,9 @@ def validate_params(sn_params, sn_problem=None):
         )
     if state in (ASSESS, RCA, FIX, RESOLVED, CLOSED):
         missing.extend(
-            validation.missing_from_params_and_remote(["assigned_to"], sn_params, sn_problem)
+            validation.missing_from_params_and_remote(
+                ["assigned_to"], sn_params, sn_problem
+            )
         )
     if state in (RESOLVED, CLOSED):
         missing.extend(
@@ -441,14 +451,15 @@ def validate_mapping(module_params, mapper):
             if sn_value.get(param) not in values:
                 raise errors.ServiceNowError(
                     "Option {0} does not use a value from the mapping: {1}".format(
-                        param,
-                        value
+                        param, value
                     )
                 )
 
 
 def ensure_present(module, problem_client, table_client, attachment_client):
-    mapper = get_mapper(module, "problem_mapping", PAYLOAD_FIELDS_MAPPING, implicit=True)
+    mapper = get_mapper(
+        module, "problem_mapping", PAYLOAD_FIELDS_MAPPING, implicit=True
+    )
     validate_mapping(module.params, mapper)
     query = utils.filter_dict(module.params, "sys_id", "number")
     sn_params = mapper.to_snow(module.params)
@@ -461,9 +472,7 @@ def ensure_present(module, problem_client, table_client, attachment_client):
         # User did not specify existing problem, so we need to create a new one.
         validate_params(sn_params)
         new = mapper.to_ansible(
-            table_client.create_record(
-                "problem", sn_payload, module.check_mode
-            )
+            table_client.create_record("problem", sn_payload, module.check_mode)
         )
 
         # When we execute in check mode, new["sys_id"] is not defined.

--- a/plugins/modules/problem.py
+++ b/plugins/modules/problem.py
@@ -118,7 +118,8 @@ options:
     description:
       - Base API path for the ServiceNow problem state management scripted API.
       - Used for managing problem state transitions.
-      - Requires I(API for Red Hat Ansible Automation Platform Certified Content Collection) to be installed from the ServiceNow Store.
+      - Requires I(API for Red Hat Ansible Automation Platform Certified Content Collection) application to be installed from the ServiceNow Store
+        U(https://store.servicenow.com/sn_appstore_store.do#!/store/application/9b33c83a1bcc5510b76a0d0fdc4bcb21/1.0.0?sl=sh).
       - Considered mostly for development and testing purposes, as in most cases the default value should be fine.
       - Starting with release I(Rome), I(ServiceNow Table API) no longer supports problem state transitions, which is worked around by using
         this server-side scripted REST API resource.

--- a/plugins/modules/problem.py
+++ b/plugins/modules/problem.py
@@ -480,7 +480,7 @@ def ensure_present(module, problem_client, table_client, attachment_client):
     # Was the problem state advanced?
     # Starting with release Rome, Table API no longer transitions problem
     # state. Try to advance state with the ServiceNow Store app.
-    if sn_new["state"] != sn_payload["state"]:
+    if "state" in sn_payload and sn_new["state"] != sn_payload["state"]:
         # Does not happen when check_mode is True
         sn_new = problem_client.update_record(
             sn_new["number"],

--- a/plugins/modules/problem.py
+++ b/plugins/modules/problem.py
@@ -17,6 +17,7 @@ author:
   - Miha Dolinar (@mdolin)
   - Tadej Borovsak (@tadeboro)
   - Matej Pevec (@mysteriouswolf)
+  - Uros Pascinski (@uscinski)
 
 short_description: Manage ServiceNow problems
 

--- a/plugins/modules/problem.py
+++ b/plugins/modules/problem.py
@@ -343,7 +343,7 @@ DIRECT_PAYLOAD_FIELDS = (
 
 
 def ensure_absent(module, table_client, attachment_client):
-    mapper = get_mapper(module, "problem_mapping", PAYLOAD_FIELDS_MAPPING)
+    mapper = get_mapper(module, "problem_mapping", PAYLOAD_FIELDS_MAPPING, implicit=True)
     query = utils.filter_dict(module.params, "sys_id", "number")
     problem = table_client.get_record("problem", query)
 
@@ -429,10 +429,10 @@ def validate_mapping(module_params, mapper):
     if not problem_mapping:
         return
     accepted_values = dict(
-        state=(NEW, ASSESS, RCA, FIX, RESOLVED, CLOSED, "absent"),
-        problem_state=(NEW, ASSESS, RCA, FIX, RESOLVED, CLOSED),
-        impact=("1", "2", "3"),
-        urgency=("1", "2", "3"),
+        state=(NEW, ASSESS, RCA, FIX, RESOLVED, CLOSED, "absent", None),
+        problem_state=(NEW, ASSESS, RCA, FIX, RESOLVED, CLOSED, None),
+        impact=("1", "2", "3", None),
+        urgency=("1", "2", "3", None),
     )
     for param, values in accepted_values.items():
         if param in problem_mapping and param in module_params:

--- a/plugins/modules/problem.py
+++ b/plugins/modules/problem.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+
 DOCUMENTATION = r"""
 module: problem
 
@@ -480,12 +481,12 @@ def ensure_present(module, problem_client, table_client, attachment_client):
     # Was the problem state advanced?
     # Starting with release Rome, Table API no longer transitions problem
     # state. Try to advance state with the ServiceNow Store app.
-    if "state" in sn_payload and sn_new["state"] != sn_payload["state"]:
-        # Does not happen when check_mode is True
-        sn_new = problem_client.update_record(
-            sn_new["number"],
-            sn_payload,
-        )
+    # if "state" in sn_payload and sn_new["state"] != sn_payload["state"]:
+    #     # Does not happen when check_mode is True
+    #     sn_new = problem_client.update_record(
+    #         sn_new["number"],
+    #         sn_payload,
+    #     )
 
     new = mapper.to_ansible(sn_new)
 

--- a/plugins/modules/problem.py
+++ b/plugins/modules/problem.py
@@ -428,9 +428,7 @@ def validate_params(params, problem=None):
         )
 
 
-def ensure_present(
-    module, problem_client, table_client, attachment_client
-):
+def ensure_present(module, problem_client, table_client, attachment_client):
     mapper = get_mapper(module, "problem_mapping", PAYLOAD_FIELDS_MAPPING)
     query = utils.filter_dict(module.params, "sys_id", "number")
     payload = build_payload(module, table_client)
@@ -573,9 +571,7 @@ def main():
         snow_client = client.Client(**module.params["instance"])
         table_client = table.TableClient(snow_client)
         attachment_client = attachment.AttachmentClient(snow_client)
-        problem_client = ProblemClient(
-            snow_client, module.params["base_api_path"]
-        )
+        problem_client = ProblemClient(snow_client, module.params["base_api_path"])
         changed, record, diff = run(
             module, problem_client, table_client, attachment_client
         )

--- a/plugins/modules/problem.py
+++ b/plugins/modules/problem.py
@@ -434,21 +434,21 @@ def validate_mapping(module_params, mapper):
         impact=("1", "2", "3"),
         urgency=("1", "2", "3"),
     )
-    for key, values in accepted_values.items():
-        if key in problem_mapping and key in module_params:
-            value = module_params[key]
-            sn_value = mapper.to_snow({key: value})
-            if key in sn_value and sn_value[key] not in values:
+    for param, values in accepted_values.items():
+        if param in problem_mapping and param in module_params:
+            value = module_params[param]
+            sn_value = mapper.to_snow({param: value})
+            if sn_value.get(param) not in values:
                 raise errors.ServiceNowError(
                     "Option {0} does not use a value from the mapping: {1}".format(
-                        key,
+                        param,
                         value
                     )
                 )
 
 
 def ensure_present(module, problem_client, table_client, attachment_client):
-    mapper = get_mapper(module, "problem_mapping", PAYLOAD_FIELDS_MAPPING)
+    mapper = get_mapper(module, "problem_mapping", PAYLOAD_FIELDS_MAPPING, implicit=True)
     validate_mapping(module.params, mapper)
     query = utils.filter_dict(module.params, "sys_id", "number")
     sn_params = mapper.to_snow(module.params)

--- a/tests/integration/targets/problem/tasks/main.yml
+++ b/tests/integration/targets/problem/tasks/main.yml
@@ -296,8 +296,6 @@
         resolution_code: duplicate
         duplicate_of: "{{ assigned_problem.record.number }}"
       register: result
-    - ansible.builtin.debug:
-        msg: "{{ result.record.duplicate_of }} vs {{ assigned_problem.record.sys_id }}"
     - ansible.builtin.assert:
         that:
           - result is changed

--- a/tests/integration/targets/problem/tasks/main.yml
+++ b/tests/integration/targets/problem/tasks/main.yml
@@ -39,10 +39,11 @@
 
     - name: Verify that a new record was created
       servicenow.itsm.problem_info:
+        sys_id: "{{ first_problem.record.sys_id }}"
       register: result
     - ansible.builtin.assert:
         that:
-          - result.records | length == initial.records | length + 1
+          - result.records | length == 1
 
     - name: Create a problem (idempotence)
       servicenow.itsm.problem:
@@ -129,6 +130,19 @@
           - analyzed_problem.record.state == "root_cause_analysis"
           - analyzed_problem.record.cause_notes == "cause"
 
+    - name: Resolve a problem as a duplicate of a non-existent problem
+      servicenow.itsm.problem:
+        sys_id: "{{ analyzed_problem.record.sys_id }}"
+        state: closed
+        resolution_code: duplicate
+        duplicate_of: nonexistent-problem
+      register: result
+      ignore_errors: true
+    - ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'No problem records match' in result.msg"
+
     - name: Start fixing the problem
       servicenow.itsm.problem:
         sys_id: "{{ analyzed_problem.record.sys_id }}"
@@ -152,23 +166,23 @@
           - resolved_problem is changed
           - resolved_problem.record.state == "resolved"
           # FIXME: Uncomment the line below once the issue with setting resolution code at the ServiceNow side is resolved.
-          #- resolved_problem.record.resolution_code == "fix_applied"
+          - resolved_problem.record.resolution_code == "fix_applied"
 
 # FIXME: The task below causes '403 - Data Policy Exception: The following fields are mandatory: Resolution code'
 # despite resolution_code being present in the request.
 #
-#    - name: Close the problem
-#      servicenow.itsm.problem:
-#        sys_id: "{{ resolved_problem.record.sys_id }}"
-#        state: closed
-#        resolution_code: fix_applied
-#      register: closed_problem
-#    - ansible.builtin.assert:
-#        that:
-#          - closed_problem is changed
-#          - closed_problem.record.state == "resolved"
-#          # FIXME: Uncomment the line below once the issue with setting resolution code at the ServiceNow side is resolved.
-#          #- closed_problem.record.resolution_code == "fix_applied"
+    - name: Close the problem
+      servicenow.itsm.problem:
+        sys_id: "{{ resolved_problem.record.sys_id }}"
+        state: closed
+        resolution_code: fix_applied
+      register: closed_problem
+    - ansible.builtin.assert:
+        that:
+          - closed_problem is changed
+          - closed_problem.record.state == "closed"
+          # FIXME: Uncomment the line below once the issue with setting resolution code at the ServiceNow side is resolved.
+          - closed_problem.record.resolution_code == "fix_applied"
 
 
     - name: Create a bogus problem for cancellation
@@ -178,33 +192,36 @@
         assigned_to: problem.manager
       register: bogus_problem
 
-    - name: Cancel a problem
+    - name: Cancel a problem (fail)
       servicenow.itsm.problem:
         sys_id: "{{ bogus_problem.record.sys_id }}"
         state: resolved
         resolution_code: canceled
         close_notes: closing
       register: result
-    - ansible.builtin.assert:
-        that:
-          - result is changed
-          - result.record.state == "resolved"
-          # FIXME: Uncomment the line below once the issue with setting resolution code at the ServiceNow side is resolved.
-          #- result.record.resolution_code == "canceled"
-          - result.record.close_notes == "closing"
-
-    - name: Resolve a problem as a duplicate of a non-existent problem
-      servicenow.itsm.problem:
-        sys_id: "{{ assigned_problem.record.sys_id }}"
-        state: closed
-        resolution_code: duplicate
-        duplicate_of: nonexistent-problem
-      register: result
       ignore_errors: true
     - ansible.builtin.assert:
         that:
           - result is failed
-          - "'No problem records match' in result.msg"
+          - "'Problem state transition from state 102 to 106 is not possible' in result.msg"
+          # FIXME: Uncomment the line below once the issue with setting resolution code at the ServiceNow side is resolved.
+          #- result.record.resolution_code == "canceled"
+          #- result.record.close_notes == "closing"
+
+    - name: Cancel a problem
+      servicenow.itsm.problem:
+        sys_id: "{{ bogus_problem.record.sys_id }}"
+        state: closed
+        resolution_code: canceled
+        close_notes: closing
+      register: result
+    - ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.record.state == "closed"
+          # FIXME: Uncomment the line below once the issue with setting resolution code at the ServiceNow side is resolved.
+          - result.record.resolution_code == "canceled"
+          - result.record.close_notes == "closing"
 
     - name: Create a resolved problem that was fixed
       servicenow.itsm.problem:
@@ -276,22 +293,30 @@
 # FIXME: The task below causes '403 - Data Policy Exception: The following fields are mandatory: Resolution code'
 # despite resolution_code being present in the request.
 #
-#    - name: Resolve a problem as a duplicate of another problem
-#      servicenow.itsm.problem:
-#        sys_id: "{{ assigned_problem.record.sys_id }}"
-#        state: closed
-#        resolution_code: duplicate
-#        duplicate_of: "{{ fixed_problem.record.number }}"
-#      register: result
-#    - ansible.builtin.debug:
-#        var: result.record
-#    - ansible.builtin.assert:
-#        that:
-#          - result is changed
-#          - result.record.state == "closed"
-#          - result.record.duplicate_of == fixed_problem.record.sys_id
-#          # FIXME: Uncomment the line below once the issue with setting resolution code at the ServiceNow side is resolved.
-#          #- result.record.resolution_code == "duplicate"
+
+    - name: Create a problem for resolution as a duplicate
+      servicenow.itsm.problem:
+        state: root_cause_analysis
+        assigned_to: problem.manager
+        short_description: a-duplicate
+      register: duplicated_problem
+
+    - name: Resolve a problem as a duplicate of another problem
+      servicenow.itsm.problem:
+        sys_id: "{{ duplicated_problem.record.sys_id }}"
+        state: closed
+        resolution_code: duplicate
+        duplicate_of: "{{ assigned_problem.record.number }}"
+      register: result
+    - ansible.builtin.debug:
+        msg: "{{ result.record.duplicate_of }} vs {{ assigned_problem.record.sys_id }}"
+    - ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.record.state == "closed"
+          - result.record.duplicate_of == assigned_problem.record.sys_id
+          # FIXME: Uncomment the line below once the issue with setting resolution code at the ServiceNow side is resolved.
+          - result.record.resolution_code == "duplicate"
 
     - name: Delete a problem (check mode)
       servicenow.itsm.problem: &problem-delete

--- a/tests/integration/targets/problem/tasks/main.yml
+++ b/tests/integration/targets/problem/tasks/main.yml
@@ -35,6 +35,8 @@
     - name: Create a problem
       servicenow.itsm.problem: *problem-create
       register: first_problem
+    - ansible.builtin.debug:
+        var: first_problem.record
     - ansible.builtin.assert: *problem-create-assertions
 
     - name: Verify that a new record was created
@@ -50,6 +52,8 @@
         <<: *problem-create
         sys_id: "{{ first_problem.record.sys_id }}"
       register: result
+    - ansible.builtin.debug:
+        var: result.record
     - ansible.builtin.assert:
         that:
           - result is not changed
@@ -160,7 +164,12 @@
         sys_id: "{{ in_progress_problem.record.sys_id }}"
         state: resolved
         resolution_code: fix_applied
+        other:
+          resolved_by: "6816f79cc0a8016401c5a33be04be441"
+          resolved_at: "2022-08-24 16:54:34"
       register: resolved_problem
+    - ansible.builtin.debug:
+        var: resolved_problem.record
     - ansible.builtin.assert:
         that:
           - resolved_problem is changed

--- a/tests/integration/targets/problem/tasks/main.yml
+++ b/tests/integration/targets/problem/tasks/main.yml
@@ -165,12 +165,8 @@
         that:
           - resolved_problem is changed
           - resolved_problem.record.state == "resolved"
-          # FIXME: Uncomment the line below once the issue with setting resolution code at the ServiceNow side is resolved.
           - resolved_problem.record.resolution_code == "fix_applied"
 
-# FIXME: The task below causes '403 - Data Policy Exception: The following fields are mandatory: Resolution code'
-# despite resolution_code being present in the request.
-#
     - name: Close the problem
       servicenow.itsm.problem:
         sys_id: "{{ resolved_problem.record.sys_id }}"
@@ -181,7 +177,6 @@
         that:
           - closed_problem is changed
           - closed_problem.record.state == "closed"
-          # FIXME: Uncomment the line below once the issue with setting resolution code at the ServiceNow side is resolved.
           - closed_problem.record.resolution_code == "fix_applied"
 
 
@@ -204,9 +199,6 @@
         that:
           - result is failed
           - "'Problem state transition from state 102 to 106 is not possible' in result.msg"
-          # FIXME: Uncomment the line below once the issue with setting resolution code at the ServiceNow side is resolved.
-          #- result.record.resolution_code == "canceled"
-          #- result.record.close_notes == "closing"
 
     - name: Cancel a problem
       servicenow.itsm.problem:
@@ -219,7 +211,6 @@
         that:
           - result is changed
           - result.record.state == "closed"
-          # FIXME: Uncomment the line below once the issue with setting resolution code at the ServiceNow side is resolved.
           - result.record.resolution_code == "canceled"
           - result.record.close_notes == "closing"
 
@@ -290,9 +281,6 @@
           - result.records.0.state == "resolved"
           - result.records.0.short_description == "accepted-problem"
 
-# FIXME: The task below causes '403 - Data Policy Exception: The following fields are mandatory: Resolution code'
-# despite resolution_code being present in the request.
-#
 
     - name: Create a problem for resolution as a duplicate
       servicenow.itsm.problem:
@@ -315,7 +303,6 @@
           - result is changed
           - result.record.state == "closed"
           - result.record.duplicate_of == assigned_problem.record.sys_id
-          # FIXME: Uncomment the line below once the issue with setting resolution code at the ServiceNow side is resolved.
           - result.record.resolution_code == "duplicate"
 
     - name: Delete a problem (check mode)

--- a/tests/integration/targets/problem/tasks/main.yml
+++ b/tests/integration/targets/problem/tasks/main.yml
@@ -35,8 +35,6 @@
     - name: Create a problem
       servicenow.itsm.problem: *problem-create
       register: first_problem
-    - ansible.builtin.debug:
-        var: first_problem.record
     - ansible.builtin.assert: *problem-create-assertions
 
     - name: Verify that a new record was created
@@ -52,8 +50,6 @@
         <<: *problem-create
         sys_id: "{{ first_problem.record.sys_id }}"
       register: result
-    - ansible.builtin.debug:
-        var: result.record
     - ansible.builtin.assert:
         that:
           - result is not changed
@@ -115,7 +111,6 @@
         state: assess
         assigned_to: problem.manager
       register: assigned_problem
-
     - ansible.builtin.assert:
         that:
           - assigned_problem is changed
@@ -164,12 +159,7 @@
         sys_id: "{{ in_progress_problem.record.sys_id }}"
         state: resolved
         resolution_code: fix_applied
-        other:
-          resolved_by: "6816f79cc0a8016401c5a33be04be441"
-          resolved_at: "2022-08-24 16:54:34"
       register: resolved_problem
-    - ansible.builtin.debug:
-        var: resolved_problem.record
     - ansible.builtin.assert:
         that:
           - resolved_problem is changed
@@ -284,7 +274,6 @@
          - state: = resolved
            short_description: = accepted-problem
       register: result
-
     - ansible.builtin.assert:
         that:
           - result.records.0.state == "resolved"
@@ -360,7 +349,6 @@
          - subcategory: = email
       ignore_errors: true
       register: result
-
     - ansible.builtin.assert:
         that:
           - result is failed
@@ -373,7 +361,6 @@
          - subcategory: == email
       ignore_errors: true
       register: result
-
     - ansible.builtin.assert:
         that:
           - result is failed
@@ -385,7 +372,6 @@
         query:
          - subcategory: = email
       register: result
-
     - ansible.builtin.assert:
         that:
           - "'email' in result.records[0].subcategory"
@@ -397,7 +383,6 @@
          - short_description: ISEMPTY SAP
       ignore_errors: true
       register: result
-
     - ansible.builtin.assert:
         that:
           - result is failed
@@ -409,7 +394,6 @@
         query:
          - short_description: ISNOTEMPTY
       register: result
-
     - ansible.builtin.assert:
         that:
           - result.records[0].short_description != ""

--- a/tests/integration/targets/problem_with_mapping/tasks/main.yml
+++ b/tests/integration/targets/problem_with_mapping/tasks/main.yml
@@ -47,6 +47,8 @@
     - name: Create a problem
       servicenow.itsm.problem: *problem-create
       register: first_problem
+    - ansible.builtin.debug:
+        var: first_problem.record
     - ansible.builtin.assert: *problem-create-assertions
 
     - name: Verify that a new record was created
@@ -61,6 +63,8 @@
         <<: *problem-create
         sys_id: "{{ first_problem.record.sys_id }}"
       register: result
+    - ansible.builtin.debug:
+        var: result.record
     - ansible.builtin.assert:
         that:
           - result is not changed

--- a/tests/integration/targets/problem_with_mapping/tasks/main.yml
+++ b/tests/integration/targets/problem_with_mapping/tasks/main.yml
@@ -9,18 +9,15 @@
       problem:
         state:
           101: "my_new"
-          102: "asses"
+          102: "assess"
           103: "root_cause"
           104: "progress"
           106: "resolved"
           107: "closed"
-        # problem_state:
-        #   101: "my_new"
-        #   102: "asses"
-        #   103: "root_cause"
-        #   104: "progress"
-        #   106: "resolved"
-        #   107: "closed"
+        impact:
+          1: "highest"
+        urgency:
+          2: "normal"
 
   block:
     - name: Retrieve problem records
@@ -76,9 +73,10 @@
     - name: Update the problem (check mode)
       servicenow.itsm.problem: &problem-update
         sys_id: "{{ first_problem.record.sys_id }}"
+        problem_mapping: "{{ mapping.problem }}"
         description: abc
-        impact: high
-        urgency: medium
+        impact: highest
+        urgency: normal
         other:
           user_input: notes
       check_mode: true
@@ -88,8 +86,8 @@
           - updated_problem is changed
           - updated_problem.record.sys_id == first_problem.record.sys_id
           - updated_problem.record.description == "abc"
-          - updated_problem.record.impact == "high"
-          - updated_problem.record.urgency == "medium"
+          - updated_problem.record.impact == "highest"
+          - updated_problem.record.urgency == "normal"
           - updated_problem.record.user_input == "notes"
 
     - name: Verify modification in check mode did not update the record
@@ -115,6 +113,7 @@
     - name: Assign the problem to a non-existent user
       servicenow.itsm.problem:
         sys_id: "{{ first_problem.record.sys_id }}"
+        problem_mapping: "{{ mapping.problem }}"
         state: assess
         assigned_to: nonexistent.user
       register: result
@@ -127,30 +126,35 @@
     - name: Assign the problem for assessment
       servicenow.itsm.problem:
         sys_id: "{{ first_problem.record.sys_id }}"
+        problem_mapping: "{{ mapping.problem }}"
         state: assess
         assigned_to: problem.manager
+        urgency: normal
       register: assigned_problem
     - ansible.builtin.assert:
         that:
           - assigned_problem is changed
           - assigned_problem.record.state == "assess"
           - assigned_problem.record.assigned_to != ""
+          - assigned_problem.record.urgency == "normal"
 
     - name: Mark the problem for root cause analysis
       servicenow.itsm.problem:
         sys_id: "{{ assigned_problem.record.sys_id }}"
-        state: root_cause_analysis
+        problem_mapping: "{{ mapping.problem }}"
+        state: root_cause
         cause_notes: cause
       register: analyzed_problem
     - ansible.builtin.assert:
         that:
           - analyzed_problem is changed
-          - analyzed_problem.record.state == "root_cause_analysis"
+          - analyzed_problem.record.state == "root_cause"
           - analyzed_problem.record.cause_notes == "cause"
 
     - name: Resolve a problem as a duplicate of a non-existent problem
       servicenow.itsm.problem:
         sys_id: "{{ analyzed_problem.record.sys_id }}"
+        problem_mapping: "{{ mapping.problem }}"
         state: closed
         resolution_code: duplicate
         duplicate_of: nonexistent-problem
@@ -164,18 +168,20 @@
     - name: Start fixing the problem
       servicenow.itsm.problem:
         sys_id: "{{ analyzed_problem.record.sys_id }}"
-        state: fix_in_progress
+        problem_mapping: "{{ mapping.problem }}"
+        state: progress
         fix_notes: fix
       register: in_progress_problem
     - ansible.builtin.assert:
         that:
           - in_progress_problem is changed
-          - in_progress_problem.record.state == "fix_in_progress"
+          - in_progress_problem.record.state == "progress"
           - in_progress_problem.record.fix_notes == "fix"
 
     - name: Resolve the problem
       servicenow.itsm.problem:
         sys_id: "{{ in_progress_problem.record.sys_id }}"
+        problem_mapping: "{{ mapping.problem }}"
         state: resolved
         resolution_code: fix_applied
       register: resolved_problem
@@ -188,18 +194,22 @@
     - name: Close the problem
       servicenow.itsm.problem:
         sys_id: "{{ resolved_problem.record.sys_id }}"
+        problem_mapping: "{{ mapping.problem }}"
         state: closed
         resolution_code: fix_applied
+        impact: highest
       register: closed_problem
     - ansible.builtin.assert:
         that:
           - closed_problem is changed
           - closed_problem.record.state == "closed"
           - closed_problem.record.resolution_code == "fix_applied"
+          - closed_problem.record.impact == "highest"
 
 
     - name: Create a bogus problem for cancellation
       servicenow.itsm.problem:
+        problem_mapping: "{{ mapping.problem }}"
         state: assess
         short_description: cancel-me
         assigned_to: problem.manager
@@ -208,6 +218,7 @@
     - name: Cancel a problem (fail)
       servicenow.itsm.problem:
         sys_id: "{{ bogus_problem.record.sys_id }}"
+        problem_mapping: "{{ mapping.problem }}"
         state: resolved
         resolution_code: canceled
         close_notes: closing
@@ -221,6 +232,7 @@
     - name: Cancel a problem
       servicenow.itsm.problem:
         sys_id: "{{ bogus_problem.record.sys_id }}"
+        problem_mapping: "{{ mapping.problem }}"
         state: closed
         resolution_code: canceled
         close_notes: closing
@@ -235,6 +247,7 @@
     - name: Create a resolved problem that was fixed
       servicenow.itsm.problem:
         state: resolved
+        problem_mapping: "{{ mapping.problem }}"
         short_description: fixed-problem
         assigned_to: problem.manager
         resolution_code: fix_applied
@@ -250,6 +263,7 @@
 
     - name: Create a resolved problem with accepted risk
       servicenow.itsm.problem:
+        problem_mapping: "{{ mapping.problem }}"
         state: resolved
         short_description: accepted-problem
         assigned_to: problem.manager
@@ -264,7 +278,7 @@
           - risk_accepted_problem.record.cause_notes == "cause"
           - risk_accepted_problem.record.close_notes == "close"
 
-    - name: Get specific problem info by sysparm query
+    - name: Get specific problem info by query
       servicenow.itsm.problem_info:
         query:
          - number: = {{ risk_accepted_problem.record.number }}
@@ -287,7 +301,7 @@
           - result.records.0.cause_notes == "cause"
           - result.records.0.close_notes == "close"
 
-    - name: Get problem info by sysparm query - state and short_description
+    - name: Get problem info by query - state and short_description
       servicenow.itsm.problem_info:
         query:
          - state: = resolved
@@ -300,13 +314,15 @@
 
     - name: Create a problem for resolution as a duplicate
       servicenow.itsm.problem:
-        state: root_cause_analysis
+        problem_mapping: "{{ mapping.problem }}"
+        state: root_cause
         assigned_to: problem.manager
         short_description: a-duplicate
       register: duplicated_problem
 
     - name: Resolve a problem as a duplicate of another problem
       servicenow.itsm.problem:
+        problem_mapping: "{{ mapping.problem }}"
         sys_id: "{{ duplicated_problem.record.sys_id }}"
         state: closed
         resolution_code: duplicate
@@ -321,6 +337,7 @@
 
     - name: Delete a problem (check mode)
       servicenow.itsm.problem: &problem-delete
+        problem_mapping: "{{ mapping.problem }}"
         sys_id: "{{ first_problem.record.sys_id }}"
         state: absent
       check_mode: true

--- a/tests/integration/targets/problem_with_mapping/tasks/main.yml
+++ b/tests/integration/targets/problem_with_mapping/tasks/main.yml
@@ -130,7 +130,6 @@
         state: assess
         assigned_to: problem.manager
       register: assigned_problem
-
     - ansible.builtin.assert:
         that:
           - assigned_problem is changed
@@ -148,6 +147,19 @@
           - analyzed_problem is changed
           - analyzed_problem.record.state == "root_cause_analysis"
           - analyzed_problem.record.cause_notes == "cause"
+
+    - name: Resolve a problem as a duplicate of a non-existent problem
+      servicenow.itsm.problem:
+        sys_id: "{{ analyzed_problem.record.sys_id }}"
+        state: closed
+        resolution_code: duplicate
+        duplicate_of: nonexistent-problem
+      register: result
+      ignore_errors: true
+    - ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'No problem records match' in result.msg"
 
     - name: Start fixing the problem
       servicenow.itsm.problem:
@@ -171,24 +183,19 @@
         that:
           - resolved_problem is changed
           - resolved_problem.record.state == "resolved"
-          # FIXME: Uncomment the line below once the issue with setting resolution code at the ServiceNow side is resolved.
-          #- resolved_problem.record.resolution_code == "fix_applied"
+          - resolved_problem.record.resolution_code == "fix_applied"
 
-# FIXME: The task below causes '403 - Data Policy Exception: The following fields are mandatory: Resolution code'
-# despite resolution_code being present in the request.
-#
-#    - name: Close the problem
-#      servicenow.itsm.problem:
-#        sys_id: "{{ resolved_problem.record.sys_id }}"
-#        state: closed
-#        resolution_code: fix_applied
-#      register: closed_problem
-#    - ansible.builtin.assert:
-#        that:
-#          - closed_problem is changed
-#          - closed_problem.record.state == "resolved"
-#          # FIXME: Uncomment the line below once the issue with setting resolution code at the ServiceNow side is resolved.
-#          #- closed_problem.record.resolution_code == "fix_applied"
+    - name: Close the problem
+      servicenow.itsm.problem:
+        sys_id: "{{ resolved_problem.record.sys_id }}"
+        state: closed
+        resolution_code: fix_applied
+      register: closed_problem
+    - ansible.builtin.assert:
+        that:
+          - closed_problem is changed
+          - closed_problem.record.state == "closed"
+          - closed_problem.record.resolution_code == "fix_applied"
 
 
     - name: Create a bogus problem for cancellation
@@ -198,33 +205,32 @@
         assigned_to: problem.manager
       register: bogus_problem
 
-    - name: Cancel a problem
+    - name: Cancel a problem (fail)
       servicenow.itsm.problem:
         sys_id: "{{ bogus_problem.record.sys_id }}"
         state: resolved
         resolution_code: canceled
         close_notes: closing
       register: result
-    - ansible.builtin.assert:
-        that:
-          - result is changed
-          - result.record.state == "resolved"
-          # FIXME: Uncomment the line below once the issue with setting resolution code at the ServiceNow side is resolved.
-          #- result.record.resolution_code == "canceled"
-          - result.record.close_notes == "closing"
-
-    - name: Resolve a problem as a duplicate of a non-existent problem
-      servicenow.itsm.problem:
-        sys_id: "{{ assigned_problem.record.sys_id }}"
-        state: closed
-        resolution_code: duplicate
-        duplicate_of: nonexistent-problem
-      register: result
       ignore_errors: true
     - ansible.builtin.assert:
         that:
           - result is failed
-          - "'No problem records match' in result.msg"
+          - "'Problem state transition from state 102 to 106 is not possible' in result.msg"
+
+    - name: Cancel a problem
+      servicenow.itsm.problem:
+        sys_id: "{{ bogus_problem.record.sys_id }}"
+        state: closed
+        resolution_code: canceled
+        close_notes: closing
+      register: result
+    - ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.record.state == "closed"
+          - result.record.resolution_code == "canceled"
+          - result.record.close_notes == "closing"
 
     - name: Create a resolved problem that was fixed
       servicenow.itsm.problem:
@@ -287,31 +293,31 @@
          - state: = resolved
            short_description: = accepted-problem
       register: result
-
     - ansible.builtin.assert:
         that:
           - result.records.0.state == "resolved"
           - result.records.0.short_description == "accepted-problem"
 
-# FIXME: The task below causes '403 - Data Policy Exception: The following fields are mandatory: Resolution code'
-# despite resolution_code being present in the request.
-#
-#    - name: Resolve a problem as a duplicate of another problem
-#      servicenow.itsm.problem:
-#        sys_id: "{{ assigned_problem.record.sys_id }}"
-#        state: closed
-#        resolution_code: duplicate
-#        duplicate_of: "{{ fixed_problem.record.number }}"
-#      register: result
-#    - ansible.builtin.debug:
-#        var: result.record
-#    - ansible.builtin.assert:
-#        that:
-#          - result is changed
-#          - result.record.state == "closed"
-#          - result.record.duplicate_of == fixed_problem.record.sys_id
-#          # FIXME: Uncomment the line below once the issue with setting resolution code at the ServiceNow side is resolved.
-#          #- result.record.resolution_code == "duplicate"
+    - name: Create a problem for resolution as a duplicate
+      servicenow.itsm.problem:
+        state: root_cause_analysis
+        assigned_to: problem.manager
+        short_description: a-duplicate
+      register: duplicated_problem
+
+    - name: Resolve a problem as a duplicate of another problem
+      servicenow.itsm.problem:
+        sys_id: "{{ duplicated_problem.record.sys_id }}"
+        state: closed
+        resolution_code: duplicate
+        duplicate_of: "{{ assigned_problem.record.number }}"
+      register: result
+    - ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.record.state == "closed"
+          - result.record.duplicate_of == assigned_problem.record.sys_id
+          - result.record.resolution_code == "duplicate"
 
     - name: Delete a problem (check mode)
       servicenow.itsm.problem: &problem-delete
@@ -361,7 +367,6 @@
          - subcategory: = email
       ignore_errors: true
       register: result
-
     - ansible.builtin.assert:
         that:
           - result is failed
@@ -374,7 +379,6 @@
          - subcategory: == email
       ignore_errors: true
       register: result
-
     - ansible.builtin.assert:
         that:
           - result is failed
@@ -386,7 +390,6 @@
         query:
          - subcategory: = email
       register: result
-
     - ansible.builtin.assert:
         that:
           - "'email' in result.records[0].subcategory"
@@ -398,7 +401,6 @@
          - short_description: ISEMPTY SAP
       ignore_errors: true
       register: result
-
     - ansible.builtin.assert:
         that:
           - result is failed
@@ -410,7 +412,6 @@
         query:
          - short_description: ISNOTEMPTY
       register: result
-
     - ansible.builtin.assert:
         that:
           - result.records[0].short_description != ""

--- a/tests/integration/targets/problem_with_mapping/tasks/main.yml
+++ b/tests/integration/targets/problem_with_mapping/tasks/main.yml
@@ -14,6 +14,13 @@
           104: "progress"
           106: "resolved"
           107: "closed"
+        # problem_state:
+        #   101: "my_new"
+        #   102: "asses"
+        #   103: "root_cause"
+        #   104: "progress"
+        #   106: "resolved"
+        #   107: "closed"
 
   block:
     - name: Retrieve problem records
@@ -47,24 +54,21 @@
     - name: Create a problem
       servicenow.itsm.problem: *problem-create
       register: first_problem
-    - ansible.builtin.debug:
-        var: first_problem.record
     - ansible.builtin.assert: *problem-create-assertions
 
     - name: Verify that a new record was created
       servicenow.itsm.problem_info:
+        sys_id: "{{ first_problem.record.sys_id }}"
       register: result
     - ansible.builtin.assert:
         that:
-          - result.records | length == initial.records | length + 1
+          - result.records | length == 1
 
     - name: Create a problem (idempotence)
       servicenow.itsm.problem:
         <<: *problem-create
         sys_id: "{{ first_problem.record.sys_id }}"
       register: result
-    - ansible.builtin.debug:
-        var: result.record
     - ansible.builtin.assert:
         that:
           - result is not changed

--- a/tests/unit/plugins/conftest.py
+++ b/tests/unit/plugins/conftest.py
@@ -5,6 +5,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import json
@@ -16,9 +17,8 @@ from ansible.module_utils._text import to_bytes
 
 from ansible_collections.servicenow.itsm.plugins.module_utils.client import Client
 from ansible_collections.servicenow.itsm.plugins.module_utils.table import TableClient
-from ansible_collections.servicenow.itsm.plugins.module_utils.attachment import (
-    AttachmentClient,
-)
+from ansible_collections.servicenow.itsm.plugins.module_utils.attachment import AttachmentClient
+from ansible_collections.servicenow.itsm.plugins.module_utils.problem import ProblemClient
 
 
 @pytest.fixture
@@ -34,6 +34,11 @@ def table_client(mocker):
 @pytest.fixture
 def attachment_client(mocker):
     return mocker.Mock(spec=AttachmentClient)
+
+
+@pytest.fixture
+def problem_client(mocker):
+    return mocker.Mock(spec=ProblemClient)
 
 
 @pytest.fixture

--- a/tests/unit/plugins/conftest.py
+++ b/tests/unit/plugins/conftest.py
@@ -17,8 +17,12 @@ from ansible.module_utils._text import to_bytes
 
 from ansible_collections.servicenow.itsm.plugins.module_utils.client import Client
 from ansible_collections.servicenow.itsm.plugins.module_utils.table import TableClient
-from ansible_collections.servicenow.itsm.plugins.module_utils.attachment import AttachmentClient
-from ansible_collections.servicenow.itsm.plugins.module_utils.problem import ProblemClient
+from ansible_collections.servicenow.itsm.plugins.module_utils.attachment import (
+    AttachmentClient,
+)
+from ansible_collections.servicenow.itsm.plugins.module_utils.problem import (
+    ProblemClient,
+)
 
 
 @pytest.fixture

--- a/tests/unit/plugins/module_utils/test_problem.py
+++ b/tests/unit/plugins/module_utils/test_problem.py
@@ -13,7 +13,9 @@ import pytest
 
 from ansible_collections.servicenow.itsm.plugins.module_utils import errors
 from ansible_collections.servicenow.itsm.plugins.module_utils.client import Response
-from ansible_collections.servicenow.itsm.plugins.module_utils.problem import ProblemClient
+from ansible_collections.servicenow.itsm.plugins.module_utils.problem import (
+    ProblemClient,
+)
 
 
 pytestmark = pytest.mark.skipif(
@@ -29,7 +31,7 @@ class TestProblemClient:
             ("/api/path", "/api/path/"),
             ("", "/"),
             ("//api///path///", "/api/path/"),
-        ]
+        ],
     )
     def test_init(self, client, in_base_api_path, out_base_api_path):
         pc = ProblemClient(client, in_base_api_path)
@@ -37,9 +39,7 @@ class TestProblemClient:
         assert pc.base_api_path == out_base_api_path
 
     def test_update_record(self, client):
-        client.patch.return_value = Response(
-            200, '{"result": []}', {}
-        )
+        client.patch.return_value = Response(200, '{"result": []}', {})
         pc = ProblemClient(client, "/api/path")
 
         data = dict(state="103")

--- a/tests/unit/plugins/module_utils/test_problem.py
+++ b/tests/unit/plugins/module_utils/test_problem.py
@@ -47,7 +47,7 @@ class TestProblemClient:
 
         client.patch.assert_called_once_with(
             "/api/path/PRB02/new_state/103",
-            data,
+            dict(),
             query=dict(sysparm_exclude_reference_link=True),
         )
 
@@ -64,6 +64,6 @@ class TestProblemClient:
 
         client.patch.assert_called_once_with(
             "/api/path/PRB02/new_state/103",
-            data,
+            dict(),
             query=dict(sysparm_exclude_reference_link=True),
         )

--- a/tests/unit/plugins/module_utils/test_problem.py
+++ b/tests/unit/plugins/module_utils/test_problem.py
@@ -48,6 +48,7 @@ class TestProblemClient:
         client.patch.assert_called_once_with(
             "/api/path/PRB02/new_state/103",
             data,
+            query=dict(sysparm_exclude_reference_link=True),
         )
 
         assert result == []
@@ -64,4 +65,5 @@ class TestProblemClient:
         client.patch.assert_called_once_with(
             "/api/path/PRB02/new_state/103",
             data,
+            query=dict(sysparm_exclude_reference_link=True),
         )

--- a/tests/unit/plugins/module_utils/test_problem.py
+++ b/tests/unit/plugins/module_utils/test_problem.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2022, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+
+import pytest
+
+from ansible_collections.servicenow.itsm.plugins.module_utils import errors
+from ansible_collections.servicenow.itsm.plugins.module_utils.client import Response
+from ansible_collections.servicenow.itsm.plugins.module_utils.problem import ProblemClient
+
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires python2.7 or higher"
+)
+
+
+class TestProblemClient:
+    @pytest.mark.parametrize(
+        "in_base_api_path,out_base_api_path",
+        [
+            ("api/path", "/api/path/"),
+            ("/api/path", "/api/path/"),
+            ("", "/"),
+            ("//api///path///", "/api/path/"),
+        ]
+    )
+    def test_init(self, client, in_base_api_path, out_base_api_path):
+        pc = ProblemClient(client, in_base_api_path)
+
+        assert pc.base_api_path == out_base_api_path
+
+    def test_update_record(self, client):
+        client.patch.return_value = Response(
+            200, '{"result": []}', {}
+        )
+        pc = ProblemClient(client, "/api/path")
+
+        data = dict(state="103")
+        result = pc.update_record("PRB02", data)
+
+        client.patch.assert_called_once_with(
+            "/api/path/PRB02/new_state/103",
+            data,
+        )
+
+        assert result == []
+
+    def test_update_record_error(self, client):
+        client.patch.side_effect = errors.ServiceNowError("Something went wrong")
+        pc = ProblemClient(client, "/api/path")
+
+        data = dict(state="103")
+
+        with pytest.raises(errors.ServiceNowError, match="Something went wrong"):
+            pc.update_record("PRB02", data)
+
+        client.patch.assert_called_once_with(
+            "/api/path/PRB02/new_state/103",
+            data,
+        )

--- a/tests/unit/plugins/modules/test_problem.py
+++ b/tests/unit/plugins/modules/test_problem.py
@@ -233,7 +233,9 @@ class TestEnsurePresent:
         )
         attachment_client.upload_records.return_value = []
 
-        result = problem.ensure_present(module, problem_client, table_client, attachment_client)
+        result = problem.ensure_present(
+            module, problem_client, table_client, attachment_client
+        )
 
         table_client.create_record.assert_called_once()
         problem_client.update_record.assert_not_called()
@@ -297,7 +299,9 @@ class TestEnsurePresent:
         attachment_client.update_records.return_value = []
         attachment_client.list_records.return_value = []
 
-        result = problem.ensure_present(module, problem_client, table_client, attachment_client)
+        result = problem.ensure_present(
+            module, problem_client, table_client, attachment_client
+        )
 
         table_client.get_record.assert_called_once()
         problem_client.update_record.assert_not_called()
@@ -381,7 +385,9 @@ class TestEnsurePresent:
         attachment_client.update_records.return_value = []
         attachment_client.list_records.return_value = []
 
-        result = problem.ensure_present(module, problem_client, table_client, attachment_client)
+        result = problem.ensure_present(
+            module, problem_client, table_client, attachment_client
+        )
 
         table_client.update_record.assert_called_once()
         problem_client.update_record.assert_not_called()
@@ -473,7 +479,9 @@ class TestEnsurePresent:
             sys_id="1234",
         )
 
-        result = problem.ensure_present(module, problem_client, table_client, attachment_client)
+        result = problem.ensure_present(
+            module, problem_client, table_client, attachment_client
+        )
 
         table_client.update_record.assert_called_once()
 

--- a/tests/unit/plugins/modules/test_problem.py
+++ b/tests/unit/plugins/modules/test_problem.py
@@ -1219,6 +1219,7 @@ class TestProblemMapping:
             ("state", "my-resolved"),
             ("state", "my-closed"),
             ("state", "absent"),
+            ("state", None),
 
             ("problem_state", "my-new"),
             ("problem_state", "my-assess"),
@@ -1226,14 +1227,17 @@ class TestProblemMapping:
             ("problem_state", "fix"),
             ("problem_state", "my-resolved"),
             ("problem_state", "my-closed"),
+            ("problem_state", None),
 
             ("urgency", "one"),
             ("urgency", "two"),
             ("urgency", "three"),
+            ("urgency", None),
 
             ("impact", "111"),
             ("impact", "222"),
             ("impact", "333"),
+            ("impact", None),
         ]
     )
     def test_validate_mapping(self, create_module, mapped_param, param_value):
@@ -1273,6 +1277,7 @@ class TestProblemMapping:
             ("state", "resolved"),
             ("state", "closed"),
             ("state", "absent"),
+            ("state", None),
 
             ("problem_state", "new"),
             ("problem_state", "explicitly-mapped-assess"),
@@ -1280,14 +1285,17 @@ class TestProblemMapping:
             ("problem_state", "fix_in_progress"),
             ("problem_state", "resolved"),
             ("problem_state", "closed"),
+            ("problem_state", None),
 
             ("urgency", "not_too_urgent"),
             ("urgency", "medium"),
             ("urgency", "high"),
+            ("urgency", None),
 
             ("impact", "low"),
             ("impact", "medium"),
             ("impact", "highly_impacted"),
+            ("impact", None),
         ]
     )
     def test_validate_mapping_implicit(self, create_module, mapped_param, param_value):

--- a/tests/unit/plugins/modules/test_problem.py
+++ b/tests/unit/plugins/modules/test_problem.py
@@ -5,7 +5,6 @@
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
-from venv import create
 
 __metaclass__ = type
 
@@ -17,7 +16,13 @@ from ansible_collections.servicenow.itsm.plugins.modules import problem
 from ansible_collections.servicenow.itsm.plugins.module_utils import errors
 from ansible_collections.servicenow.itsm.plugins.module_utils.utils import get_mapper
 from ansible_collections.servicenow.itsm.plugins.module_utils.problem import (
-    NEW, ASSESS, PAYLOAD_FIELDS_MAPPING, RCA, FIX, RESOLVED, CLOSED
+    NEW,
+    ASSESS,
+    PAYLOAD_FIELDS_MAPPING,
+    RCA,
+    FIX,
+    RESOLVED,
+    CLOSED,
 )
 
 pytestmark = pytest.mark.skipif(
@@ -94,7 +99,9 @@ class TestBuildPayload:
             {"sys_id": "6816f79cc0a8016401c5a33be04be441"},
         ]
 
-        mapper = get_mapper(module, "problem_mapping", PAYLOAD_FIELDS_MAPPING, implicit=True)
+        mapper = get_mapper(
+            module, "problem_mapping", PAYLOAD_FIELDS_MAPPING, implicit=True
+        )
         sn_params = mapper.to_snow(module.params)
 
         result = problem.build_payload(sn_params, table_client)
@@ -126,7 +133,9 @@ class TestBuildPayload:
             ),
         )
 
-        mapper = get_mapper(module, "problem_mapping", PAYLOAD_FIELDS_MAPPING, implicit=True)
+        mapper = get_mapper(
+            module, "problem_mapping", PAYLOAD_FIELDS_MAPPING, implicit=True
+        )
         sn_params = mapper.to_snow(module.params)
 
         result = problem.build_payload(sn_params, table_client)
@@ -154,12 +163,8 @@ class TestBuildPayload:
                 duplicate_of="PRB0000010",
                 other=None,
                 problem_mapping=dict(
-                    state={
-                        CLOSED: "my-closed",
-                    },
-                    impact={
-                        "3": "lowest",
-                    }
+                    state={CLOSED: "my-closed"},
+                    impact={"3": "lowest"},
                 ),
             ),
         )
@@ -168,7 +173,9 @@ class TestBuildPayload:
             {"sys_id": "6816f79cc0a8016401c5a33be04be441"},
         ]
 
-        mapper = get_mapper(module, "problem_mapping", PAYLOAD_FIELDS_MAPPING, implicit=True)
+        mapper = get_mapper(
+            module, "problem_mapping", PAYLOAD_FIELDS_MAPPING, implicit=True
+        )
         sn_params = mapper.to_snow(module.params)
 
         result = problem.build_payload(sn_params, table_client)
@@ -235,9 +242,7 @@ class TestValidateParams:
     def test_valid_resolved_state(self, state, params):
         problem.validate_params(dict(params, state=state))
 
-    @pytest.mark.parametrize(
-        "state", [NEW, ASSESS, RCA, FIX, RESOLVED, CLOSED]
-    )
+    @pytest.mark.parametrize("state", [NEW, ASSESS, RCA, FIX, RESOLVED, CLOSED])
     def test_missing_short_description(self, state):
         params = dict(
             state=state,
@@ -252,9 +257,7 @@ class TestValidateParams:
         with pytest.raises(errors.ServiceNowError, match="short_description"):
             problem.validate_params(params)
 
-    @pytest.mark.parametrize(
-        "state", [ASSESS, RCA, FIX, RESOLVED, CLOSED]
-    )
+    @pytest.mark.parametrize("state", [ASSESS, RCA, FIX, RESOLVED, CLOSED])
     def test_missing_assigned_to(self, state):
         params = dict(
             state=state,
@@ -269,9 +272,7 @@ class TestValidateParams:
         with pytest.raises(errors.ServiceNowError, match="assigned_to"):
             problem.validate_params(params)
 
-    @pytest.mark.parametrize(
-        "state", [RESOLVED, CLOSED]
-    )
+    @pytest.mark.parametrize("state", [RESOLVED, CLOSED])
     def test_missing_resolution_code(self, state):
         params = dict(
             state=state,
@@ -286,9 +287,7 @@ class TestValidateParams:
         with pytest.raises(errors.ServiceNowError, match="resolution_code"):
             problem.validate_params(params)
 
-    @pytest.mark.parametrize(
-        "param", ["cause_notes", "fix_notes"],
-    )
+    @pytest.mark.parametrize("param", ["cause_notes", "fix_notes"])
     def test_in_progress_missing_params(self, param):
         params = dict(
             state=FIX,
@@ -311,7 +310,7 @@ class TestValidateParams:
             ("risk_accepted", "close_notes"),
             ("canceled", "cause_notes"),
             ("duplicate", "fix_notes"),
-        ]
+        ],
     )
     def test_resolution_code_missing_params(self, resolution_code, param):
         params = dict(
@@ -526,7 +525,7 @@ class TestEnsurePresent:
                 short_description="Test problem",
                 attachments=[],
                 sys_id="1234",
-                assigned_to="123abc"
+                assigned_to="123abc",
             ),
             dict(
                 before=dict(
@@ -582,7 +581,7 @@ class TestEnsurePresent:
             number="PRB0000001",
             short_description="Test problem",
             sys_id="1234",
-            assigned_to="123abc"
+            assigned_to="123abc",
         )
         table_client.get_record.return_value = dict(
             state=NEW,
@@ -613,7 +612,7 @@ class TestEnsurePresent:
                 number="PRB0000001",
                 short_description="Test problem",
                 sys_id="1234",
-                assigned_to="123abc"
+                assigned_to="123abc",
             ),
         )
 
@@ -626,7 +625,7 @@ class TestEnsurePresent:
                 short_description="Test problem",
                 attachments=[],
                 sys_id="1234",
-                assigned_to="123abc"
+                assigned_to="123abc",
             ),
             dict(
                 before=dict(
@@ -715,13 +714,8 @@ class TestProblemMapping:
             module, problem_client, table_client, attachment_client
         )
 
-        sn_payload = dict(
-            state=NEW,
-            short_description="Test problem",
-        )
-        table_client.create_record.assert_called_once_with(
-            "problem", sn_payload, False
-        )
+        sn_payload = dict(state=NEW, short_description="Test problem")
+        table_client.create_record.assert_called_once_with("problem", sn_payload, False)
 
         assert result == (
             True,
@@ -782,10 +776,7 @@ class TestProblemMapping:
 
         table_client.create_record.assert_called_once_with(
             "problem",
-            dict(
-                state=ASSESS, short_description="Test problem",
-                assigned_to="123456"
-            ),
+            dict(state=ASSESS, short_description="Test problem", assigned_to="123456"),
             False,
         )
 
@@ -850,10 +841,7 @@ class TestProblemMapping:
 
         table_client.create_record.assert_called_once_with(
             "problem",
-            dict(
-                state=RCA, short_description="Test problem",
-                assigned_to="123456"
-            ),
+            dict(state=RCA, short_description="Test problem", assigned_to="123456"),
             False,
         )
 
@@ -923,8 +911,10 @@ class TestProblemMapping:
         table_client.create_record.assert_called_once_with(
             "problem",
             dict(
-                state=FIX, short_description="Test problem",
-                assigned_to="123456", fix_notes="some fix notes",
+                state=FIX,
+                short_description="Test problem",
+                assigned_to="123456",
+                fix_notes="some fix notes",
                 cause_notes="some cause notes",
             ),
             False,
@@ -1002,8 +992,10 @@ class TestProblemMapping:
         table_client.create_record.assert_called_once_with(
             "problem",
             dict(
-                state=RESOLVED, short_description="Test problem",
-                assigned_to="123456", fix_notes="some fix notes",
+                state=RESOLVED,
+                short_description="Test problem",
+                assigned_to="123456",
+                fix_notes="some fix notes",
                 cause_notes="some cause notes",
                 resolution_code="fix_applied",
             ),
@@ -1084,8 +1076,10 @@ class TestProblemMapping:
         table_client.create_record.assert_called_once_with(
             "problem",
             dict(
-                state=CLOSED, short_description="Test problem",
-                assigned_to="123456", fix_notes="some fix notes",
+                state=CLOSED,
+                short_description="Test problem",
+                assigned_to="123456",
+                fix_notes="some fix notes",
                 cause_notes="some cause notes",
                 resolution_code="fix_applied",
             ),
@@ -1144,7 +1138,9 @@ class TestProblemMapping:
         ):
             problem.ensure_present(module, None, None, None)
 
-    def test_create_implicitly_mapped_problem_state(self, create_module, table_client, problem_client, attachment_client):
+    def test_create_implicitly_mapped_problem_state(
+        self, create_module, table_client, problem_client, attachment_client
+    ):
         module_params = self.create_empty_module_params()
         module_params.update(
             dict(
@@ -1153,9 +1149,7 @@ class TestProblemMapping:
                 assigned_to="problem.admin",
                 base_api_path="/api/path",
                 problem_mapping=dict(
-                    state={
-                        NEW: "my-new"
-                    },
+                    state={NEW: "my-new"},
                 ),
             )
         )
@@ -1181,10 +1175,7 @@ class TestProblemMapping:
 
         table_client.create_record.assert_called_once_with(
             "problem",
-            dict(
-                state=ASSESS, short_description="Test problem",
-                assigned_to="123456"
-            ),
+            dict(state=ASSESS, short_description="Test problem", assigned_to="123456"),
             False,
         )
 
@@ -1220,7 +1211,6 @@ class TestProblemMapping:
             ("state", "my-closed"),
             ("state", "absent"),
             ("state", None),
-
             ("problem_state", "my-new"),
             ("problem_state", "my-assess"),
             ("problem_state", "rca"),
@@ -1228,17 +1218,15 @@ class TestProblemMapping:
             ("problem_state", "my-resolved"),
             ("problem_state", "my-closed"),
             ("problem_state", None),
-
             ("urgency", "one"),
             ("urgency", "two"),
             ("urgency", "three"),
             ("urgency", None),
-
             ("impact", "111"),
             ("impact", "222"),
             ("impact", "333"),
             ("impact", None),
-        ]
+        ],
     )
     def test_validate_mapping(self, create_module, mapped_param, param_value):
         all_mappings = dict(
@@ -1263,7 +1251,9 @@ class TestProblemMapping:
 
         module = create_module(params=module_params)
 
-        mapper = get_mapper(module, "problem_mapping", PAYLOAD_FIELDS_MAPPING, implicit=True)
+        mapper = get_mapper(
+            module, "problem_mapping", PAYLOAD_FIELDS_MAPPING, implicit=True
+        )
 
         problem.validate_mapping(module_params, mapper)
 
@@ -1278,7 +1268,6 @@ class TestProblemMapping:
             ("state", "closed"),
             ("state", "absent"),
             ("state", None),
-
             ("problem_state", "new"),
             ("problem_state", "explicitly-mapped-assess"),
             ("problem_state", "root_cause_analysis"),
@@ -1286,17 +1275,15 @@ class TestProblemMapping:
             ("problem_state", "resolved"),
             ("problem_state", "closed"),
             ("problem_state", None),
-
             ("urgency", "not_too_urgent"),
             ("urgency", "medium"),
             ("urgency", "high"),
             ("urgency", None),
-
             ("impact", "low"),
             ("impact", "medium"),
             ("impact", "highly_impacted"),
             ("impact", None),
-        ]
+        ],
     )
     def test_validate_mapping_implicit(self, create_module, mapped_param, param_value):
         all_mappings = dict(
@@ -1317,7 +1304,9 @@ class TestProblemMapping:
 
         module = create_module(params=module_params)
 
-        mapper = get_mapper(module, "problem_mapping", PAYLOAD_FIELDS_MAPPING, implicit=True)
+        mapper = get_mapper(
+            module, "problem_mapping", PAYLOAD_FIELDS_MAPPING, implicit=True
+        )
 
         problem.validate_mapping(module_params, mapper)
 
@@ -2045,7 +2034,7 @@ class TestProblemMapping:
                     assigned_to="abc123",
                     fix_notes="some fix notes",
                     cause_notes="some cause notes",
-                    resolution_code=""
+                    resolution_code="",
                 ),
                 after=expected,
             ),

--- a/tests/unit/plugins/modules/test_problem.py
+++ b/tests/unit/plugins/modules/test_problem.py
@@ -1167,7 +1167,7 @@ class TestProblemMapping:
 
         module = create_module(params=module_params)
 
-        mapper = get_mapper(module, "problem_mapping", PAYLOAD_FIELDS_MAPPING)
+        mapper = get_mapper(module, "problem_mapping", PAYLOAD_FIELDS_MAPPING, implicit=True)
 
         problem.validate_mapping(module_params, mapper)
 


### PR DESCRIPTION
##### SUMMARY
Works around ServiceNow's limitation introduced in recent releases (starting with Rome) which made problem state transitioning with Table API impossible.

Fixes #163, #27 and #93.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

- `module_utils/problem.py` - Added problem client for requesting problem state updates from _API for Red Hat Ansible Automation Platform Certified Content Collection_ Scripted REST API Service.
- `module_utils/util.py` - Added optional Boolean parameter `implicit` to `get_mapper` function to provide the default values for missing keys in the mapping.
- `modules/problem.py` - Added optional module parameter `base_api_path` to control the URI prefix of the endpoint exposed by _API for Red Hat Ansible Automation Platform Certified Content Collection_ Scripted REST API Service.
- `modules/problem.py` - Added module parameters validation to match the mapping specification.
- `modules/problem.py` - Uses _API for Red Hat Ansible Automation Platform Certified Content Collection_ Scripted REST API Service for transitioning problem state in case Table API fails.

##### ADDITIONAL INFORMATION
Requires [API for Red Hat Ansible Automation Platform Certified Content Collection](https://store.servicenow.com/sn_appstore_store.do#!/store/application/9b33c83a1bcc5510b76a0d0fdc4bcb21/1.0.0?sl=sh) application to be installed from the ServiceNow Store.
