### PR TITLE
Update servicenow.itsm.incident_info_module.rst

### DIFF
--- a/docs/servicenow.itsm.incident_info_module.rst
+++ b/docs/servicenow.itsm.incident_info_module.rst
@@ -353,7 +353,7 @@ Parameters
                 </td>
                 <td>
                         <div>Provides a set of operators for use with filters, condition builders, and encoded queries.</div>
-                        <div>The data type of a field determines what operators are available for it. Refer to the ServiceNow Available Filters Queries documentation at <a href='https://docs.servicenow.com/bundle/quebec-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html'>https://docs.servicenow.com/bundle/quebec-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html</a>.</div>
+                        <div>The data type of a field determines what operators are available for it. Refer to the ServiceNow Available Filters Queries documentation at <a href='https://docs.servicenow.com/bundle/vancouver-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html'>https://docs.servicenow.com/bundle/vancouver-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html</a>.</div>
                         <div>Mutually exclusive with <code>sysparm_query</code>.</div>
                 </td>
             </tr>
@@ -407,7 +407,7 @@ Parameters
                 </td>
                 <td>
                         <div>An encoded query string used to filter the results as an alternative to <code>query</code>.</div>
-                        <div>Refer to the ServiceNow Available Filters Queries documentation at <a href='https://docs.servicenow.com/bundle/quebec-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html'>https://docs.servicenow.com/bundle/quebec-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html</a>.</div>
+                        <div>Refer to the ServiceNow Available Filters Queries documentation at <a href='https://docs.servicenow.com/bundle/vancouver-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html'>https://docs.servicenow.com/bundle/vancouver-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html</a>.</div>
                         <div>If not set, the value of the <code>SN_SYSPARM_QUERY</code> environment, if specified.</div>
                         <div>Mutually exclusive with <code>query</code>.</div>
                 </td>


### PR DESCRIPTION
Corrected 2 urls that were wrong.  Version name in the url was quebec when it should have been vancouver.

##### SUMMARY
Corrected 2 urls that were pointing to the same page.  The url includes the version name and it was quebec (old version?).  Current version is Vancouver and updating the url takes you to the correct page.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
servicenow.itsm.incident_info_module.rst

##### ADDITIONAL INFORMATION

```
