### PR TITLE
Bugfix: sysparm_query is now used inside request

### DIFF
--- a/changelogs/fragments/inventory_plugin_bugfix.yml
+++ b/changelogs/fragments/inventory_plugin_bugfix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+ - inventory plugin - sysparm_query attribute is taken into account.

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -415,7 +415,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
         # TODO: Insert caching here once we remove deprecated functionality
         records = fetch_records(
-            table_client, table, query, is_encoded_query=bool(sysparm_query)
+            table_client, table, query or sysparm_query, is_encoded_query=bool(sysparm_query)
         )
 
         if enhanced:

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -415,7 +415,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
         # TODO: Insert caching here once we remove deprecated functionality
         records = fetch_records(
-            table_client, table, query or sysparm_query, is_encoded_query=bool(sysparm_query)
+            table_client,
+            table,
+            query or sysparm_query,
+            fields=columns,
+            is_encoded_query=bool(sysparm_query),
         )
 
         if enhanced:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Sysparm_query value was not used because of a bug. End result was, that whole cmdb table was returned in that case.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Inventory plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
