### PR TITLE
Adding instance -> custom_headers and instance -> api_path

### DIFF
--- a/docs/servicenow.itsm.api_info_module.rst
+++ b/docs/servicenow.itsm.api_info_module.rst
@@ -107,6 +107,23 @@ Parameters
                         <div>ServiceNow instance information.</div>
                 </td>
             </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>api_path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">api/now</div>
+                </td>
+                <td>
+                        <div>Adjust path to api endpoint in case you have custom api path.</div>
+                </td>
+            </tr> 
                                 <tr>
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
@@ -141,6 +158,23 @@ Parameters
                         <div>Secret associated with <em>client_id</em>. Used for OAuth authentication.</div>
                         <div>If not set, the value of the <code>SN_CLIENT_SECRET</code> environment variable will be used.</div>
                         <div>If provided, it requires <em>client_id</em>.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>custom_headers</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">{}</div>
+                </td>
+                <td>
+                        <div>Any custom headers you want to add to the requests.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/servicenow.itsm.api_module.rst
+++ b/docs/servicenow.itsm.api_module.rst
@@ -91,6 +91,23 @@ Parameters
                         <div>ServiceNow instance information.</div>
                 </td>
             </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>api_path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">api/now</div>
+                </td>
+                <td>
+                        <div>Adjust path to api endpoint in case you have custom api path.</div>
+                </td>
+            </tr>
                                 <tr>
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
@@ -125,6 +142,23 @@ Parameters
                         <div>Secret associated with <em>client_id</em>. Used for OAuth authentication.</div>
                         <div>If not set, the value of the <code>SN_CLIENT_SECRET</code> environment variable will be used.</div>
                         <div>If provided, it requires <em>client_id</em>.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>custom_headers</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">{}</div>
+                </td>
+                <td>
+                        <div>Any custom headers you want to add to the requests.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/servicenow.itsm.attachment_module.rst
+++ b/docs/servicenow.itsm.attachment_module.rst
@@ -67,6 +67,23 @@ Parameters
                         <div>ServiceNow instance information.</div>
                 </td>
             </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>api_path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">api/now</div>
+                </td>
+                <td>
+                        <div>Adjust path to api endpoint in case you have custom api path.</div>
+                </td>
+            </tr>
                                 <tr>
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
@@ -101,6 +118,23 @@ Parameters
                         <div>Secret associated with <em>client_id</em>. Used for OAuth authentication.</div>
                         <div>If not set, the value of the <code>SN_CLIENT_SECRET</code> environment variable will be used.</div>
                         <div>If provided, it requires <em>client_id</em>.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>custom_headers</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">{}</div>
+                </td>
+                <td>
+                        <div>Any custom headers you want to add to the requests.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/servicenow.itsm.change_request_info_module.rst
+++ b/docs/servicenow.itsm.change_request_info_module.rst
@@ -149,6 +149,23 @@ Parameters
                         <div>ServiceNow instance information.</div>
                 </td>
             </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>api_path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">api/now</div>
+                </td>
+                <td>
+                        <div>Adjust path to api endpoint in case you have custom api path.</div>
+                </td>
+            </tr>
                                 <tr>
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
@@ -183,6 +200,23 @@ Parameters
                         <div>Secret associated with <em>client_id</em>. Used for OAuth authentication.</div>
                         <div>If not set, the value of the <code>SN_CLIENT_SECRET</code> environment variable will be used.</div>
                         <div>If provided, it requires <em>client_id</em>.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>custom_headers</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">{}</div>
+                </td>
+                <td>
+                        <div>Any custom headers you want to add to the requests.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/servicenow.itsm.change_request_module.rst
+++ b/docs/servicenow.itsm.change_request_module.rst
@@ -344,6 +344,23 @@ Parameters
                         <div>ServiceNow instance information.</div>
                 </td>
             </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>api_path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">api/now</div>
+                </td>
+                <td>
+                        <div>Adjust path to api endpoint in case you have custom api path.</div>
+                </td>
+            </tr>
                                 <tr>
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
@@ -378,6 +395,23 @@ Parameters
                         <div>Secret associated with <em>client_id</em>. Used for OAuth authentication.</div>
                         <div>If not set, the value of the <code>SN_CLIENT_SECRET</code> environment variable will be used.</div>
                         <div>If provided, it requires <em>client_id</em>.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>custom_headers</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">{}</div>
