### PR TITLE
Fixed two examples

### DIFF
--- a/plugins/modules/api_info.py
+++ b/plugins/modules/api_info.py
@@ -97,7 +97,7 @@ EXAMPLES = """
   servicenow.itsm.api_info:
     resource: incident
     sysparm_query: numberSTARTSWITHINC^ORnumberSTARTSWITHABC^state!=7^stateBETWEEN1@4^short_descriptionISNOTEMPTY
-    display_value: true
+    display_value: "true"
     exclude_reference_link: true
     columns:
       - state

--- a/plugins/modules/problem_task.py
+++ b/plugins/modules/problem_task.py
@@ -143,7 +143,7 @@ EXAMPLES = r"""
 
     state: closed
     number: PTASK0010005
-    close_code:
+    close_code: canceled
     close_notes: Closed
 
 - name: Delete problem task


### PR DESCRIPTION
##### SUMMARY
api_info:
Attribute display_value: true was implicitly casted to bool and back to str resulting in value sent to API beeing "True" instead of "true".

problem_task:
Close code was missing.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
api_info,  problem_task
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
