### PR TITLE
Replace `get_record` by `get_record_by_sys_id` for update and delete op in api module

### DIFF
--- a/changelogs/fragments/api.yml
+++ b/changelogs/fragments/api.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - use get_record_by_sys_id instead of get_record in methods update, delete

--- a/changelogs/fragments/api.yml
+++ b/changelogs/fragments/api.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - use get_record_by_sys_id instead of get_record in methods update, delete
+  - use get_record_by_sys_id instead of get_record in methods update, delete (https://github.com/ansible-collections/servicenow.itsm/pull/307).

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -68,7 +68,13 @@ def table_name(module):
 
 
 def get_query_by_sys_id(module):
+    """Deprecated in v2.4.0."""
     return dict(sys_id=module.params[FIELD_SYS_ID])
+
+
+def get_sys_id(module):
+    """Return the sys_id from module's parameters"""
+    return module.params[FIELD_SYS_ID]
 
 
 def field_present(module, field):

--- a/plugins/modules/api.py
+++ b/plugins/modules/api.py
@@ -275,14 +275,13 @@ from ..module_utils.api import (
     FIELD_SYS_ID,
     FIELD_TEMPLATE,
     field_present,
-    get_query_by_sys_id,
     table_name,
+    get_sys_id,
 )
 
 
 def update_resource(module, table_client):
-    query = get_query_by_sys_id(module)
-    record_old = table_client.get_record(table_name(module), query)
+    record_old = table_client.get_record_by_sys_id(table_name(module), get_sys_id(module))
     if record_old is None:
         return False, None, dict(before=None, after=None)
     record_new = table_client.update_record(
@@ -308,8 +307,7 @@ def create_resource(module, table_client):
 
 
 def delete_resource(module, table_client):
-    query = get_query_by_sys_id(module)
-    record = table_client.get_record(table_name(module), query)
+    record = table_client.get_record_by_sys_id(table_name(module), get_sys_id(module))
     if record is None:
         return False, None, dict(before=None, after=None)
     table_client.delete_record(table_name(module), record, module.check_mode)

--- a/plugins/modules/api.py
+++ b/plugins/modules/api.py
@@ -281,7 +281,9 @@ from ..module_utils.api import (
 
 
 def update_resource(module, table_client):
-    record_old = table_client.get_record_by_sys_id(table_name(module), get_sys_id(module))
+    record_old = table_client.get_record_by_sys_id(
+        table_name(module), get_sys_id(module)
+    )
     if record_old is None:
         return False, None, dict(before=None, after=None)
     record_new = table_client.update_record(

--- a/tests/unit/plugins/modules/test_api.py
+++ b/tests/unit/plugins/modules/test_api.py
@@ -43,7 +43,7 @@ class TestUpdateResource:
             )
         )
 
-        table_client.get_record.return_value = None
+        table_client.get_record_by_sys_id.return_value = None
 
         result = api.run(module, table_client)
 
@@ -60,7 +60,7 @@ class TestUpdateResource:
             )
         )
 
-        table_client.get_record.return_value = dict(
+        table_client.get_record_by_sys_id.return_value = dict(
             number="INC0000001",
             short_description="Test incident",
             impact="3",
@@ -230,7 +230,7 @@ class TestDeleteResource:
             )
         )
 
-        table_client.get_record.return_value = None
+        table_client.get_record_by_sys_id.return_value = None
 
         result = api.run(module, table_client)
 
@@ -246,7 +246,7 @@ class TestDeleteResource:
             )
         )
 
-        table_client.get_record.return_value = dict(
+        table_client.get_record_by_sys_id.return_value = dict(
             state="1",
             number="INC0000001",
             short_description="Test incident",


### PR DESCRIPTION
##### SUMMARY
This PR replaces `get_record` call with `get_record_by_sys_id` in `update` and `delete` methods of `api` module.
This change will allow the `api` module to call other APIs than `Table API`. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
api module

##### ADDITIONAL INFORMATION
Follow up to #306 