### PR TITLE
Fix 'KeyError' exception when trying to get by sys_id non existent record

### DIFF
--- a/changelogs/fragments/table_client.yml
+++ b/changelogs/fragments/table_client.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - table_client - Fix 'KeyError' exception when fetching records by sys_id and add `must_have` arguments (https://github.com/ansible-collections/servicenow.itsm/pull/306)

--- a/plugins/module_utils/table.py
+++ b/plugins/module_utils/table.py
@@ -66,9 +66,10 @@ class TableClient:
 
     def get_record_by_sys_id(self, table, sys_id):
         response = self.client.get(_path(self.client.api_path, table, sys_id))
-        record = response.json["result"]
+        if "result" in response.json:
+            return response.json["result"]
 
-        return record
+        return None
 
     def create_record(self, table, payload, check_mode, query=None):
         if check_mode:

--- a/plugins/module_utils/table.py
+++ b/plugins/module_utils/table.py
@@ -64,12 +64,16 @@ class TableClient:
 
         return records[0] if records else None
 
-    def get_record_by_sys_id(self, table, sys_id):
+    def get_record_by_sys_id(self, table, sys_id, must_exist=False):
         response = self.client.get(_path(self.client.api_path, table, sys_id))
-        if "result" in response.json:
-            return response.json["result"]
 
-        return None
+        record = response.json.get("result", None)
+        if must_exist and not record:
+            raise errors.ServiceNowError(
+                "No {0} records match the sys_id {1}.".format(table, sys_id)
+            )
+
+        return record
 
     def create_record(self, table, payload, check_mode, query=None):
         if check_mode:

--- a/tests/unit/plugins/module_utils/test_table.py
+++ b/tests/unit/plugins/module_utils/test_table.py
@@ -159,7 +159,7 @@ class TestTableGetRecordBySysId:
         )
         t = table.TableClient(client)
 
-        record = t.get_record_by_sys_id("my_table", "sys_id", True)
+        record = t.get_record_by_sys_id("my_table", "sys_id", must_exist=True)
 
         assert dict(a=3, b="sys_id") == record
         client.get.assert_called_with("api/now/table/my_table/sys_id")

--- a/tests/unit/plugins/module_utils/test_table.py
+++ b/tests/unit/plugins/module_utils/test_table.py
@@ -153,6 +153,37 @@ class TestTableGetRecordBySysId:
         assert dict(a=3, b="sys_id") == record
         client.get.assert_called_with("api/now/table/my_table/sys_id")
 
+    def test_get_record_by_sys_id_must_exists(self, client):
+        client.get.return_value = Response(
+            200, '{"result": {"a": 3, "b": "sys_id"}}', {"X-Total-Count": "1"}
+        )
+        t = table.TableClient(client)
+
+        record = t.get_record_by_sys_id("my_table", "sys_id", True)
+
+        assert dict(a=3, b="sys_id") == record
+        client.get.assert_called_with("api/now/table/my_table/sys_id")
+
+    def test_get_record_by_sys_id_no_record(self, client):
+        client.get.return_value = Response(
+            404, '{"error": {"message": "no record found"}}', {}
+        )
+        t = table.TableClient(client)
+
+        record = t.get_record_by_sys_id("my_table", "sys_id")
+
+        assert not record
+        client.get.assert_called_with("api/now/table/my_table/sys_id")
+
+    def test_get_record_by_sys_id_no_record_must_exists(self, client):
+        client.get.return_value = Response(
+            404, '{"error": {"message": "no record found"}}', {}
+        )
+        t = table.TableClient(client)
+
+        with pytest.raises(errors.ServiceNowError, match="No"):
+            t.get_record_by_sys_id("my_table", "sys_id", True)
+
 
 class TestTableCreateRecord:
     def test_normal_mode(self, client):

--- a/tests/unit/plugins/module_utils/test_table.py
+++ b/tests/unit/plugins/module_utils/test_table.py
@@ -182,7 +182,7 @@ class TestTableGetRecordBySysId:
         t = table.TableClient(client)
 
         with pytest.raises(errors.ServiceNowError, match="No"):
-            t.get_record_by_sys_id("my_table", "sys_id", True)
+            t.get_record_by_sys_id("my_table", "sys_id", must_exist=True)
 
 
 class TestTableCreateRecord:


### PR DESCRIPTION
When fetching records by sys_id that do not exist, the response body has no `results` key.

This PR adds a test for key existence before returning the content of results.

##### SUMMARY
Fixes expectation `KeyError` when record not found by `sys_id`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
table_client

##### ADDITIONAL INFORMATION
```
curl -s "https://$instance/api/now/table/incident/bad-sys-id" --header "Accept:application/json" --user "admin":$PASS | jq
{
  "error": {
    "message": "No Record found",
    "detail": "Record doesn't exist or ACL restricts the record retrieval"
  },
  "status": "failure"
}
```