+                </td>
+                <td>
+                        <div>Any custom headers you want to add to the requests.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/servicenow.itsm.change_request_task_info_module.rst
+++ b/docs/servicenow.itsm.change_request_task_info_module.rst
@@ -83,6 +83,23 @@ Parameters
                         <div>ServiceNow instance information.</div>
                 </td>
             </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>api_path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">api/now</div>
+                </td>
+                <td>
+                        <div>Adjust path to api endpoint in case you have custom api path.</div>
+                </td>
+            </tr>
                                 <tr>
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
@@ -117,6 +134,23 @@ Parameters
                         <div>Secret associated with <em>client_id</em>. Used for OAuth authentication.</div>
                         <div>If not set, the value of the <code>SN_CLIENT_SECRET</code> environment variable will be used.</div>
                         <div>If provided, it requires <em>client_id</em>.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>custom_headers</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">{}</div>
+                </td>
+                <td>
+                        <div>Any custom headers you want to add to the requests.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/servicenow.itsm.change_request_task_module.rst
+++ b/docs/servicenow.itsm.change_request_task_module.rst
@@ -248,6 +248,23 @@ Parameters
                         <div>ServiceNow instance information.</div>
                 </td>
             </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>api_path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">api/now</div>
+                </td>
+                <td>
+                        <div>Adjust path to api endpoint in case you have custom api path.</div>
+                </td>
+            </tr>
                                 <tr>
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
@@ -282,6 +299,23 @@ Parameters
                         <div>Secret associated with <em>client_id</em>. Used for OAuth authentication.</div>
                         <div>If not set, the value of the <code>SN_CLIENT_SECRET</code> environment variable will be used.</div>
                         <div>If provided, it requires <em>client_id</em>.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>custom_headers</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">{}</div>
+                </td>
+                <td>
+                        <div>Any custom headers you want to add to the requests.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/servicenow.itsm.configuration_item_batch_module.rst
+++ b/docs/servicenow.itsm.configuration_item_batch_module.rst
@@ -84,6 +84,23 @@ Parameters
                         <div>ServiceNow instance information.</div>
                 </td>
             </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>api_path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">api/now</div>
+                </td>
+                <td>
+                        <div>Adjust path to api endpoint in case you have custom api path.</div>
+                </td>
+            </tr>
                                 <tr>
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
@@ -118,6 +135,23 @@ Parameters
                         <div>Secret associated with <em>client_id</em>. Used for OAuth authentication.</div>
                         <div>If not set, the value of the <code>SN_CLIENT_SECRET</code> environment variable will be used.</div>
                         <div>If provided, it requires <em>client_id</em>.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>custom_headers</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">{}</div>
+                </td>
+                <td>
+                        <div>Any custom headers you want to add to the requests.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/servicenow.itsm.configuration_item_info_module.rst
+++ b/docs/servicenow.itsm.configuration_item_info_module.rst
@@ -116,6 +116,23 @@ Parameters
                         <div>ServiceNow instance information.</div>
                 </td>
             </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>api_path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">api/now</div>
+                </td>
+                <td>
+                        <div>Adjust path to api endpoint in case you have custom api path.</div>
+                </td>
+            </tr>
                                 <tr>
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
@@ -150,6 +167,23 @@ Parameters
                         <div>Secret associated with <em>client_id</em>. Used for OAuth authentication.</div>
                         <div>If not set, the value of the <code>SN_CLIENT_SECRET</code> environment variable will be used.</div>
                         <div>If provided, it requires <em>client_id</em>.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>custom_headers</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">{}</div>
+                </td>
+                <td>
+                        <div>Any custom headers you want to add to the requests.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/servicenow.itsm.configuration_item_module.rst
+++ b/docs/servicenow.itsm.configuration_item_module.rst
@@ -267,6 +267,23 @@ Parameters
                         <div>ServiceNow instance information.</div>
                 </td>
             </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>api_path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">api/now</div>
+                </td>
+                <td>
+                        <div>Adjust path to api endpoint in case you have custom api path.</div>
+                </td>
+            </tr>
                                 <tr>
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
@@ -301,6 +318,23 @@ Parameters
                         <div>Secret associated with <em>client_id</em>. Used for OAuth authentication.</div>
                         <div>If not set, the value of the <code>SN_CLIENT_SECRET</code> environment variable will be used.</div>
                         <div>If provided, it requires <em>client_id</em>.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>custom_headers</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">{}</div>
