### PR TITLE
Add generic client

### DIFF
--- a/changelogs/fragments/api.yml
+++ b/changelogs/fragments/api.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - api - allow `api` module to make request outside `Table API` namespace(https://github.com/ansible-collections/servicenow.itsm/pull/314).
+

--- a/changelogs/fragments/api.yml
+++ b/changelogs/fragments/api.yml
@@ -1,4 +1,3 @@
 ---
 minor_changes:
   - api - allow `api` module to make request outside `Table API` namespace(https://github.com/ansible-collections/servicenow.itsm/pull/314).
-

--- a/changelogs/fragments/api_info.yml
+++ b/changelogs/fragments/api_info.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - api_info - allow `api_info` module to make request outside `Table API` namespace(https://github.com/ansible-collections/servicenow.itsm/pull/314).

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -32,6 +32,7 @@ FIELD_DATA = "data"
 FIELD_TEMPLATE = "template"
 FIELD_DATA_RENDERED = "data_rendered"
 FIELD_QUERY_PARAMS = "query_params"
+FIELD_ATTRIBUTES_NAME = "attributes"
 
 POSSIBLE_FILTER_PARAMETERS = [
     FIELD_QUERY_NAME,
@@ -79,3 +80,12 @@ def get_sys_id(module):
 
 def field_present(module, field):
     return field in module.params and module.params[field]
+
+
+def get_parent_url(api_path, parent_sys_id):
+    """
+    Returns the parent url from a subresource api path
+    """
+    if api_path.find(parent_sys_id) == -1:
+        return api_path
+    return api_path.split(parent_sys_id)[0]

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -64,8 +64,16 @@ def transform_query_to_servicenow_query(query):
 def table_name(module):
     """
     In api.py and api_info.py the table's name is always going to be stored in module's resource
+    Deprecated in v.2.5.0
     """
     return module.params["resource"]
+
+
+def resource_name(module):
+    """
+    Return either the api_path or the table name from modules's parameters
+    """
+    return module.params["resource"] or module.params["api_path"]
 
 
 def get_query_by_sys_id(module):

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -88,12 +88,3 @@ def get_sys_id(module):
 
 def field_present(module, field):
     return field in module.params and module.params[field]
-
-
-def get_parent_url(api_path, parent_sys_id):
-    """
-    Returns the parent url from a subresource api path
-    """
-    if api_path.find(parent_sys_id) == -1:
-        return api_path
-    return api_path.split(parent_sys_id)[0]

--- a/plugins/module_utils/client.py
+++ b/plugins/module_utils/client.py
@@ -192,7 +192,7 @@ class Client:
 
     def post(self, path, data, query=None):
         resp = self.request("POST", path, data=data, query=query)
-        if resp.status == 201:
+        if resp.status in (200, 201):
             return resp
         raise UnexpectedAPIResponse(resp.status, resp.data)
 

--- a/plugins/module_utils/generic.py
+++ b/plugins/module_utils/generic.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2024, Red Hat
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from . import snow
+from ..module_utils.api import FIELD_SYS_ID, FIELD_ATTRIBUTES_NAME
+
+
+class GenericClient(snow.SNowClient):
+    def __init__(self, client, batch_size=1000):
+        super(GenericClient, self).__init__(client, batch_size)
+
+    def list_records(self, api_path, query=None):
+        """
+        List records from api_path.
+        The method is retreiving all the records by making multiple GET requests to server.
+
+        api_path    -- full path (ex: "api/now/cmdb/instance/cmdb_ci_linux_server"
+        query       -- query in SNow format
+        """
+        return self.list(api_path, query)
+
+    def get_record(self, api_path, query, must_exist=False):
+        """
+        Return a record matched by the query.
+
+        api_path    -- full path (ex: "api/now/cmdb/instance/cmdb_ci_linux_server")
+        query       -- query in SNow format
+        must_exist  -- if true the method throws an expection if the records does not exists.
+                       Returns None else.
+        """
+
+        return self.get(api_path, query, must_exist)
+
+    def get_record_by_sys_id(self, api_path, sys_id):
+        """
+        Return a record by sys_id
+
+        api_path    -- full path without the sys_id (ex: "api/now/cmdb/instance/cmdb_ci_linux_server")
+        sys_id      -- id of the record
+        """
+        response = self.client.get("/".join((api_path.rstrip("/"), sys_id)))
+        if "result" in response.json:
+            return response.json["result"]
+
+        return None
+
+    def create_record(self, api_path, payload, check_mode, query=None):
+        """
+        Create a record
+
+        api_path    -- full path (ex: "api/now/cmdb/instance/cmdb_ci_linux_server")
+        payload     -- record's data as a dict
+        query       -- query in SNow format
+        check_mode  -- set to true if check_mode is activated
+        """
+        if check_mode:
+            # Approximate the result using the payload.
+            return payload
+        return self.create(api_path, payload, query)
+
+    def update_record(self, api_path, record, payload, check_mode, query=None):
+        """
+        Update a record
+
+        api_path    -- full path (ex: "api/now/cmdb/instance/cmdb_ci_linux_server")
+        payload     -- updated record's data
+        query       -- query in SNow format
+        check_mode  -- set to true if check_mode is activated
+        """
+        if check_mode:
+            # Approximate the result by manually patching the existing state.
+            return dict(record, **payload)
+        return self.update(api_path, self.get_sys_id(record), payload, query)
+
+    def delete_record(self, api_path, record, check_mode):
+        """
+        Remove the record
+
+        api_path -- full path (ex: "api/now/cmdb/instance/cmdb_ci_linux_server")
+        record: -- record's data
+        query -- query in SNow format
+        check_mode -- bool
+        """
+        if not check_mode:
+            return self.delete(api_path, self.get_sys_id(record))
+
+    def delete_record_by_sys_id(self, api_path, sys_id):
+        """
+        Remove the record by sys_id
+
+        api_path -- full path (ex: "api/now/cmdb/instance/cmdb_ci_linux_server")
+        record: -- record's data
+        query -- query in SNow format
+        check_mode -- bool
+        """
+        return self.delete(api_path, sys_id)
+
+    def get_sys_id(self, record):
+        """
+        Returns the sys_id from the record.
+
+        Different services has differnt record structure, so we need to take into
+        account all the different records.
+        """
+        if FIELD_SYS_ID in record:
+            sys_id = record.get(FIELD_SYS_ID)
+            if isinstance(sys_id, dict):
+                # records from Change Request API has FIELD_SYS_ID as dict
+                return FIELD_SYS_ID.get("value")
+            return record.get(FIELD_SYS_ID)
+
+        # cmdb record
+        if FIELD_ATTRIBUTES_NAME in record:
+            return record.get(FIELD_ATTRIBUTES_NAME).get(FIELD_SYS_ID)

--- a/plugins/module_utils/generic.py
+++ b/plugins/module_utils/generic.py
@@ -105,7 +105,7 @@ class GenericClient(snow.SNowClient):
         """
         Returns the sys_id from the record.
 
-        Different services has differnt record structure, so we need to take into
+        Different services have different record structures, so we need to take into
         account all the different records.
         """
         if FIELD_SYS_ID in record:

--- a/plugins/module_utils/snow.py
+++ b/plugins/module_utils/snow.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2024, Red Hat
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+from . import errors
+
+
+class SNowClient:
+    def __init__(self, client, batch_size=1000):
+        self.client = client
+        self.batch_size = batch_size
+
+    def list(self, api_path, query=None):
+        base_query = self._sanitize_query(query)
+        base_query["sysparm_limit"] = self.batch_size
+
+        offset = 0
+        total = 1  # Dummy value that ensures loop executes at least once
+        result = []
+
+        while offset < total:
+            response = self.client.get(
+                api_path,
+                query=dict(base_query, sysparm_offset=offset),
+            )
+
+            result.extend(response.json["result"])
+            # This is a header only for Table API.
+            # When using this client for generic api, the header is not present anymore
+            # and we need to find a new method to break from the loop
+            # It can be removed from Table API but for it's better to keep it for now.
+            if response.headers["x-total-count"]:
+                total = int(response.headers["x-total-count"])
+            else:
+                if len(response.json["result"]) == 0:
+                    break
+
+            offset += self.batch_size
+
+        return result
+
+    def get(self, api_path, query, must_exist=False):
+        records = self.list(api_path, query)
+
+        if len(records) > 1:
+            raise errors.ServiceNowError(
+                "{0} {1} records match the {2} query.".format(
+                    len(records), api_path, query
+                )
+            )
+
+        if must_exist and not records:
+            raise errors.ServiceNowError(
+                "No {0} records match the {1} query.".format(api_path, query)
+            )
+
+        return records[0] if records else None
+
+    def get_by_sys_id(self, api_path, sys_id, must_exist=False):
+        response = self.client.get("/".join([api_path.rstrip("/"), sys_id]))
+
+        record = response.json.get("result", None)
+        if must_exist and not record:
+            raise errors.ServiceNowError(
+                "No {0} records match the sys_id {1}.".format(api_path, sys_id)
+            )
+
+        return record
+
+    def create(self, api_path, payload, query=None):
+        return self.client.post(
+            api_path, payload, query=self._sanitize_query(query)
+        ).json["result"]
+
+    def update(self, api_path, sys_id, payload, query=None):
+        return self.client.patch(
+            "/".join((api_path.rstrip("/"), sys_id)),
+            payload,
+            query=self._sanitize_query(query),
+        ).json["result"]
+
+    def delete(self, api_path, sys_id):
+        self.client.delete("/".join((api_path.rstrip("/"), sys_id)))
+
+    def _sanitize_query(self, query):
+        query = query or dict()
+        query.setdefault("sysparm_exclude_reference_link", "true")
+        return query

--- a/plugins/modules/api.py
+++ b/plugins/modules/api.py
@@ -42,7 +42,7 @@ options:
     description:
       - The path of the service which a record is to be created, updated or deleted from.
       - Mutually exclusive with C(resource).
-      - Require one of C(resource) or C(api_path)
+      - Require one of C(resource) or C(api_path).
     type: str
   action:
     description: The action to perform.

--- a/plugins/modules/api.py
+++ b/plugins/modules/api.py
@@ -275,6 +275,7 @@ from ..module_utils.api import (
     FIELD_SYS_ID,
     FIELD_TEMPLATE,
     field_present,
+<<<<<<< Updated upstream
     table_name,
     get_sys_id,
 )
@@ -284,6 +285,16 @@ def update_resource(module, table_client):
     record_old = table_client.get_record_by_sys_id(
         table_name(module), get_sys_id(module)
     )
+=======
+    get_sys_id,
+    resource_name,
+    get_parent_url,
+)
+
+
+def update_resource(module, client):
+    record_old = client.get_record_by_sys_id(resource_name(module), get_sys_id(module))
+>>>>>>> Stashed changes
     if record_old is None:
         return False, None, dict(before=None, after=None)
     record_new = table_client.update_record(
@@ -308,11 +319,33 @@ def create_resource(module, table_client):
     return True, new, dict(before=None, after=new)
 
 
+<<<<<<< Updated upstream
 def delete_resource(module, table_client):
     record = table_client.get_record_by_sys_id(table_name(module), get_sys_id(module))
     if record is None:
         return False, None, dict(before=None, after=None)
     table_client.delete_record(table_name(module), record, module.check_mode)
+=======
+def delete_resource(module, client):
+    if field_present(module, "parent_sys_id"):
+        parent_sys_id = module.params["parent_sys_id"]
+        parent_record = client.get_record_by_sys_id(
+            get_parent_url(resource_name(module), parent_sys_id), parent_sys_id)
+        if parent_record is None:
+            return False, None, dict(before=None, after=None)
+
+        client.delete_record_by_sys_id(resource_name(module), get_sys_id(module))
+        # get the parent record again.
+        new_parent_record = client.get_record_by_sys_id(
+            get_parent_url(resource_name(module), parent_sys_id), parent_sys_id)
+        return True, new_parent_record, dict(before=parent_record, after=new_parent_record)
+
+    record = client.get_record_by_sys_id(resource_name(module), get_sys_id(module))
+    if record is None:
+        return False, None, dict(before=None, after=None)
+
+    client.delete_record(resource_name(module), record, module.check_mode)
+>>>>>>> Stashed changes
     return True, None, dict(before=record, after=None)
 
 
@@ -332,7 +365,13 @@ def main():
             "instance",
             "sys_id",  # necessary for deleting and patching a resource, not relevant if creating a resource
         ),
+<<<<<<< Updated upstream
         resource=dict(type="str", required=True),
+=======
+        resource=dict(type="str"),
+        api_path=dict(type="str"),
+        parent_sys_id=dict(type="str"),
+>>>>>>> Stashed changes
         action=dict(
             type="str",
             required=True,

--- a/plugins/modules/api_info.py
+++ b/plugins/modules/api_info.py
@@ -30,7 +30,7 @@ options:
     description:
       - The name of the table in which a record is to be created, updated or deleted from.
       - Mutually exclusive with C(api_path).
-      - Require one of C(resource) or C(api_path)
+      - Require one of C(resource) or C(api_path).
     type: str
   api_path:
     version_added: "2.5.0"

--- a/plugins/modules/api_info.py
+++ b/plugins/modules/api_info.py
@@ -37,7 +37,7 @@ options:
     description:
       - The path of the service which a record is to be created, updated or deleted from.
       - Mutually exclusive with C(resource).
-      - Require one of C(resource) or C(api_path)
+      - Require one of C(resource) or C(api_path).
     type: str
   sysparm_query:
     description:

--- a/plugins/modules/api_info.py
+++ b/plugins/modules/api_info.py
@@ -28,9 +28,17 @@ seealso:
 options:
   resource:
     description:
-      - The name of the table that we want to obtain records from.
+      - The name of the table in which a record is to be created, updated or deleted from.
+      - Mutually exclusive with C(api_path).
+      - Require one of C(resource) or C(api_path)
     type: str
-    required: true
+  api_path:
+    version_added: "2.5.0"
+    description:
+      - The path of the service which a record is to be created, updated or deleted from.
+      - Mutually exclusive with C(resource).
+      - Require one of C(resource) or C(api_path)
+    type: str
   sysparm_query:
     description:
       - An encoded query string used to filter the results.
@@ -106,6 +114,10 @@ EXAMPLES = """
     query_no_domain: true
     no_count: false
   register: result
+
+- name: Retreive all linux servers
+  servicenow.itsm.api_info:
+    api_path: api/now/cmdb/instance/cmdb_ci_linux_server
 """
 
 RETURN = r"""
@@ -208,34 +220,36 @@ records:
 
 from ansible.module_utils.basic import AnsibleModule
 
-from ..module_utils import arguments, client, errors, table, utils
+from ..module_utils import arguments, client, errors, table, utils, generic
 from ..module_utils.api import (
     FIELD_COLUMNS_NAME,
     POSSIBLE_FILTER_PARAMETERS,
-    table_name,
+    resource_name,
     transform_query_to_servicenow_query,
 )
 
 
-def run(module, table_client):
+def run(module, client):
     search_dict = dict(module.params)
     columns = ",".join([field.lower() for field in module.params[FIELD_COLUMNS_NAME]])
     search_dict.update(columns=columns)
     query = utils.filter_dict(search_dict, *POSSIBLE_FILTER_PARAMETERS)
     servicenow_query = transform_query_to_servicenow_query(query)
-    return table_client.list_records(table_name(module), servicenow_query)
+    return client.list_records(resource_name(module), servicenow_query)
 
 
 def main():
     arg_spec = dict(
         arguments.get_spec("instance", "sys_id"),
-        resource=dict(type="str", required=True),
+        resource=dict(type="str"),
+        api_path=dict(type="str"),
         sysparm_query=dict(type="str"),
         display_value=dict(
             type="str",
             choices=["true", "false", "all"],
             default="false",
-        ),  # Return field display values (true), actual values (false), or both (all) (default: false)
+            # Return field display values (true), actual values (false), or both (all) (default: false)
+        ),
         exclude_reference_link=dict(
             type="bool",
             default=False,  # to enforce False when this parameter is omitted from a playbook
@@ -259,12 +273,19 @@ def main():
     module = AnsibleModule(
         supports_check_mode=True,
         argument_spec=arg_spec,
+        mutually_exclusive=[("resource", "api_path")],
+        required_one_of=[("resource", "api_path")],
     )
 
     try:
         snow_client = client.Client(**module.params["instance"])
-        table_client = table.TableClient(snow_client)
-        records = run(module, table_client)
+
+        if module.params["api_path"]:
+            _client = generic.GenericClient(snow_client)
+        else:
+            _client = table.TableClient(snow_client)
+
+        records = run(module, _client)
         module.exit_json(changed=False, record=records)
     except errors.ServiceNowError as e:
         module.fail_json(msg=str(e))

--- a/tests/integration/targets/api_generic/tasks/main.yml
+++ b/tests/integration/targets/api_generic/tasks/main.yml
@@ -1,0 +1,106 @@
+---
+- environment:
+    SN_HOST: "{{ sn_host }}"
+    SN_USERNAME: "{{ sn_username }}"
+    SN_PASSWORD: "{{ sn_password }}"
+
+  block:
+    - name: Retreive all ci linux server cmdb
+      servicenow.itsm.api_info:
+        api_path: "api/now/cmdb/instance/cmdb_ci_linux_server"
+      register: initial
+
+    - name: Create test ci - check mode
+      servicenow.itsm.api: &cmdb-ci-create-data
+        api_path: "api/now/cmdb/instance/cmdb_ci_linux_server"
+        action: post
+        data:
+          attributes:
+            name: "linux99"
+            firewall_status: "intranet"
+          source: "ServiceNow"
+      register: server
+
+    - ansible.builtin.debug:
+        var: server
+
+    # - name: Create test ci
+    #   servicenow.itsm.api: *cmdb-ci-create-data
+    #   register: server
+
+    # - ansible.builtin.assert:
+    #     that:
+    #       - server is changed
+
+    # - name: Update test ci -- check mode
+    #   servicenow.itsm.api: &cmdb-ci-update-data
+    #     api_path: "api/now/cmdb/instance/cmdb_ci_linux_server"
+    #     action: patch
+    #     sys_id: "{{ server.record.attributes.sys_id }}"
+    #     data:
+    #       attributes:
+    #         cpu_name: "i5"
+    #       source: "ServiceNow"
+    #   register: updated_server
+    #   check_mode: true
+    # - ansible.builtin.assert: &update-server-assertion-data
+    #     that:
+    #       - updated_server is changed
+    #       - updated_server.record.attributes.cpu_name == 'i5'
+    
+    # - name: Update test ci 
+    #   servicenow.itsm.api: *cmdb-ci-update-data
+    #   register: first_server
+    # - ansible.builtin.assert: *update-server-assertion-data
+
+    # - name: Get relation type "Used by"
+    #   servicenow.itsm.api_info:
+    #     resource: cmdb_rel_type
+    #     sysparm_query: nameLIKEUsed
+    #   register: relations
+
+    # - name: Create another ci
+    #   servicenow.itsm.api: 
+    #     api_path: "api/now/cmdb/instance/cmdb_ci_linux_server"
+    #     action: post
+    #     data:
+    #       attributes:
+    #         name: "linux100"
+    #         firewall_status: "intranet"
+    #       source: "ServiceNow"
+    #   register: another_server
+
+    # - name: Create relation between first and second server
+    #   servicenow.itsm.api:
+    #     api_path: "{{ 'api/now/cmdb/instance/cmdb_ci_linux_server/' + first_server.record.attributes.sys_id + '/relation'}}"
+    #     action: post
+    #     data:
+    #       inbound_relations:
+    #         - target: "{{ another_server.record.attributes.sys_id }}"
+    #           type: "{{ relations.record[0].sys_id }}"
+    #   register: result
+
+    # - ansible.builtin.assert:
+    #     that:
+    #       - result.record.inbound_relations | length == 1
+
+    # - ansible.builtin.debug:
+    #     var: "{{ item }}"
+    #   loop:
+    #     -  first_server.record.attributes.sys_id
+    #     -  result.record.inbound_relations[0].sys_id
+
+    # - name: Remove relation
+    #   servicenow.itsm.api:
+    #     api_path: "{{ 'api/now/cmdb/instance/cmdb_ci_linux_server/' + first_server.record.attributes.sys_id + '/relation'}}"
+    #     parent_sys_id: "{{ first_server.record.attributes.sys_id }}"
+    #     sys_id: "{{ result.record.inbound_relations[0].sys_id }}"
+    #     action: delete
+    #   register: result
+
+    # - ansible.builtin.assert:
+    #     that:
+    #       - result.record.inbound_relations == []
+
+
+

--- a/tests/integration/targets/api_generic/tasks/main.yml
+++ b/tests/integration/targets/api_generic/tasks/main.yml
@@ -24,83 +24,68 @@
     - ansible.builtin.debug:
         var: server
 
-    # - name: Create test ci
-    #   servicenow.itsm.api: *cmdb-ci-create-data
-    #   register: server
+    - name: Create test ci
+      servicenow.itsm.api: *cmdb-ci-create-data
+      register: server
 
-    # - ansible.builtin.assert:
-    #     that:
-    #       - server is changed
+    - ansible.builtin.assert:
+        that:
+          - server is changed
 
-    # - name: Update test ci -- check mode
-    #   servicenow.itsm.api: &cmdb-ci-update-data
-    #     api_path: "api/now/cmdb/instance/cmdb_ci_linux_server"
-    #     action: patch
-    #     sys_id: "{{ server.record.attributes.sys_id }}"
-    #     data:
-    #       attributes:
-    #         cpu_name: "i5"
-    #       source: "ServiceNow"
-    #   register: updated_server
-    #   check_mode: true
-    # - ansible.builtin.assert: &update-server-assertion-data
-    #     that:
-    #       - updated_server is changed
-    #       - updated_server.record.attributes.cpu_name == 'i5'
+    - name: Update test ci -- check mode
+      servicenow.itsm.api: &cmdb-ci-update-data
+        api_path: "api/now/cmdb/instance/cmdb_ci_linux_server"
+        action: patch
+        sys_id: "{{ server.record.attributes.sys_id }}"
+        data:
+          attributes:
+            cpu_name: "i5"
+          source: "ServiceNow"
+      register: updated_server
+      check_mode: true
+    - ansible.builtin.assert: &update-server-assertion-data
+        that:
+          - updated_server is changed
+          - updated_server.record.attributes.cpu_name == 'i5'
     
-    # - name: Update test ci 
-    #   servicenow.itsm.api: *cmdb-ci-update-data
-    #   register: first_server
-    # - ansible.builtin.assert: *update-server-assertion-data
+    - name: Update test ci 
+      servicenow.itsm.api: *cmdb-ci-update-data
+      register: first_server
+    - ansible.builtin.assert: *update-server-assertion-data
 
-    # - name: Get relation type "Used by"
-    #   servicenow.itsm.api_info:
-    #     resource: cmdb_rel_type
-    #     sysparm_query: nameLIKEUsed
-    #   register: relations
+    - name: Get relation type "Used by"
+      servicenow.itsm.api_info:
+        resource: cmdb_rel_type
+        sysparm_query: nameLIKEUsed
+      register: relations
 
-    # - name: Create another ci
-    #   servicenow.itsm.api: 
-    #     api_path: "api/now/cmdb/instance/cmdb_ci_linux_server"
-    #     action: post
-    #     data:
-    #       attributes:
-    #         name: "linux100"
-    #         firewall_status: "intranet"
-    #       source: "ServiceNow"
-    #   register: another_server
+    - name: Create another ci
+      servicenow.itsm.api: 
+        api_path: "api/now/cmdb/instance/cmdb_ci_linux_server"
+        action: post
+        data:
+          attributes:
+            name: "linux100"
+            firewall_status: "intranet"
+          source: "ServiceNow"
+      register: another_server
 
-    # - name: Create relation between first and second server
-    #   servicenow.itsm.api:
-    #     api_path: "{{ 'api/now/cmdb/instance/cmdb_ci_linux_server/' + first_server.record.attributes.sys_id + '/relation'}}"
-    #     action: post
-    #     data:
-    #       inbound_relations:
-    #         - target: "{{ another_server.record.attributes.sys_id }}"
-    #           type: "{{ relations.record[0].sys_id }}"
-    #   register: result
+    - name: Create relation between first and second server
+      servicenow.itsm.api:
+        api_path: "{{ 'api/now/cmdb/instance/cmdb_ci_linux_server/' + first_server.record.attributes.sys_id + '/relation'}}"
+        action: post
+        data:
+          inbound_relations:
+            - target: "{{ another_server.record.attributes.sys_id }}"
+              type: "{{ relations.record[0].sys_id }}"
+      register: result
 
-    # - ansible.builtin.assert:
-    #     that:
-    #       - result.record.inbound_relations | length == 1
+    - ansible.builtin.assert:
+        that:
+          - result.record.inbound_relations | length == 1
 
-    # - ansible.builtin.debug:
-    #     var: "{{ item }}"
-    #   loop:
-    #     -  first_server.record.attributes.sys_id
-    #     -  result.record.inbound_relations[0].sys_id
-
-    # - name: Remove relation
-    #   servicenow.itsm.api:
-    #     api_path: "{{ 'api/now/cmdb/instance/cmdb_ci_linux_server/' + first_server.record.attributes.sys_id + '/relation'}}"
-    #     parent_sys_id: "{{ first_server.record.attributes.sys_id }}"
-    #     sys_id: "{{ result.record.inbound_relations[0].sys_id }}"
-    #     action: delete
-    #   register: result
-
-    # - ansible.builtin.assert:
-    #     that:
-    #       - result.record.inbound_relations == []
-
-
-
+    - ansible.builtin.debug:
+        var: "{{ item }}"
+      loop:
+        - first_server.record.attributes.sys_id
+        - result.record.inbound_relations[0].sys_id


### PR DESCRIPTION
This PR adds a new client that can access services outside "/table" namespace.

A new client, on top of the rest client, has been added to add the functionality of snow services. This is needed because the snow services don't have the same behavior.
For example, the `Table API` server puts the total items in the custom header `x-total-count` where others don't.

The high-level clients `TableClient` and `GenericClient` inherit this client.

A new field `api_path` is added in the modules `api` and `api_info` to choose between `TableClient` or `GenericClient`.
`api_path` is mutually exclusive with `resource` which refers to a table in `Table API`.

```
- name: Create test ci - check mode
  servicenow.itsm.api:
    api_path: "api/now/cmdb/instance/cmdb_ci_linux_server"
      action: post
      data:
        attributes:
          name: "linux99"
          firewall_status: "intranet"
        source: "ServiceNow"
```

##### SUMMARY
Fixes #247 #310

##### ISSUE TYPE
- Feature Pull Request