### PR TITLE
Fix incident and incident_with_mapping integration tests

### DIFF
--- a/tests/integration/targets/incident/tasks/main.yml
+++ b/tests/integration/targets/incident/tasks/main.yml
@@ -4,14 +4,6 @@
     SN_PASSWORD: "{{ sn_password }}"
 
   block:
-    - name: Retrieve all incidents
-      servicenow.itsm.incident_info:
-      register: result
-
-    - ansible.builtin.assert:
-        that:
-          - result.records != []
-
     - name: Create test incident - check mode
       servicenow.itsm.incident: &create-incident
         caller: admin
@@ -137,7 +129,7 @@
           name: incident
           element: close_code
           value: 1
-          label: Solved Remotely (Permanently)
+          label: Resolved by problem
       register: incident_choices
 
     - set_fact:
@@ -148,7 +140,7 @@
         caller: admin
         number: "{{ test_result.record.number }}"
         state: resolved
-        close_code: Solved Remotely (Permanently)
+        close_code: Resolved by problem
         close_notes: Done testing
       check_mode: true
       register: result
@@ -157,7 +149,7 @@
         that:
           - result is changed
           - result.record.state == "resolved"
-          - result.record.close_code == "Solved Remotely (Permanently)"
+          - result.record.close_code == "Resolved by problem"
           - result.record.close_notes == "Done testing"
 
 
@@ -173,7 +165,7 @@
          - caller: = admin
            number: = {{ test_result.record.number }}
            state: = resolved
-           close_code: = Solved Remotely (Permanently)
+           close_code: = Resolved by problem
            close_notes: = Done testing
       register: result
 
@@ -183,7 +175,7 @@
           - result.records[0].caller_id != ""
           - result.records[0].number == test_result.record.number
           - result.records[0].state == "resolved"
-          - result.records[0].close_code == "Solved Remotely (Permanently)"
+          - result.records[0].close_code == "Resolved by problem"
           - result.records[0].close_notes == "Done testing"
 
 
@@ -196,7 +188,7 @@
         that:
           - result.records[0].number == test_result.record.number
           - result.records[0].state == "resolved"
-          - result.records[0].close_code == "Solved Remotely (Permanently)"
+          - result.records[0].close_code == "Resolved by problem"
           - result.records[0].close_notes == "Done testing"
 
 
@@ -220,35 +212,6 @@
     - ansible.builtin.assert:
         that:
           - result is not changed
-
-
-    - name: Delete incident - check mode
-      servicenow.itsm.incident: &delete-incident
-        caller: admin
-        number: "{{ test_result.record.number }}"
-        state: absent
-      check_mode: true
-      register: result
-
-    - ansible.builtin.assert: &delete-incident-result
-        that:
-          - result is changed
-
-
-    - name: Delete incident
-      servicenow.itsm.incident: *delete-incident
-
-    - ansible.builtin.assert: *delete-incident-result
-
-
-    - name: Make sure incident is absent
-      servicenow.itsm.incident_info:
-        number: "{{ test_result.record.number }}"
-      register: result
-
-    - ansible.builtin.assert:
-        that:
-          - result.records | length == 0
 
 
     - name: Test bad parameter combinator (number + query)
@@ -281,12 +244,12 @@
     - name: Get incident info by sysparm query - short_description
       servicenow.itsm.incident_info:
         query:
-         - short_description: LIKE SAP
+         - short_description: LIKE Test
       register: result
 
     - ansible.builtin.assert:
         that:
-          - "'SAP' in result.records[0].short_description"
+          - "'Test' in result.records[0].short_description"
 
 
     - name: Test unary operator with argument detection
@@ -312,8 +275,40 @@
         that:
           - result.records[0].short_description != ""
 
+
     - name: Delete incident choices
       servicenow.itsm.api:
         resource: sys_choice
         action: delete
         sys_id: "{{ solved_remotely_choice }}"