+                </td>
+                <td>
+                        <div>Any custom headers you want to add to the requests.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/servicenow.itsm.incident_info_module.rst
+++ b/docs/servicenow.itsm.incident_info_module.rst
@@ -133,6 +133,23 @@ Parameters
                         <div>ServiceNow instance information.</div>
                 </td>
             </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>api_path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">api/now</div>
+                </td>
+                <td>
+                        <div>Adjust path to api endpoint in case you have custom api path.</div>
+                </td>
+            </tr>
                                 <tr>
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
@@ -167,6 +184,23 @@ Parameters
                         <div>Secret associated with <em>client_id</em>. Used for OAuth authentication.</div>
                         <div>If not set, the value of the <code>SN_CLIENT_SECRET</code> environment variable will be used.</div>
                         <div>If provided, it requires <em>client_id</em>.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>custom_headers</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">{}</div>
+                </td>
+                <td>
+                        <div>Any custom headers you want to add to the requests.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/servicenow.itsm.incident_module.rst
+++ b/docs/servicenow.itsm.incident_module.rst
@@ -306,6 +306,23 @@ Parameters
                         <div>ServiceNow instance information.</div>
                 </td>
             </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>api_path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">api/now</div>
+                </td>
+                <td>
+                        <div>Adjust path to api endpoint in case you have custom api path.</div>
+                </td>
+            </tr>
                                 <tr>
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
@@ -340,6 +357,23 @@ Parameters
                         <div>Secret associated with <em>client_id</em>. Used for OAuth authentication.</div>
                         <div>If not set, the value of the <code>SN_CLIENT_SECRET</code> environment variable will be used.</div>
                         <div>If provided, it requires <em>client_id</em>.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>custom_headers</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">{}</div>
+                </td>
+                <td>
+                        <div>Any custom headers you want to add to the requests.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/servicenow.itsm.now_inventory.rst
+++ b/docs/servicenow.itsm.now_inventory.rst
@@ -132,6 +132,23 @@ Parameters
                         <div>ServiceNow instance information.</div>
                 </td>
             </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>api_path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">api/now</div>
+                </td>
+                <td>
+                        <div>Adjust path to api endpoint in case you have custom api path.</div>
+                </td>
+            </tr>
                                 <tr>
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
@@ -170,6 +187,23 @@ Parameters
                 <td>
                         <div>Secret associated with <em>client_id</em>. Used for OAuth authentication.</div>
                         <div>If provided, it requires <em>client_id</em>.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>custom_headers</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">{}</div>
+                </td>
+                <td>
+                        <div>Any custom headers you want to add to the requests.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/servicenow.itsm.problem_info_module.rst
+++ b/docs/servicenow.itsm.problem_info_module.rst
@@ -49,6 +49,23 @@ Parameters
                         <div>ServiceNow instance information.</div>
                 </td>
             </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>api_path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">api/now</div>
+                </td>
+                <td>
+                        <div>Adjust path to api endpoint in case you have custom api path.</div>
+                </td>
+            </tr>
                                 <tr>
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
@@ -83,6 +100,23 @@ Parameters
                         <div>Secret associated with <em>client_id</em>. Used for OAuth authentication.</div>
                         <div>If not set, the value of the <code>SN_CLIENT_SECRET</code> environment variable will be used.</div>
                         <div>If provided, it requires <em>client_id</em>.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>custom_headers</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">{}</div>
+                </td>
+                <td>
+                        <div>Any custom headers you want to add to the requests.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/servicenow.itsm.problem_module.rst
+++ b/docs/servicenow.itsm.problem_module.rst
@@ -253,6 +253,23 @@ Parameters
                         <div>ServiceNow instance information.</div>
                 </td>
             </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>api_path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">api/now</div>
+                </td>
+                <td>
+                        <div>Adjust path to api endpoint in case you have custom api path.</div>
+                </td>
+            </tr>
                                 <tr>
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
@@ -287,6 +304,23 @@ Parameters
                         <div>Secret associated with <em>client_id</em>. Used for OAuth authentication.</div>
                         <div>If not set, the value of the <code>SN_CLIENT_SECRET</code> environment variable will be used.</div>
                         <div>If provided, it requires <em>client_id</em>.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>custom_headers</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">{}</div>
+                </td>
+                <td>
+                        <div>Any custom headers you want to add to the requests.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/servicenow.itsm.problem_task_info_module.rst
+++ b/docs/servicenow.itsm.problem_task_info_module.rst
@@ -49,6 +49,23 @@ Parameters
                         <div>ServiceNow instance information.</div>
                 </td>
             </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>api_path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">api/now</div>
