### PR TITLE
Search for standard changes within custom template tables

### DIFF
--- a/plugins/module_utils/table.py
+++ b/plugins/module_utils/table.py
@@ -105,9 +105,9 @@ def find_assignment_group(table_client, assignment_id):
     )
 
 
-def find_standard_change_template(table_client, template_name):
+def find_standard_change_template(table_client, template_name, template_table):
     return table_client.get_record(
-        "std_change_producer_version",
+        template_table,
         dict(name=template_name),
         must_exist=True,
     )

--- a/plugins/modules/change_request.py
+++ b/plugins/modules/change_request.py
@@ -352,7 +352,7 @@ def build_payload(module, table_client):
 
     if module.params["template"]:
         standard_change_template = table.find_standard_change_template(
-            table_client, module.params["template"]
+            table_client, module.params["template"], module.params["template_table"]
         )
         payload["std_change_producer_version"] = standard_change_template["sys_id"]
 
@@ -383,6 +383,10 @@ def main():
         ),
         template=dict(
             type="str",
+        ),
+        template_table=dict(
+            type="str",
+            default="std_change_producer_version",
         ),
         requested_by=dict(
             type="str",


### PR DESCRIPTION
##### SUMMARY
Enable the ability to search for standard changes within custom tables, instead of being limited to finding templates solely in the 'std_change_producer_version' table.

##### ISSUE TYPE
- Feature Idea

##### COMPONENT NAME
servicenow.itsm.change_request

##### ADDITIONAL INFORMATION
In my scenario, the standard change I'm searching for is stored in a custom table, which makes it difficult to locate the corresponding template. To address this, I suggest implementing an optional parameter called 'template_table' in the 'find_standard_change()' function. This parameter would allow users to specify a custom table for searching the standard change. To ensure backward compatibility, the parameter could have a default value of 'std_change_producer_version'.

```Yaml
  - name: Create ServiceNow standard change
    servicenow.itsm.change_request:
      instance:
        host: "{{ servicenow_change_instance }}"
        username: "{{ servicenow_change_username }}"
        password: "{{ servicenow_change_password }}"
      type: standard
      state: new
      other:
        company: "{{ servicenow_change_company }}"
      template: "{{ servicenow_change_template }}"
      template_table: "{{ servicenow_change_template_table }}"      <-- New parameter with standard value
    register: snow_change_request

```
