### PR TITLE
Allow passing a object_hook to rest client

### DIFF
--- a/changelogs/fragments/client_object_hook.yml
+++ b/changelogs/fragments/client_object_hook.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - client - allow user to pass a `object_hook` function to rest client for custom decoding of the json response(https://github.com/ansible-collections/servicenow.itsm/pull/316).


### PR DESCRIPTION
This commit allows the user to pass a `object_hook` function to client for custom decoding the json response from SNow.
It will be used to fix **Change Management API** response.

##### SUMMARY
Fixes #305 

##### ISSUE TYPE

- Bugfix Pull Request