+    
+
+    - name: Delete incident - check mode
+      servicenow.itsm.incident: &delete-incident
+        caller: admin
+        number: "{{ test_result.record.number }}"
+        state: absent
+      check_mode: true
+      register: result
+
+    - ansible.builtin.assert: &delete-incident-result
+        that:
+          - result is changed
+
+
+    - name: Delete incident
+      servicenow.itsm.incident: *delete-incident
+
+    - ansible.builtin.assert: *delete-incident-result
+
+
+    - name: Make sure incident is absent
+      servicenow.itsm.incident_info:
+        number: "{{ test_result.record.number }}"
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result.records | length == 0
+
+

--- a/tests/integration/targets/incident_with_mapping/tasks/main.yml
+++ b/tests/integration/targets/incident_with_mapping/tasks/main.yml
@@ -34,15 +34,6 @@
           1: "Solved Remotely (Permanently)"
 
   block:
-    - name: Retrieve all incidents
-      servicenow.itsm.incident_info:
-        incident_mapping: "{{ mapping.incident }}"
-      register: result
-
-    - ansible.builtin.assert:
-        that:
-          - result.records != []
-
     - name: Create test incident - check mode
       servicenow.itsm.incident: &create-incident
         incident_mapping: "{{ mapping.incident }}"
@@ -263,37 +254,6 @@
           - result is not changed
 
 
-    - name: Delete incident - check mode
-      servicenow.itsm.incident: &delete-incident
-        incident_mapping: "{{ mapping.incident }}"
-        caller: admin
-        number: "{{ test_result.record.number }}"
-        state: absent
-      check_mode: true
-      register: result
-
-    - ansible.builtin.assert: &delete-incident-result
-        that:
-          - result is changed
-
-
-    - name: Delete incident
-      servicenow.itsm.incident: *delete-incident
-
-    - ansible.builtin.assert: *delete-incident-result
-
-
-    - name: Make sure incident is absent
-      servicenow.itsm.incident_info:
-        incident_mapping: "{{ mapping.incident }}"
-        number: "{{ test_result.record.number }}"
-      register: result
-
-    - ansible.builtin.assert:
-        that:
-          - result.records | length == 0
-
-
     - name: Test bad parameter combinator (number + query)
       servicenow.itsm.incident_info:
         incident_mapping: "{{ mapping.incident }}"
@@ -327,12 +287,12 @@
       servicenow.itsm.incident_info:
         incident_mapping: "{{ mapping.incident }}"
         query:
-         - short_description: LIKE SAP
+         - short_description: LIKE Test
       register: result
 
     - ansible.builtin.assert:
         that:
-          - "'SAP' in result.records[0].short_description"
+          - "'Test' in result.records[0].short_description"
 
 
     - name: Test unary operator with argument detection
@@ -365,3 +325,35 @@
         resource: sys_choice
         action: delete
         sys_id: "{{ solved_remotely_choice }}"
+
+
+    - name: Delete incident - check mode
+      servicenow.itsm.incident: &delete-incident
+        incident_mapping: "{{ mapping.incident }}"
+        caller: admin
+        number: "{{ test_result.record.number }}"
+        state: absent
+      check_mode: true
+      register: result
+
+    - ansible.builtin.assert: &delete-incident-result
+        that:
+          - result is changed
+
+
+    - name: Delete incident
+      servicenow.itsm.incident: *delete-incident
+
+    - ansible.builtin.assert: *delete-incident-result
+
+
+    - name: Make sure incident is absent
+      servicenow.itsm.incident_info:
+        incident_mapping: "{{ mapping.incident }}"
+        number: "{{ test_result.record.number }}"
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result.records | length == 0
+


### PR DESCRIPTION
This PR fixes the incident and incident_with_mapping integration tests.

On **Utah** version the close code seems to be different so this fix takes that into account.
Other changes:
- remove any incident created during test
- remove the first test which is listing the db. it assumes the db is not empty which in test environments is not always the case. Nerverless the functionality is tested elsewhere.

##### ISSUE TYPE
- Bugfix Pull Request