+                </td>
+                <td>
+                        <div>Adjust path to api endpoint in case you have custom api path.</div>
+                </td>
+            </tr>
                                 <tr>
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
@@ -83,6 +100,23 @@ Parameters
                         <div>Secret associated with <em>client_id</em>. Used for OAuth authentication.</div>
                         <div>If not set, the value of the <code>SN_CLIENT_SECRET</code> environment variable will be used.</div>
                         <div>If provided, it requires <em>client_id</em>.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>custom_headers</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">{}</div>
+                </td>
+                <td>
+                        <div>Any custom headers you want to add to the requests.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/servicenow.itsm.problem_task_module.rst
+++ b/docs/servicenow.itsm.problem_task_module.rst
@@ -160,6 +160,23 @@ Parameters
                         <div>ServiceNow instance information.</div>
                 </td>
             </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>api_path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">api/now</div>
+                </td>
+                <td>
+                        <div>Adjust path to api endpoint in case you have custom api path.</div>
+                </td>
+            </tr>
                                 <tr>
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
@@ -194,6 +211,23 @@ Parameters
                         <div>Secret associated with <em>client_id</em>. Used for OAuth authentication.</div>
                         <div>If not set, the value of the <code>SN_CLIENT_SECRET</code> environment variable will be used.</div>
                         <div>If provided, it requires <em>client_id</em>.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>custom_headers</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">{}</div>
+                </td>
+                <td>
+                        <div>Any custom headers you want to add to the requests.</div>
                 </td>
             </tr>
             <tr>

--- a/plugins/doc_fragments/instance.py
+++ b/plugins/doc_fragments/instance.py
@@ -45,6 +45,11 @@ options:
         default: password
         type: str
         version_added: '1.1.0'
+      api_path:
+        description:
+          - Change the API endpoint of SNOW instance from default api/now
+        type: str
+        default: api/now
       client_id:
         description:
           - ID of the client application used for OAuth authentication.
@@ -59,6 +64,10 @@ options:
             variable will be used.
           - If provided, it requires I(client_id).
         type: str
+      custom_headers:
+        description:
+          - Dictionary containing any extra headers which will be passed with request
+        type: dict
       refresh_token:
         description:
           - Refresh token used for OAuth authentication.

--- a/plugins/module_utils/arguments.py
+++ b/plugins/module_utils/arguments.py
@@ -97,6 +97,10 @@ SHARED_SPECS = dict(
                 default="password",
                 fallback=(env_fallback, ["SN_GRANT_TYPE"]),
             ),
