### PR TITLE
incident: allow incident_mapping for close_code

### DIFF
--- a/changelogs/fragments/cclose_code.yml
+++ b/changelogs/fragments/cclose_code.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - incident - allow incident_mapping for close_code parameter.

--- a/plugins/doc_fragments/incident_mapping.py
+++ b/plugins/doc_fragments/incident_mapping.py
@@ -36,4 +36,10 @@ options:
         description:
           - The extent to which resolution of an incident can bear delay.
         type: dict
+      close_code:
+        description:
+          - Provide information on how the incident was resolved.
+          - Required if I(state) value is C(closed).
+          - This option is introduce in 2.4.0.
+        type: dict
 """

--- a/plugins/module_utils/arguments.py
+++ b/plugins/module_utils/arguments.py
@@ -17,6 +17,7 @@ INCIDENT_MAPPING_SPEC = dict(
         hold_reason=dict(type="dict"),
         impact=dict(type="dict"),
         urgency=dict(type="dict"),
+        close_code=dict(type="dict"),
     ),
 )
 

--- a/plugins/module_utils/incident.py
+++ b/plugins/module_utils/incident.py
@@ -26,4 +26,14 @@ PAYLOAD_FIELDS_MAPPING = dict(
         ("4", "awaiting_vendor"),
         ("5", "awaiting_change"),
     ],
+    close_code=[
+        ("1", "Solved Remotely (Permanently)"),
+        ("2", "Solved (Work Around)"),
+        ("3", "Solved (Permanently)"),
+        ("4", "Solved Remotely (Work Around)"),
+        ("5", "Solved Remotely (Permanently)"),
+        ("6", "Not Solved (Not Reproducible)"),
+        ("7", "Not Solved (Too Costly)"),
+        ("8", "Closed/Resolved by Caller"),
+    ],
 )

--- a/plugins/modules/incident.py
+++ b/plugins/modules/incident.py
@@ -78,10 +78,12 @@ options:
   close_code:
     description:
       - Provide information on how the incident was resolved.
-    choices: [ Solved (Work Around), Solved (Permanently),
-               Solved Remotely (Work Around), Solved Remotely (Permanently),
-               Not Solved (Not Reproducible), Not Solved (Too Costly),
-               Closed/Resolved by Caller ]
+      - Default choices are C(Solved (Work Around)), C(Solved (Permanently)),
+        C(Solved Remotely (Work Around)), C(Solved Remotely (Permanently)),
+        C(Not Solved (Not Reproducible)), C(Not Solved (Too Costly)),
+        C(Closed/Resolved by Caller).
+        One can override them by setting I(incident_mapping.close_code).
+      - Choices for I(close_code) removed in 2.4.0.
     type: str
   close_notes:
     description:
@@ -311,15 +313,6 @@ def main():
         ),
         close_code=dict(
             type="str",
-            choices=[
-                "Solved (Work Around)",
-                "Solved (Permanently)",
-                "Solved Remotely (Work Around)",
-                "Solved Remotely (Permanently)",
-                "Not Solved (Not Reproducible)",
-                "Not Solved (Too Costly)",
-                "Closed/Resolved by Caller",
-            ],
         ),
         close_notes=dict(
             type="str",

--- a/tests/integration/targets/incident/tasks/main.yml
+++ b/tests/integration/targets/incident/tasks/main.yml
@@ -129,6 +129,19 @@
           - "'close_code' in result.msg"
           - "'close_notes' in result.msg"
 
+    - name: Update incident choices
+      servicenow.itsm.api:
+        resource: sys_choice
+        action: post
+        data:
+          name: incident
+          element: close_code
+          value: 1
+          label: Solved Remotely (Permanently)
+      register: incident_choices
+
+    - set_fact:
+        solved_remotely_choice: "{{ incident_choices.record.sys_id }}"
 
     - name: Update incident state - check mode
       servicenow.itsm.incident: &update-incident-state
@@ -298,3 +311,9 @@
     - ansible.builtin.assert:
         that:
           - result.records[0].short_description != ""
+
+    - name: Delete incident choices
+      servicenow.itsm.api:
+        resource: sys_choice
+        action: delete
+        sys_id: "{{ solved_remotely_choice }}"

--- a/tests/integration/targets/incident_with_mapping/tasks/main.yml
+++ b/tests/integration/targets/incident_with_mapping/tasks/main.yml
@@ -27,7 +27,11 @@
           3: "awaiting_problem"
           4: "awaiting_vendor"
           5: "awaiting_change"
-
+      incident_with_close_code:
+        state:
+          6: "resolved"
+        close_code:
+          1: "Solved Remotely (Permanently)"
 
   block:
     - name: Retrieve all incidents
@@ -162,10 +166,23 @@
           - "'close_code' in result.msg"
           - "'close_notes' in result.msg"
 
+    - name: Update incident choices
+      servicenow.itsm.api:
+        resource: sys_choice
+        action: post
+        data:
+          name: incident
+          element: close_code
+          value: 1
+          label: Solved Remotely (Permanently)
+      register: incident_choices
+
+    - set_fact:
+        solved_remotely_choice: "{{ incident_choices.record.sys_id }}"
 
     - name: Update incident state - check mode
       servicenow.itsm.incident: &update-incident-state
-        incident_mapping: "{{ mapping.incident }}"
+        incident_mapping: "{{ mapping.incident_with_close_code }}"
         caller: admin
         number: "{{ test_result.record.number }}"
         state: resolved
@@ -190,7 +207,7 @@
 
     - name: Get specific incident info by sysparm query
       servicenow.itsm.incident_info:
-        incident_mapping: "{{ mapping.incident }}"
+        incident_mapping: "{{ mapping.incident_with_close_code }}"
         query:
          - caller: = admin
            number: = {{ test_result.record.number }}
@@ -342,3 +359,9 @@
     - ansible.builtin.assert:
         that:
           - result.records[0].short_description != ""
+
+    - name: Delete incident choices
+      servicenow.itsm.api:
+        resource: sys_choice
+        action: delete
+        sys_id: "{{ solved_remotely_choice }}"


### PR DESCRIPTION
##### SUMMARY

* Removed hardcoding of parameter choices in close_code
* Allow incident_mapping for close_code so user can provide
  custom choices.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


