### PR TITLE
Enable lookups for dot walking

### DIFF
--- a/changelogs/fragments/inventory_plugin_reference_fields.yml
+++ b/changelogs/fragments/inventory_plugin_reference_fields.yml
@@ -1,0 +1,2 @@
+minor_changes:
+ - inventory plugin - Plugin now supports mapping of reference fields inside 'compose' block.

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -20,7 +20,8 @@ description:
   - Builds inventory from ServiceNow table records.
   - Requires a configuration file ending in C(now.yml) or C(now.yaml).
   - The plugin sets host variables denoted by I(columns).
-  - For variables with dots (for example 'location.country') use lookup('ansible.builtin.vars', 'variable.name') notation. See the example section for more details. This feature is added in version 2.1.0.
+  - For variables with dots (for example 'location.country') use lookup('ansible.builtin.vars', 'variable.name') notation.
+    See the example section for more details. This feature is added in version 2.1.0.
 version_added: 1.0.0
 extends_documentation_fragment:
   - ansible.builtin.constructed

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -477,7 +477,8 @@ class InventoryModule(BaseInventoryPlugin, ConstructableWithLookup):
                 fields=referenced_columns + ["sys_id"],
                 is_encoded_query=bool(sysparm_query),
             )
-            referenced_dict = {x["sys_id"]: x for x in referenced_records}
+
+            referenced_dict = dict((x["sys_id"], x) for x in referenced_records)
             for record in records:
                 referenced = referenced_dict.get(record["sys_id"], None)
                 if referenced:

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -20,7 +20,7 @@ description:
   - Builds inventory from ServiceNow table records.
   - Requires a configuration file ending in C(now.yml) or C(now.yaml).
   - The plugin sets host variables denoted by I(columns).
-  - For . walking use lookup('ansible.builtin.vars','variable.name') notation
+  - For variables with dots (for example 'location.country') use lookup('ansible.builtin.vars', 'variable.name') notation. See the example section for more details. This feature is added in version 2.1.0.
 version_added: 1.0.0
 extends_documentation_fragment:
   - ansible.builtin.constructed

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -20,6 +20,7 @@ description:
   - Builds inventory from ServiceNow table records.
   - Requires a configuration file ending in C(now.yml) or C(now.yaml).
   - The plugin sets host variables denoted by I(columns).
+  - For . walking use lookup('ansible.builtin.vars','variable.name') notation
 version_added: 1.0.0
 extends_documentation_fragment:
   - ansible.builtin.constructed
@@ -241,7 +242,32 @@ compose:
 # |  |  |--{cost = 2,160 USD}
 # |  |  |--{cpu_type = Intel}
 # |  |  |--{name = INSIGHT-NY-03}
