### PR TITLE
Fix change_request and change_request_task int tests

### DIFF
--- a/tests/integration/targets/change_request/tasks/main.yml
+++ b/tests/integration/targets/change_request/tasks/main.yml
@@ -4,16 +4,6 @@
     SN_PASSWORD: "{{ sn_password }}"
 
   block:
-    - name: Retrieve all change_requests
-      servicenow.itsm.change_request_info:
-      register: result
-
-    - ansible.builtin.assert:
-        that:
-          - result.records != []
-          - result.records | length != 0
-
-
     - name: Create test change_request - check mode
       servicenow.itsm.change_request: &create-change_request
         requested_by: admin
@@ -23,6 +13,7 @@
         priority: low
         risk: low
         impact: low
+        short_description: some short description
         attachments:
           - path: targets/change_request/res/sample_file.txt
       check_mode: true
@@ -324,6 +315,66 @@
         that:
           - result is not changed
 
+    - name: Test bad parameter combinator (number + query)
+      servicenow.itsm.change_request_info:
+        number: "{{ test_result.record.number }}"
+        query:
+         - short_description: LIKE Oracle
+      ignore_errors: true
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'parameters are mutually exclusive: number|query' in result.msg"
+
+
+    - name: Test invalid operator detection
+      servicenow.itsm.change_request_info:
+        query:
+         - short_description: LIKEE Oracle
+      ignore_errors: true
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'Invalid condition' in result.msg"
+
+
+    - name: Get change_request info by sysparm query - short_description
+      servicenow.itsm.change_request_info:
+        query:
+         - short_description: LIKE some
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - "'some' in result.records[0].short_description"
+
+
+    - name: Test unary operator with argument detection
+      servicenow.itsm.change_request_info:
+        query:
+         - short_description: ISEMPTY SAP
+      ignore_errors: true
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'Operator ISEMPTY does not take any arguments' in result.msg"
+
+
+    - name: Test sysparm query unary operator - short_description
+      servicenow.itsm.change_request_info:
+        query:
+         - short_description: ISNOTEMPTY
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result.records[0].short_description != ""
 
     - name: Delete change_request - check mode
       servicenow.itsm.change_request: &delete-change_request
@@ -363,63 +414,3 @@
           - result is not changed
 
 
-    - name: Test bad parameter combinator (number + query)
-      servicenow.itsm.change_request_info:
-        number: "{{ test_result.record.number }}"
-        query:
-         - short_description: LIKE Oracle
-      ignore_errors: true
-      register: result
-
-    - ansible.builtin.assert:
-        that:
-          - result is failed
-          - "'parameters are mutually exclusive: number|query' in result.msg"
-
-
-    - name: Test invalid operator detection
-      servicenow.itsm.change_request_info:
-        query:
-         - short_description: LIKEE Oracle
-      ignore_errors: true
-      register: result
-
-    - ansible.builtin.assert:
-        that:
-          - result is failed
-          - "'Invalid condition' in result.msg"
-
-
-    - name: Get change_request info by sysparm query - short_description
-      servicenow.itsm.change_request_info:
-        query:
-         - short_description: LIKE Oracle
-      register: result
-
-    - ansible.builtin.assert:
-        that:
-          - "'Oracle' in result.records[0].short_description"
-
-
-    - name: Test unary operator with argument detection
-      servicenow.itsm.change_request_info:
-        query:
-         - short_description: ISEMPTY SAP
-      ignore_errors: true
-      register: result
-
-    - ansible.builtin.assert:
-        that:
-          - result is failed
-          - "'Operator ISEMPTY does not take any arguments' in result.msg"
-
-
-    - name: Test sysparm query unary operator - short_description
-      servicenow.itsm.change_request_info:
-        query:
-         - short_description: ISNOTEMPTY
-      register: result
-
-    - ansible.builtin.assert:
-        that:
-          - result.records[0].short_description != ""

--- a/tests/integration/targets/change_request/tasks/main.yml
+++ b/tests/integration/targets/change_request/tasks/main.yml
@@ -412,5 +412,3 @@
     - ansible.builtin.assert:
         that:
           - result is not changed
-
-

--- a/tests/integration/targets/change_request_task/tasks/main.yml
+++ b/tests/integration/targets/change_request_task/tasks/main.yml
@@ -4,18 +4,8 @@
     SN_PASSWORD: "{{ sn_password }}"
 
   block:
-    - name: Retrieve all entries in the change_task table
-      servicenow.itsm.change_request_task_info:
-      register: result
-
-    - ansible.builtin.assert:
-        that:
-          - result.records != []
-          - result.records | length != 0
-
-
-    - name: Create test change_request for refferencing in change tasks
-      servicenow.itsm.change_request:
+    - name: Create test change_request for referencing in change tasks
+      servicenow.itsm.change_request: 
         requested_by: admin
         state: new
         type: standard
@@ -342,14 +332,39 @@
     - name: Get change_request_task info by sysparm query - short_description
       servicenow.itsm.change_request_task_info:
         query:
-          - short_description: LIKE Oracle
+          - short_description: LIKE Implement
       register: result
 
     - ansible.builtin.assert:
         that:
-          - "'Oracle' in result.records[0].short_description"
+          - "'Implement collision' in result.records[0].short_description"
+
+    - name: Test bad parameter combinator (number + query)
+      servicenow.itsm.change_request_task_info:
+        number: "{{ test_result.record.number }}"
+        query:
+         - short_description: LIKE Oracle
+      ignore_errors: true
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'parameters are mutually exclusive: number|query' in result.msg"
 
 
+    - name: Test invalid operator detection
+      servicenow.itsm.change_request_task_info:
+        query:
+         - short_description: LIKEE Oracle
+      ignore_errors: true
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'Invalid condition' in result.msg"
+    
     - name: Delete change_request_task - check mode
       servicenow.itsm.change_request_task: &delete-change_request_task
         number: "{{ test_result.record.number }}"
@@ -387,28 +402,12 @@
           - result is not changed
 
 
-    - name: Test bad parameter combinator (number + query)
-      servicenow.itsm.change_request_task_info:
-        number: "{{ test_result.record.number }}"
-        query:
-         - short_description: LIKE Oracle
-      ignore_errors: true
+    - name: Delete change_request used for testing 
+      servicenow.itsm.change_request:
+        number: "{{ change_request_result.record.number }}"
+        state: absent
       register: result
 
-    - ansible.builtin.assert:
+    - ansible.builtin.assert: 
         that:
-          - result is failed
-          - "'parameters are mutually exclusive: number|query' in result.msg"
-
-
-    - name: Test invalid operator detection
-      servicenow.itsm.change_request_task_info:
-        query:
-         - short_description: LIKEE Oracle
-      ignore_errors: true
-      register: result
-
-    - ansible.builtin.assert:
-        that:
-          - result is failed
-          - "'Invalid condition' in result.msg"
+          - result is changed


### PR DESCRIPTION
This PR fixes change_request and change_request_task integration tests on **Utah**.
Changes:
- makes the tests independent of the state of the db. Initially, the tests assumed some _change_requests_ exist already in db.
- clean up the resources created for the tests

##### SUMMARY
Fixes _change_request_ and _change_request_task_ integration tests.
The tests had been executed on **Utah** release.

##### ISSUE TYPE
- Bugfix Pull Request
