### PR TITLE
Update ServiceNow docs URL

### DIFF
--- a/plugins/doc_fragments/change_request_mapping.py
+++ b/plugins/doc_fragments/change_request_mapping.py
@@ -43,7 +43,7 @@ options:
             that check is not performed there.
           - For more information on state model and transition,
             refer to the ServiceNow documentation at
-            U(https://docs.servicenow.com/bundle/paris-it-service-management/page/product/change-management/concept/c_ChangeStateModel.html)
+            U(https://docs.servicenow.com/bundle/tokyo-it-service-management/page/product/change-management/concept/c_ChangeStateModel.html)
           - Special value that can not be overridden is C(absent), which would remove a change request from ServiceNow.
         type: dict
 """

--- a/plugins/doc_fragments/query.py
+++ b/plugins/doc_fragments/query.py
@@ -16,7 +16,7 @@ options:
       - Provides a set of operators for use with filters, condition builders, and encoded queries.
       - The data type of a field determines what operators are available for it.
         Refer to the ServiceNow Available Filters Queries documentation at
-        U(https://docs.servicenow.com/bundle/quebec-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html).
+        U(https://docs.servicenow.com/bundle/tokyo-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html).
       - Mutually exclusive with C(sysparm_query).
     type: list
     elements: dict
@@ -24,7 +24,7 @@ options:
     description:
       - An encoded query string used to filter the results as an alternative to C(query).
       - Refer to the ServiceNow Available Filters Queries documentation at
-        U(https://docs.servicenow.com/bundle/quebec-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html).
+        U(https://docs.servicenow.com/bundle/tokyo-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html).
       - If not set, the value of the C(SN_SYSPARM_QUERY) environment, if specified.
       - Mutually exclusive with C(query).
     type: str

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -281,7 +281,7 @@ compose:
 #   }
 #   return cis;
 # }
-# Other examples in https://docs.servicenow.com/bundle/utah-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html
+# Other examples in https://docs.servicenow.com/bundle/tokyo-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html
 plugin: servicenow.itsm.now
 table: cmdb_ci_server
 query:

--- a/plugins/module_utils/query.py
+++ b/plugins/module_utils/query.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-# https://docs.servicenow.com/bundle/quebec-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html
+# https://docs.servicenow.com/bundle/tokyo-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html
 OPERATORS_STRING = set(
     (
         "STARTSWITH",

--- a/plugins/module_utils/relations.py
+++ b/plugins/module_utils/relations.py
@@ -12,7 +12,7 @@ import re
 REL_TABLE = "cmdb_rel_ci"
 # sysparm_fields to be used when querying REL_TABLE. Uses dot-walking
 # notation to extract fields from linked tables in a single REST API call.
-# https://docs.servicenow.com/bundle/rome-application-development/page/integrate/inbound-rest/concept/c_RESTAPI.html#d1168970e439
+# https://docs.servicenow.com/bundle/tokyo-application-development/page/integrate/inbound-rest/concept/c_RESTAPI.html
 REL_FIELDS = set(
     (
         "sys_id",

--- a/plugins/modules/api.py
+++ b/plugins/modules/api.py
@@ -19,7 +19,7 @@ short_description: Manage ServiceNow POST, PATCH and DELETE requests
 description:
   - Create, delete or update a ServiceNow record from the given resource.
   - For more information, refer to the ServiceNow REST Table API documentation at
-    U(https://docs.servicenow.com/bundle/sandiego-application-development/page/integrate/inbound-rest/concept/c_TableAPI.html).
+    U(https://docs.servicenow.com/bundle/tokyo-application-development/page/integrate/inbound-rest/concept/c_RESTAPI.html).
 version_added: 2.0.0
 seealso:
   - module: servicenow.itsm.api_info

--- a/plugins/modules/api_info.py
+++ b/plugins/modules/api_info.py
@@ -18,7 +18,7 @@ short_description: Manage ServiceNow GET requests
 description:
   - Retrieve records via ServiceNow REST Table API for an arbitrary table.
   - For more information, refer to the ServiceNow REST Table API documentation at
-    U(https://docs.servicenow.com/bundle/sandiego-application-development/page/integrate/inbound-rest/concept/c_TableAPI.html).
+    U(https://docs.servicenow.com/bundle/tokyo-application-development/page/integrate/inbound-rest/concept/c_RESTAPI.html).
 version_added: 2.0.0
 extends_documentation_fragment:
   - servicenow.itsm.instance
@@ -35,8 +35,8 @@ options:
     description:
       - An encoded query string used to filter the results.
       - List of all possible operators and a guide on how to map them to form a query may be found at
-        U(https://docs.servicenow.com/en-US/bundle/sandiego-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html).
-        and U(https://developer.servicenow.com/dev.do#!/reference/api/sandiego/rest/c_TableAPI) under 'sysparm_query'.
+        U(https://docs.servicenow.com/bundle/tokyo-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html).
+        and U(https://developer.servicenow.com/dev.do#!/reference/api/tokyo/rest/c_TableAPI) under 'sysparm_query'.
     type: str
   display_value:
     description:

--- a/plugins/modules/change_request.py
+++ b/plugins/modules/change_request.py
@@ -23,7 +23,7 @@ short_description: Manage ServiceNow change requests
 description:
   - Create, delete or update a ServiceNow change request.
   - For more information, refer to the ServiceNow change management documentation at
-    U(https://docs.servicenow.com/bundle/paris-it-service-management/page/product/change-management/concept/c_ITILChangeManagement.html).
+    U(https://docs.servicenow.com/bundle/tokyo-it-service-management/page/product/change-management/concept/c_ITILChangeManagement.html).
 version_added: 1.0.0
 extends_documentation_fragment:
   - servicenow.itsm.instance
@@ -43,7 +43,7 @@ options:
         I(assignment_group) parameter must be filled in.
       - For more information on state model and transition,
         refere to the ServiceNow documentation at
-        U(https://docs.servicenow.com/bundle/paris-it-service-management/page/product/change-management/concept/c_ChangeStateModel.html)
+        U(https://docs.servicenow.com/bundle/tokyo-it-service-management/page/product/change-management/concept/c_ChangeStateModel.html)
       - Default choices are C(new), C(assess), C(authorize), C(scheduled), C(implement), C(review), C(closed), C(canceled), C(absent).
         One can override them by setting I(change_request_mapping.state).
     type: str
@@ -56,7 +56,7 @@ options:
     description:
       - Predefined template name for standard change request.
       - For more information on templates refer to ServiceNow documentation at
-        U(https://docs.servicenow.com/bundle/quebec-it-service-management/page/product/change-management/concept/c_StandardChangeCatalogPlugin.html)
+        U(https://docs.servicenow.com/bundle/tokyo-it-service-management/page/product/change-management/concept/c_StandardChangeCatalogPlugin.html)
         or find template names on <your_service_id>.service-now.com/nav_to.do?uri=%2Fstd_change_producer_version_list.do%3F
     type: str
   requested_by:
@@ -137,7 +137,7 @@ options:
       - Optional remaining parameters.
       - For more information on optional parameters, refer to the ServiceNow
         change request documentation at
-        U(https://docs.servicenow.com/bundle/paris-it-service-management/page/product/change-management/task/t_CreateAChange.html).
+        U(https://docs.servicenow.com/bundle/tokyo-it-service-management/page/product/change-management/task/t_CreateAChange.html).
     type: dict
 """
 

--- a/plugins/modules/change_request_info.py
+++ b/plugins/modules/change_request_info.py
@@ -22,7 +22,7 @@ short_description: List ServiceNow change requests
 description:
   - Retrieve information about ServiceNow change requests.
   - For more information, refer to the ServiceNow change management documentation at
-    U(https://docs.servicenow.com/bundle/paris-it-service-management/page/product/change-management/concept/c_ITILChangeManagement.html).
+    U(https://docs.servicenow.com/bundle/tokyo-it-service-management/page/product/change-management/concept/c_ITILChangeManagement.html).
 version_added: 1.0.0
 extends_documentation_fragment:
   - servicenow.itsm.instance

--- a/plugins/modules/change_request_task.py
+++ b/plugins/modules/change_request_task.py
@@ -22,7 +22,7 @@ short_description: Manage ServiceNow change request tasks
 description:
   - Create, delete or update a ServiceNow change request tasks.
   - For more information, refer to the ServiceNow change management documentation at
-    U(https://docs.servicenow.com/bundle/paris-it-service-management/page/product/change-management/concept/c_ITILChangeManagement.html).
+    U(https://docs.servicenow.com/bundle/tokyo-it-service-management/page/product/change-management/concept/c_ITILChangeManagement.html).
 version_added: 1.3.0
 extends_documentation_fragment:
   - servicenow.itsm.instance
@@ -128,7 +128,7 @@ options:
       - Optional remaining parameters.
       - For more information on optional parameters, refer to the ServiceNow
         change task documentation at
-        U(https://docs.servicenow.com/bundle/paris-it-service-management/page/product/change-management/task/create-a-change-task.html).
+        U(https://docs.servicenow.com/bundle/tokyo-it-service-management/page/product/change-management/task/create-a-change-task.html).
     type: dict
 """
 

--- a/plugins/modules/change_request_task_info.py
+++ b/plugins/modules/change_request_task_info.py
@@ -20,7 +20,7 @@ short_description: List ServiceNow change request tasks
 description:
   - Retrieve information about ServiceNow change request tasks.
   - For more information, refer to the ServiceNow change management documentation at
-    U(https://docs.servicenow.com/bundle/paris-it-service-management/page/product/change-management/concept/c_ITILChangeManagement.html).
+    U(https://docs.servicenow.com/bundle/tokyo-it-service-management/page/product/change-management/concept/c_ITILChangeManagement.html).
 version_added: 1.3.0
 extends_documentation_fragment:
   - servicenow.itsm.instance

--- a/plugins/modules/configuration_item.py
+++ b/plugins/modules/configuration_item.py
@@ -59,7 +59,7 @@ options:
       - The value of this parameter should point to a ServiceNow CMDB configuration
         item table, for instance C(cmdb_ci_server).
       - For a list of valid CMDB tables, refer to ServiceNow documentation on
-        U(https://docs.servicenow.com/bundle/paris-servicenow-platform/page/product/configuration-management/reference/cmdb-tables-details.html).
+        U(https://docs.servicenow.com/bundle/tokyo-servicenow-platform/page/product/configuration-management/reference/cmdb-tables-details.html).
       - If this parameter is unset when a new configuration item needs to be created,
         the default value C(cmdb_ci) will be used.
     type: str
@@ -67,7 +67,7 @@ options:
     description:
       - Asset tag of the asset logically related to this configuration item.
       - Read more about the relationship between configuration items and assets at
-        U(https://docs.servicenow.com/bundle/paris-it-asset-management/page/product/asset-management/concept/c_ManagingAssets.html).
+        U(https://docs.servicenow.com/bundle/tokyo-it-asset-management/page/product/asset-management/concept/c_ManagingAssets.html).
     type: str
   install_status:
     description:
@@ -115,7 +115,7 @@ options:
     description:
       - Any of the remaining configuration parameters.
       - For the attributes of the base C(cmdb_ci) table, refer to the ServiceNow documentation on
-        U(https://docs.servicenow.com/bundle/paris-servicenow-platform/page/product/configuration-management/reference/cmdb-table-property-descriptions.html).
+        U(https://docs.servicenow.com/bundle/tokyo-servicenow-platform/page/product/configuration-management/reference/cmdb-table-property-descriptions.html).
       - For the attributes of configuration items specific to I(sys_class_name),
         please consult the relevant ServiceNow documentation.
     type: dict

--- a/plugins/modules/configuration_item_batch.py
+++ b/plugins/modules/configuration_item_batch.py
@@ -22,7 +22,7 @@ short_description: Manage ServiceNow configuration items in batch mode
 description:
   - Create, update ServiceNow configuration items in batch mode.
   - For more information, refer to the ServiceNow configuration management documentation at
-    U(https://docs.servicenow.com/bundle/paris-servicenow-platform/page/product/configuration-management/reference/cmdb-table-property-descriptions.html).
+    U(https://docs.servicenow.com/bundle/tokyo-servicenow-platform/page/product/configuration-management/reference/cmdb-table-property-descriptions.html).
 version_added: 1.2.0
 extends_documentation_fragment:
   - servicenow.itsm.instance

--- a/plugins/modules/configuration_item_info.py
+++ b/plugins/modules/configuration_item_info.py
@@ -25,7 +25,7 @@ short_description: List ServiceNow configuration item
 description:
   - Retrieve information about ServiceNow configuration item.
   - For more information, refer to the ServiceNow configuration item management documentation at
-    U(https://docs.servicenow.com/bundle/quebec-servicenow-platform/page/product/configuration-management/concept/c_ITILConfigurationManagement.html).
+    U(https://docs.servicenow.com/bundle/tokyo-servicenow-platform/page/product/configuration-management/concept/c_ITILConfigurationManagement.html).
 version_added: 1.0.0
 extends_documentation_fragment:
   - servicenow.itsm.instance
@@ -49,7 +49,7 @@ options:
       - The value of this parameter should point to a ServiceNow CMDB configuration
         item table, for instance C(cmdb_ci_server).
       - For a list of valid CMDB tables, refer to ServiceNow documentation on
-        U(https://docs.servicenow.com/bundle/paris-servicenow-platform/page/product/configuration-management/reference/cmdb-tables-details.html).
+        U(https://docs.servicenow.com/bundle/tokyo-servicenow-platform/page/product/configuration-management/reference/cmdb-tables-details.html).
       - If this parameter is unset when a configuration item info is queried,
         the default value C(cmdb_ci) will be used.
     type: str

--- a/plugins/modules/incident.py
+++ b/plugins/modules/incident.py
@@ -24,7 +24,7 @@ short_description: Manage ServiceNow incidents
 description:
   - Create, delete or update a ServiceNow incident.
   - For more information, refer to the ServiceNow incident management documentation at
-    U(https://docs.servicenow.com/bundle/paris-it-service-management/page/product/incident-management/concept/c_IncidentManagement.html).
+    U(https://docs.servicenow.com/bundle/tokyo-it-service-management/page/product/incident-management/concept/c_IncidentManagement.html).
 version_added: 1.0.0
 extends_documentation_fragment:
   - servicenow.itsm.instance
@@ -94,7 +94,7 @@ options:
       - Optional remaining parameters.
       - For more information on optional parameters, refer to the ServiceNow
         create incident documentation at
-        U(https://docs.servicenow.com/bundle/paris-it-service-management/page/product/incident-management/task/create-an-incident.html).
+        U(https://docs.servicenow.com/bundle/tokyo-it-service-management/page/product/incident-management/task/create-an-incident.html).
     type: dict
 """
 

--- a/plugins/modules/incident_info.py
+++ b/plugins/modules/incident_info.py
@@ -21,7 +21,7 @@ short_description: List ServiceNow incidents
 description:
   - Retrieve information about ServiceNow incidents.
   - For more information, refer to the ServiceNow incident management documentation at
-    U(https://docs.servicenow.com/bundle/paris-it-service-management/page/product/incident-management/concept/c_IncidentManagement.html).
+    U(https://docs.servicenow.com/bundle/tokyo-it-service-management/page/product/incident-management/concept/c_IncidentManagement.html).
 version_added: 1.0.0
 extends_documentation_fragment:
   - servicenow.itsm.instance

--- a/plugins/modules/problem.py
+++ b/plugins/modules/problem.py
@@ -25,7 +25,7 @@ short_description: Manage ServiceNow problems
 description:
   - Create, delete or update a ServiceNow problem.
   - For more information, refer to the ServiceNow problem management documentation at
-    U(https://docs.servicenow.com/bundle/paris-it-service-management/page/product/problem-management/concept/c_ProblemManagement.html).
+    U(https://docs.servicenow.com/bundle/tokyo-it-service-management/page/product/problem-management/concept/c_ProblemManagement.html).
 version_added: 1.0.0
 extends_documentation_fragment:
   - servicenow.itsm.instance
@@ -112,7 +112,7 @@ options:
       - Optional remaining parameters.
       - For more information on optional parameters, refer to the ServiceNow
         documentation on creating problems at
-        U(https://docs.servicenow.com/bundle/paris-it-service-management/page/product/problem-management/task/create-a-problem-v2.html).
+        U(https://docs.servicenow.com/bundle/tokyo-it-service-management/page/product/problem-management/task/create-a-problem-v2.html).
     type: dict
   base_api_path:
     description:

--- a/plugins/modules/problem_info.py
+++ b/plugins/modules/problem_info.py
@@ -21,7 +21,7 @@ short_description: List ServiceNow problems
 description:
   - Retrieve information about ServiceNow problems.
   - For more information, refer to the ServiceNow problem management documentation at
-    U(https://docs.servicenow.com/bundle/paris-it-service-management/page/product/problem-management/concept/c_ProblemManagement.html).
+    U(https://docs.servicenow.com/bundle/tokyo-it-service-management/page/product/problem-management/concept/c_ProblemManagement.html).
 version_added: 1.0.0
 extends_documentation_fragment:
   - servicenow.itsm.instance

--- a/plugins/modules/problem_task.py
+++ b/plugins/modules/problem_task.py
@@ -23,7 +23,7 @@ short_description: Manage ServiceNow problem tasks
 description:
   - Create, delete or update ServiceNow problem tasks.
   - For more information, refer to the ServiceNow problem management documentation at
-    U(https://docs.servicenow.com/bundle/paris-it-service-management/page/product/problem-management/concept/c_ProblemManagement.html).
+    U(https://docs.servicenow.com/bundle/tokyo-it-service-management/page/product/problem-management/concept/c_ProblemManagement.html).
 
 version_added: 1.3.0
 
@@ -104,7 +104,7 @@ options:
       - Optional remaining parameters.
       - For more information on optional parameters, refer to the ServiceNow
         create problem task documentation at
-        U(https://docs.servicenow.com/bundle/quebec-it-service-management/page/product/problem-management/task/create-problem-task.html).
+        U(https://docs.servicenow.com/bundle/tokyo-it-service-management/page/product/problem-management/task/create-problem-task.html).
     type: dict
 """
 

--- a/plugins/modules/problem_task_info.py
+++ b/plugins/modules/problem_task_info.py
@@ -20,7 +20,7 @@ short_description: List ServiceNow problem tasks
 description:
   - Retrieve information about ServiceNow problem tasks.
   - For more information, refer to the ServiceNow problem management documentation at
-    U(https://docs.servicenow.com/bundle/paris-it-service-management/page/product/problem-management/concept/c_ProblemManagement.html).
+    U(https://docs.servicenow.com/bundle/tokyo-it-service-management/page/product/problem-management/concept/c_ProblemManagement.html).
 version_added: 1.3.0
 extends_documentation_fragment:
   - servicenow.itsm.instance


### PR DESCRIPTION
##### SUMMARY

* Change all the ServiceNow docs URL to point to 'tokyo' release.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE

- Docs Pull Request

