### PR TITLE
Add missing env to docs for sysparm_query

### DIFF
--- a/changelogs/fragments/now_env_sysparm_query.yml
+++ b/changelogs/fragments/now_env_sysparm_query.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - now - added missing SN_SYSPARM_QUERY environment variable (https://github.com/ansible-collections/servicenow.itsm/issues/293).

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -25,7 +25,6 @@ description:
 version_added: 1.0.0
 extends_documentation_fragment:
   - ansible.builtin.constructed
-  - servicenow.itsm.query
 notes:
   - Query feature and constructed groups were added in version 1.2.0.
 options:
@@ -124,6 +123,26 @@ options:
     description:
       - The column to use for inventory hostnames.
     default: name
+  query:
+    description:
+      - Provides a set of operators for use with filters, condition builders, and encoded queries.
+      - The data type of a field determines what operators are available for it.
+        Refer to the ServiceNow Available Filters Queries documentation at
+        U(https://docs.servicenow.com/bundle/tokyo-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html).
+      - Mutually exclusive with C(sysparm_query).
+    type: list
+    elements: dict
+  sysparm_query:
+    description:
+      - An encoded query string used to filter the results as an alternative to C(query).
+      - Refer to the ServiceNow Available Filters Queries documentation at
+        U(https://docs.servicenow.com/bundle/tokyo-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html).
+      - If not set, the value of the C(SN_SYSPARM_QUERY) environment, if specified.
+      - Mutually exclusive with C(query).
+    type: str
+    env:
+      - name: SN_SYSPARM_QUERY
+    version_added: 2.0.0
 """
 
 EXAMPLES = r"""


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes: #293 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
SN_SYSPARM_QUERY env variable is not picked up by e.g. inventory plugin now.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