+            api_path=dict(
+                type="str",
+                default="api/path",
+            ),
             client_id=dict(
                 type="str",
                 fallback=(env_fallback, ["SN_CLIENT_ID"]),
@@ -105,6 +109,9 @@ SHARED_SPECS = dict(
                 type="str",
                 no_log=True,
                 fallback=(env_fallback, ["SN_CLIENT_SECRET"]),
+            ),
+            custom_headers=dict(
+                type="dict"
             ),
             refresh_token=dict(
                 type="str",

--- a/plugins/module_utils/arguments.py
+++ b/plugins/module_utils/arguments.py
@@ -99,7 +99,7 @@ SHARED_SPECS = dict(
             ),
             api_path=dict(
                 type="str",
-                default="api/path",
+                default="api/now",
             ),
             client_id=dict(
                 type="str",

--- a/plugins/module_utils/attachment.py
+++ b/plugins/module_utils/attachment.py
@@ -14,7 +14,7 @@ import os
 from . import errors
 
 
-def _path(*subpaths, api_path=("api", "now")):
+def _path(api_path, *subpaths):
     return "/".join(
         api_path
         + ("attachment",)
@@ -38,7 +38,7 @@ class AttachmentClient:
 
         while offset < total:
             response = self.client.get(
-                _path(api_path=self.client.api_path), query=dict(base_query, sysparm_offset=offset)
+                _path(self.client.api_path), query=dict(base_query, sysparm_offset=offset)
             )
 
             result.extend(response.json["result"])
@@ -52,7 +52,7 @@ class AttachmentClient:
             return query
         return self.client.request(
             "POST",
-            _path("file", api_path=self.client.api_path),
+            _path(self.client.api_path, "file"),
             query=query,
             headers={"Accept": "application/json", "Content-type": mime_type},
             bytes=data,
@@ -85,7 +85,7 @@ class AttachmentClient:
 
     def delete_record(self, record, check_mode):
         if not check_mode:
-            self.client.delete(_path(record["sys_id"], api_path=self.client.api_path))
+            self.client.delete(_path(self.client.api_path, record["sys_id"]))
 
     def delete_attached_records(self, table, table_sys_id, check_mode):
         for record in self.list_records(
@@ -108,7 +108,7 @@ class AttachmentClient:
         return list(mapped_records.values())
 
     def get_attachment(self, attachment_sys_id):
-        return self.client.get(_path(attachment_sys_id, "file", api_path=self.client.api_path))
+        return self.client.get(_path(self.client.api_path, attachment_sys_id, "file"))
 
     def save_attachment(self, binary_data, dest):
         try:

--- a/plugins/module_utils/attachment.py
+++ b/plugins/module_utils/attachment.py
@@ -14,13 +14,10 @@ import os
 from . import errors
 
 
-def _path(*subpaths):
+def _path(*subpaths, api_path=("api", "now")):
     return "/".join(
-        (
-            "api",
-            "now",
-            "attachment",
-        )
+        api_path
+        + ("attachment",)
         + subpaths
     )
 
@@ -41,7 +38,7 @@ class AttachmentClient:
 
         while offset < total:
             response = self.client.get(
-                _path(), query=dict(base_query, sysparm_offset=offset)
+                _path(api_path=self.client.api_path), query=dict(base_query, sysparm_offset=offset)
             )
 
             result.extend(response.json["result"])
@@ -55,7 +52,7 @@ class AttachmentClient:
             return query
         return self.client.request(
             "POST",
-            _path("file"),
+            _path("file", api_path=self.client.api_path),
             query=query,
             headers={"Accept": "application/json", "Content-type": mime_type},
             bytes=data,
@@ -88,7 +85,7 @@ class AttachmentClient:
 
     def delete_record(self, record, check_mode):
         if not check_mode:
-            self.client.delete(_path(record["sys_id"]))
+            self.client.delete(_path(record["sys_id"], api_path=self.client.api_path))
 
     def delete_attached_records(self, table, table_sys_id, check_mode):
         for record in self.list_records(
@@ -111,7 +108,7 @@ class AttachmentClient:
         return list(mapped_records.values())
 
     def get_attachment(self, attachment_sys_id):
-        return self.client.get(_path(attachment_sys_id, "file"))
+        return self.client.get(_path(attachment_sys_id, "file", api_path=self.client.api_path))
 
     def save_attachment(self, binary_data, dest):
         try:

--- a/plugins/module_utils/client.py
+++ b/plugins/module_utils/client.py
@@ -53,6 +53,8 @@ class Client:
         refresh_token=None,
         client_id=None,
         client_secret=None,
+        custom_headers=None,
+        api_path="api/now",
         timeout=None,
     ):
         if not (host or "").startswith(("https://", "http://")):
@@ -67,6 +69,8 @@ class Client:
         self.grant_type = grant_type
         self.client_id = client_id
         self.client_secret = client_secret
+        self.custom_headers = custom_headers
+        self.api_path = tuple(api_path.strip("/").split("/"))
         self.refresh_token = refresh_token
         self.timeout = timeout
 
@@ -157,6 +161,8 @@ class Client:
         if query:
             url = "{0}?{1}".format(url, urlencode(query))
         headers = dict(headers or DEFAULT_HEADERS, **self.auth_header)
+        if self.custom_headers:
+            headers = dict(headers, **self.custom_headers)
         if data is not None:
             data = json.dumps(data, separators=(",", ":"))
             headers["Content-type"] = "application/json"

--- a/plugins/module_utils/table.py
+++ b/plugins/module_utils/table.py
@@ -9,8 +9,9 @@ __metaclass__ = type
 
 from . import errors
 
+
 def _path(api_path, table, *subpaths):
-    return "/".join(api_path + ("table", table)  + subpaths)
+    return "/".join(api_path + ("table", table) + subpaths)
 
 
 def _query(original=None):

--- a/plugins/module_utils/table.py
+++ b/plugins/module_utils/table.py
@@ -10,8 +10,8 @@ __metaclass__ = type
 from . import errors
 
 
-def _path(table, *subpaths):
-    return "/".join(("api", "now") + ("table", table) + subpaths)
+def _path(table, *subpaths, api_path=("api", "now")):
+    return "/".join(api_path + ("table", table) + subpaths)
 
 
 def _query(original=None):
@@ -37,7 +37,7 @@ class TableClient:
 
         while offset < total:
             response = self.client.get(
-                _path(table), query=dict(base_query, sysparm_offset=offset)
+                _path(table, api_path=self.client.api_path), query=dict(base_query, sysparm_offset=offset)
             )
 
             result.extend(response.json["result"])
@@ -68,7 +68,7 @@ class TableClient:
             # Approximate the result using the payload.
             return payload
 
-        return self.client.post(_path(table), payload, query=_query(query)).json[
+        return self.client.post(_path(table, api_path=self.client.api_path), payload, query=_query(query)).json[
             "result"
         ]
 
@@ -78,12 +78,12 @@ class TableClient:
             return dict(record, **payload)
 
         return self.client.patch(
-            _path(table, record["sys_id"]), payload, query=_query(query)
+            _path(table, record["sys_id"], api_path=self.client.api_path), payload, query=_query(query)
         ).json["result"]
 
     def delete_record(self, table, record, check_mode):
         if not check_mode:
-            self.client.delete(_path(table, record["sys_id"]))
+            self.client.delete(_path(table, record["sys_id"], api_path=self.client.api_path))
 
 
 def find_user(table_client, user_id):

--- a/plugins/module_utils/table.py
+++ b/plugins/module_utils/table.py
@@ -9,9 +9,8 @@ __metaclass__ = type
 
 from . import errors
 
-
-def _path(table, *subpaths, api_path=("api", "now")):
-    return "/".join(api_path + ("table", table) + subpaths)
+def _path(api_path, table, *subpaths):
+    return "/".join(api_path + ("table", table)  + subpaths)
 
 
 def _query(original=None):
@@ -37,7 +36,7 @@ class TableClient:
 
         while offset < total:
             response = self.client.get(
-                _path(table, api_path=self.client.api_path), query=dict(base_query, sysparm_offset=offset)
+                _path(self.client.api_path, table), query=dict(base_query, sysparm_offset=offset)
             )
 
             result.extend(response.json["result"])
@@ -68,7 +67,7 @@ class TableClient:
             # Approximate the result using the payload.
             return payload
 
-        return self.client.post(_path(table, api_path=self.client.api_path), payload, query=_query(query)).json[
+        return self.client.post(_path(self.client.api_path, table), payload, query=_query(query)).json[
             "result"
         ]
 
@@ -78,12 +77,12 @@ class TableClient:
             return dict(record, **payload)
 
         return self.client.patch(
-            _path(table, record["sys_id"], api_path=self.client.api_path), payload, query=_query(query)
+            _path(self.client.api_path, table, record["sys_id"]), payload, query=_query(query)
         ).json["result"]
 
     def delete_record(self, table, record, check_mode):
         if not check_mode:
-            self.client.delete(_path(table, record["sys_id"], api_path=self.client.api_path))
+            self.client.delete(_path(self.client.api_path, table, record["sys_id"]))
 
 
 def find_user(table_client, user_id):

--- a/tests/unit/plugins/conftest.py
+++ b/tests/unit/plugins/conftest.py
@@ -27,7 +27,9 @@ from ansible_collections.servicenow.itsm.plugins.module_utils.problem import (
 
 @pytest.fixture
 def client(mocker):
-    return mocker.Mock(spec=Client)
+    return_client = mocker.Mock(spec=Client)
+    return_client.api_path = ("api", "now")
+    return return_client
 
 
 @pytest.fixture


### PR DESCRIPTION
##### SUMMARY
Adding functionality to add custom headers under instance parameter. This may be required if you are using API gateways intercepting API requests and then forwarding requests to the real endpoint.  
Adding functionality to add custom api path in case it differs from the usual "api/now" path. For example if API gateway needs this.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
adding instance->custom_headers and instance->api_path parameters. This affects arguments.py, client.py, table.py and attachment.py in plugins/module_utils folder.

##### ADDITIONAL INFORMATION
Example call for configuration item:
```
- hosts: localhost
  gather_facts: no
  tasks:
    - name: Get CI
      servicenow.itsm.configuration_item_info:
        instance:
          host: https://apigateway.example.com
          username: automation_user
          password: xyz
          custom_headers: { X-APIGW-APIKEY: xyz }
          api_path: "servicenow/v1/now"

        sys_class_name: cmdb_ci_server
        sysparm_query: "fqdn=myserver.exmple.com"
      register: result

    - name: debug
      debug:
        msg: "{{ result }}"
```
