### PR TITLE
Added option to pass OAuth2 access token

### DIFF
--- a/changelogs/fragments/client_access_token.yaml
+++ b/changelogs/fragments/client_access_token.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Added option to pass OAuth2 access token previously obtained from ServiceNow (https://github.com/ansible-collections/servicenow.itsm/pull/272).

--- a/plugins/doc_fragments/instance.py
+++ b/plugins/doc_fragments/instance.py
@@ -41,8 +41,11 @@ options:
         description:
           - Grant type used for OAuth authentication.
           - If not set, the value of the C(SN_GRANT_TYPE) environment variable will be used.
+          - Since version 2.3.0, it no longer has a default value in the argument
+            specifications.
+          - If not set by any means, the default value (i.e., I(password)) will be set
+            internally to preserve backwards compatibility.
         choices: [ 'password', 'refresh_token' ]
-        default: password
         type: str
         version_added: '1.1.0'
       client_id:
@@ -67,6 +70,13 @@ options:
           - Required when I(grant_type=refresh_token).
         type: str
         version_added: '1.1.0'
+      access_token:
+        description:
+          - Access token obtained via OAuth authentication.
+          - If not set, the value of the C(SN_ACCESS_TOKEN) environment
+            variable will be used.
+        type: str
+        version_added: '2.3.0'
       timeout:
         description:
           - Timeout in seconds for the connection with the ServiceNow instance.

--- a/plugins/doc_fragments/instance.py
+++ b/plugins/doc_fragments/instance.py
@@ -43,7 +43,7 @@ options:
           - If not set, the value of the C(SN_GRANT_TYPE) environment variable will be used.
           - Since version 2.3.0, it no longer has a default value in the argument
             specifications.
-          - If not set by any means, the default value (i.e., I(password)) will be set
+          - If not set by any means, the default value (that is, I(password)) will be set
             internally to preserve backwards compatibility.
         choices: [ 'password', 'refresh_token' ]
         type: str

--- a/plugins/module_utils/arguments.py
+++ b/plugins/module_utils/arguments.py
@@ -94,7 +94,6 @@ SHARED_SPECS = dict(
             grant_type=dict(
                 type="str",
                 choices=["password", "refresh_token"],
-                default="password",
                 fallback=(env_fallback, ["SN_GRANT_TYPE"]),
             ),
             client_id=dict(
@@ -111,6 +110,11 @@ SHARED_SPECS = dict(
                 no_log=True,
                 fallback=(env_fallback, ["SN_REFRESH_TOKEN"]),
             ),
+            access_token=dict(
+                type="str",
+                no_log=True,
+                fallback=(env_fallback, ["SN_ACCESS_TOKEN"]),
+            ),
             timeout=dict(
                 type="float",
                 fallback=(env_fallback, ["SN_TIMEOUT"]),
@@ -121,8 +125,12 @@ SHARED_SPECS = dict(
             ),
         ),
         required_together=[("client_id", "client_secret"), ("username", "password")],
-        required_one_of=[("username", "refresh_token")],
-        mutually_exclusive=[("username", "refresh_token")],
+        required_one_of=[("username", "refresh_token", "access_token")],
+        mutually_exclusive=[
+            ("username", "refresh_token", "access_token"),
+            ("client_id", "access_token"),
+            ("grant_type", "access_token"),
+        ],
         required_if=[
             ("grant_type", "password", ("username", "password")),
             ("grant_type", "refresh_token", ("refresh_token",)),

--- a/tests/integration/targets/api_authentication/tasks/main.yml
+++ b/tests/integration/targets/api_authentication/tasks/main.yml
@@ -13,8 +13,13 @@
         that:
           - result is success
 
+    - name: Set incident number for faster testing
+      ansible.builtin.set_fact:
+        incident_number: ternary(result.records, result.records[0].number, "INC0000060")
+
     - name: Basic authentication failure with wrong password
       servicenow.itsm.incident_info:
+        number: "{{ incident_number }}"
       environment:
         SN_USERNAME: "{{ sn_username }}"
         SN_PASSWORD: bad-password
@@ -27,6 +32,7 @@
 
     - name: OAuth authentication success with password
       servicenow.itsm.incident_info:
+        number: "{{ incident_number }}"
       environment:
         SN_USERNAME: "{{ sn_username }}"
         SN_PASSWORD: "{{ sn_password }}"
@@ -39,6 +45,7 @@
 
     - name: OAuth authentication failure with bad client secret
       servicenow.itsm.incident_info:
+        number: "{{ incident_number }}"
       environment:
         SN_USERNAME: "{{ sn_username }}"
         SN_PASSWORD: "{{ sn_password }}"
@@ -53,6 +60,7 @@
 
     - name: OAuth authentication failure with bad password
       servicenow.itsm.incident_info:
+        number: "{{ incident_number }}"
       environment:
         SN_USERNAME: "{{ sn_username }}"
         SN_PASSWORD: bad-password
@@ -79,9 +87,11 @@
       register: result
     - ansible.builtin.set_fact:
         sn_refresh_token: "{{ result.json.refresh_token }}"
+        sn_access_token: "{{ result.json.access_token }}"  # To be used in the test with access_token
 
     - name: OAuth authentication success with refresh_token
       servicenow.itsm.incident_info:
+        number: "{{ incident_number }}"
       environment:
         SN_GRANT_TYPE: refresh_token
         SN_REFRESH_TOKEN: "{{ sn_refresh_token }}"
@@ -94,11 +104,34 @@
 
     - name: OAuth authentication failure with bad refresh token
       servicenow.itsm.incident_info:
+        number: "{{ incident_number }}"
       environment:
         SN_GRANT_TYPE: refresh_token
         SN_REFRESH_TOKEN: bad-token
         SN_CLIENT_ID: "{{ sn_client_id }}"
         SN_CLIENT_SECRET: "{{ sn_client_secret }}"
+      register: result
+      ignore_errors: true
+    - assert:
+        that:
+          - result is failed
+          - "'Failed to authenticate with the instance' in result.msg"
+
+    - name: Authentication success with access token obtained previously
+      servicenow.itsm.incident_info:
+        number: "{{ incident_number }}"
+      environment:
+        SN_ACCESS_TOKEN: "{{ sn_access_token }}"
+      register: result
+    - ansible.builtin.assert:
+        that:
+          - result is success
+
+    - name: Authentication failure with bad access token
+      servicenow.itsm.incident_info:
+        number: "{{ incident_number }}"
+      environment:
+        SN_ACCESS_TOKEN: bad-token
       register: result
       ignore_errors: true
     - assert:

--- a/tests/unit/plugins/module_utils/test_client.py
+++ b/tests/unit/plugins/module_utils/test_client.py
@@ -105,6 +105,29 @@ class TestClientAuthHeader:
 
         assert c.auth_header == {"Authorization": "Bearer token"}
 
+    def test_oauth_refresh_token(self, mocker):
+        resp_mock = mocker.MagicMock()
+        resp_mock.status = 200  # Used when testing on Python 3
+        resp_mock.getcode.return_value = 200  # Used when testing on Python 2
+        resp_mock.read.return_value = '{"access_token": "token"}'
+
+        request_mock = mocker.patch.object(client, "Request").return_value
+        request_mock.open.return_value = resp_mock
+
+        c = client.Client(
+            "https://instance.com",
+            refresh_token="refresh_token",
+            grant_type="refresh_token",
+            client_id="id",
+            client_secret="secret",
+        )
+
+        assert c.refresh_token == "refresh_token"
+        assert c.grant_type == "refresh_token"
+        assert c.client_id == "id"
+        assert c.client_secret == "secret"
+        assert c.auth_header == {"Authorization": "Bearer token"}
+
     def test_oauth_failure(self, mocker):
         request_mock = mocker.patch.object(client, "Request").return_value
         request_mock.open.side_effect = HTTPError(
@@ -141,6 +164,22 @@ class TestClientAuthHeader:
         c.auth_header
 
         assert request_mock.open.call_count == 1
+
+    def test_login_username_password(self, mocker):
+        mocker.patch.object(client, "Request")
+        c = client.Client("https://instance.com", username="user", password="pass")
+
+        assert c.grant_type == "password"
+        assert c.username == "user"
+        assert c.password == "pass"
+        assert c.auth_header == {"Authorization": b"Basic dXNlcjpwYXNz"}  # user:pass
+
+    def test_login_access_token(self, mocker):
+        mocker.patch.object(client, "Request")
+        c = client.Client("https://instance.com", access_token="token")
+
+        assert c.access_token == "token"
+        assert c.auth_header == {"Authorization": "Bearer token"}
 
 
 class TestClientRequest:
@@ -487,7 +526,10 @@ class TestClientValidateCerts:
         module = create_module(
             params=dict(
                 instance=dict(
-                    host="https://my.host.name", username="user", password="pass", validate_certs=value,
+                    host="https://my.host.name",
+                    username="user",
+                    password="pass",
+                    validate_certs=value,
                 ),
             )
         )


### PR DESCRIPTION
##### SUMMARY
Added option to pass OAuth2 access token for authentication, previously obtained from ServiceNow.

Closes #255.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

Modifies:
- `plugins/doc_fragments/instance.py`
- `plugins/module_utils/arguments.py`
- `plugins/module_utils/client.py`
- `tests/integration/targets/api_authentication/tasks/main.yml`
- `tests/unit/plugins/module_utils/test_client.py`

##### ADDITIONAL INFORMATION
Previously, `grant_type` has had the default value `password` in the argument specification. This PR removes the default option from the argument specification, but maintains backwards compatibility by setting the default value internally.
```