+
+plugin: servicenow.itsm.now
+enhanced: false
+strict: true
+table: cmdb_ci_server
+columns:
+  - name
+  - ip_address
+  - location
+  - location.country
+compose:
+  street: location
+  country: lookup('ansible.builtin.vars', 'location.country')
+
+# `ansible-inventory -i inventory.now.yaml --graph --vars` output:
+# @all:
+# |--@ungrouped:
+# |  |--OWA-SD-01
+# |  |  |--{country = Italy}
+# |  |  |--{ip_address = }
+# |  |  |--{location = Via Nomentana 56, Rome}
+# |  |  |--{location.country = Italy}
+# |  |  |--{name = OWA-SD-01}
+# |  |  |--{street = Via Nomentana 56, Rome}
 """
+
 
 import os
 
@@ -252,6 +278,7 @@ from ansible.plugins.inventory import (
     Constructable,
     to_safe_group_name,
 )
+from ansible.utils.vars import combine_vars
 
 from ..module_utils.client import Client
 from ..module_utils.errors import ServiceNowError
@@ -287,7 +314,27 @@ def fetch_records(table_client, table, query, fields=None, is_encoded_query=Fals
     return table_client.list_records(table, snow_query)
 
 
-class InventoryModule(BaseInventoryPlugin, Constructable):
+class ConstructableWithLookup(Constructable):
+
+    def _compose(self, template, variables):
+        ''' helper method for plugins to compose variables for Ansible based on jinja2 expression and inventory vars'''
+        t = self.templar
+
+        try:
+            use_extra = self.get_option('use_extra_vars')
+        except Exception:
+            use_extra = False
+
+        if use_extra:
+            t.available_variables = combine_vars(variables, self._vars)
+        else:
+            t.available_variables = variables
+
+        ''' Only change that we have overriden is that we do not disable lookups'''
+        return t.template('%s%s%s' % (t.environment.variable_start_string, template, t.environment.variable_end_string), disable_lookups=False)
+
+
+class InventoryModule(BaseInventoryPlugin, ConstructableWithLookup):
 
     NAME = "servicenow.itsm.now"
 
@@ -418,9 +465,25 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             table_client,
             table,
             query or sysparm_query,
-            fields=columns,
             is_encoded_query=bool(sysparm_query),
         )
+
+        referenced_columns = [x for x in columns if '.' in x]
+        if referenced_columns:
+            referenced_records = fetch_records(
+                table_client,
+                table,
+                query or sysparm_query,
+                fields=referenced_columns + ["sys_id"],
+                is_encoded_query=bool(sysparm_query),
+            )
+            referenced_dict = {x["sys_id"]: x for x in referenced_records}
+            for record in records:
+                referenced = referenced_dict.get(record["sys_id"], None)
+                if referenced:
+                    referenced.pop("sys_id")
+                    for key, value in referenced.items():
+                        record[key] = value
 
         if enhanced:
             rel_records = fetch_records(

--- a/tests/integration/targets/inventory/files/reference_fields.now.yml
+++ b/tests/integration/targets/inventory/files/reference_fields.now.yml
@@ -1,0 +1,14 @@
+---
+plugin: servicenow.itsm.now
+table: cmdb_ci_ec2_instance
+enhanced: false
+columns:
+  - location.name
+  - location.street
+compose:
+  ansible_host: fqdn
+  location: location
+  location_name: lookup('ansible.builtin.vars', 'location.name')
+  street: lookup('ansible.builtin.vars', 'location.street')
+
+strict: true

--- a/tests/integration/targets/inventory/playbooks/reference_fields.yml
+++ b/tests/integration/targets/inventory/playbooks/reference_fields.yml
@@ -1,0 +1,77 @@
+---
+- name: Make sure we get back all and ungrouped groups by default
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - block:
+        - name: Create test location
+          servicenow.itsm.api:
+            resource: cmn_location
+            action: post
+            query_params:
+              sysparm_input_display_value: true
+            data:
+              city: "Some city"
+              street: "Some street"
+              name: "Name of location"
+              country: "Some country"
+          register: test_location
+
+        - name: Print created country
+          ansible.builtin.debug:
+            var: test_location.record.sys_id
+
+        - name: Create imaginary VMs
+          servicenow.itsm.configuration_item:
+            name: i{{ item }}
+            sys_class_name: cmdb_ci_ec2_instance
+            ip_address: 10.1.0.{{ item }}
+            environment: "{{ (item % 2 == 0) | ansible.builtin.ternary('development', 'production') }}"
+            other:
+              fqdn: f{{ item }}.example.com
+              guest_os_fullname: "{{ (item < 106) | ansible.builtin.ternary('OS0', 'OS1') }}"
+              vm_inst_id: i{{ item }}
+              location: "{{ test_location.record.sys_id }}"
+          loop: "{{ range(101, 103) | list }}"
+          register: vms
+
+        - name: Reload inventory
+          ansible.builtin.meta: refresh_inventory
+
+        - name: Print all hostvars
+          ansible.builtin.debug:
+            var: hostvars
+
+        - name: Check i101
+          ansible.builtin.assert:
+            that:
+              - hostvars.i101.inventory_hostname == "i101"
+              - hostvars.i101.ansible_host == "f101.example.com"
+              - hostvars.i101.street == "Some street"
+              - hostvars.i101.location_name == "Name of location"
+              - hostvars.i101.location == "Name of location"
+
+        - name: Check i107
+          ansible.builtin.assert:
+            that:
+              - hostvars.i102.inventory_hostname == "i102"
+              - hostvars.i102.ansible_host == "f102.example.com"
+              - hostvars.i102.street == "Some street"
+              - hostvars.i102.location_name == "Name of location"
+              - hostvars.i102.location == "Name of location"
+
+      always:
+        - name: Delete location
+          servicenow.itsm.api:
+            resource: cmn_location
+            action: delete
+            sys_id: "{{ test_location.record.sys_id }}"
+
+        - name: Delete VMs
+          servicenow.itsm.configuration_item:
+            state: absent
+            sys_id: "{{ item.record.sys_id }}"
+          loop: "{{ vms.results }}"
+          loop_control:
+            label: "{{ item.record.name }}"


### PR DESCRIPTION
Inside this plugin we manually enable dot walking. Because service now allows returned values to have dot in names.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes #231 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
inventrory plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
