### PR TITLE
Remove hard coding of choices of category in change_request

### DIFF
--- a/changelogs/fragments/change_request_category.yml
+++ b/changelogs/fragments/change_request_category.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - change_request - allow change_request_mapping for category parameter.

--- a/changelogs/fragments/change_request_category.yml
+++ b/changelogs/fragments/change_request_category.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - change_request - allow change_request_mapping for category parameter.
+  - change_request - allow change_request_mapping for category parameter (https://github.com/ansible-collections/servicenow.itsm/issues/266).

--- a/plugins/doc_fragments/change_request_mapping.py
+++ b/plugins/doc_fragments/change_request_mapping.py
@@ -46,4 +46,8 @@ options:
             U(https://docs.servicenow.com/bundle/tokyo-it-service-management/page/product/change-management/concept/c_ChangeStateModel.html)
           - Special value that can not be overridden is C(absent), which would remove a change request from ServiceNow.
         type: dict
+      category:
+        description:
+          - The category of the change request.
+        type: dict
 """

--- a/plugins/module_utils/arguments.py
+++ b/plugins/module_utils/arguments.py
@@ -30,6 +30,7 @@ CHANGE_REQUEST_MAPPING_SPEC = dict(
         impact=dict(type="dict"),
         urgency=dict(type="dict"),
         state=dict(type="dict"),
+        category=dict(type="dict"),
     ),
 )
 

--- a/plugins/module_utils/change_request.py
+++ b/plugins/module_utils/change_request.py
@@ -34,6 +34,5 @@ PAYLOAD_FIELDS_MAPPING = dict(
         ("8", "documentation"),
         ("9", "other"),
     ],
-
     on_hold=[("true", True), ("false", False)],
 )

--- a/plugins/module_utils/change_request.py
+++ b/plugins/module_utils/change_request.py
@@ -23,5 +23,17 @@ PAYLOAD_FIELDS_MAPPING = dict(
         ("3", "closed"),
         ("4", "canceled"),
     ],
+    category=[
+        ("1", "hardware"),
+        ("2", "software"),
+        ("3", "service"),
+        ("4", "system_software"),
+        ("5", "aplication_software"),
+        ("6", "network"),
+        ("7", "telecom"),
+        ("8", "documentation"),
+        ("9", "other"),
+    ],
+
     on_hold=[("true", True), ("false", False)],
 )

--- a/plugins/modules/change_request.py
+++ b/plugins/modules/change_request.py
@@ -84,6 +84,7 @@ options:
       - Default choices are C(hardware), C(software), C(service), C(system_software), C(aplication_software),
                C(network), C(telecom), C(documentation), C(other).
       - One can override them by setting I(change_request_mapping.category).
+      - Hard-coded choices for C(category) were removed in 2.5.0.
     type: str
   priority:
     description:

--- a/plugins/modules/change_request.py
+++ b/plugins/modules/change_request.py
@@ -81,10 +81,9 @@ options:
   category:
     description:
       - The category of the change request.
-      - Default choices are: C(hardware), C(software), C(service), C(system_software), C(aplication_software),
+      - Default choices are C(hardware), C(software), C(service), C(system_software), C(aplication_software),
                C(network), C(telecom), C(documentation), C(other).
-      - One can override them by setting C(change_request_mapping.category).
-      - Choices for C(category) removed in 2.5.0.
+      - One can override them by setting I(change_request_mapping.category).
     type: str
   priority:
     description:

--- a/plugins/modules/change_request.py
+++ b/plugins/modules/change_request.py
@@ -81,8 +81,10 @@ options:
   category:
     description:
       - The category of the change request.
-    choices: [ hardware, software, service, system_software, aplication_software,
-               network, telecom, documentation, other ]
+      - Default choices are: C(hardware), C(software), C(service), C(system_software), C(aplication_software),
+               C(network), C(telecom), C(documentation), C(other).
+      - One can override them by setting C(change_request_mapping.category).
+      - Choices for C(category) removed in 2.5.0.
     type: str
   priority:
     description:
@@ -405,17 +407,6 @@ def main():
         ),
         category=dict(
             type="str",
-            choices=[
-                "hardware",
-                "software",
-                "service",
-                "system_software",
-                "aplication_software",
-                "network",
-                "telecom",
-                "documentation",
-                "other",
-            ],
         ),
         priority=dict(
             type="str",

--- a/tests/integration/targets/change_request/tasks/main.yml
+++ b/tests/integration/targets/change_request/tasks/main.yml
@@ -481,3 +481,66 @@
         requested_by: admin
         number: "{{ result.records[0].number }}"
         state: absent
+
+
+    - name: Update category choices
+      servicenow.itsm.api:
+        resource: sys_choice
+        action: post
+        data:
+          name: change_request
+          element: category
+          value: 1
+          label: hardware
+      register: change_request_category
+
+    - set_fact:
+        solved_remotely_choice: "{{ change_request_category.record.sys_id }}"
+
+    - name: Create change_request 
+      servicenow.itsm.change_request:
+        requested_by: admin
+        state: new
+        type: standard
+        template: Clear BGP sessions on a Cisco router - 1
+        priority: low
+        risk: low
+        impact: low
+        short_description: some short description
+        category: Software
+      register: chg_request
+
+    - ansible.builtin.assert:
+        that:
+          - chg_request is changed
+          - chg_request.record.state == "new"
+          - chg_request.record.type == "standard"
+          - chg_request.record.priority == "low"
+          - chg_request.record.risk == "low"
+          - chg_request.record.impact == "low"
+          - chg_request.record.category == "Software"
+    
+    - name: Update change_request with new option
+      servicenow.itsm.change_request:
+        number: "{{ chg_request.record.number }}"
+        category: hardware
+    
+    - name: Get change_request 
+      servicenow.itsm.change_request_info:
+        number: "{{ chg_request.record.number }}"
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result.records[0].category == "hardware"
+    
+    - name: Delete change_request
+      servicenow.itsm.change_request:
+        sys_id: "{{ chg_request.record.sys_id }}"
+        state: absent
+    
+    - name: Delete change_request choices
+      servicenow.itsm.api:
+        resource: sys_choice
+        action: delete
+        sys_id: "{{ solved_remotely_choice }}"

--- a/tests/integration/targets/change_request_with_mapping/tasks/main.yml
+++ b/tests/integration/targets/change_request_with_mapping/tasks/main.yml
@@ -1,0 +1,94 @@
+- environment:
+    SN_HOST: "{{ sn_host }}"
+    SN_USERNAME: "{{ sn_username }}"
+    SN_PASSWORD: "{{ sn_password }}"
+
+  vars:
+    mapping:
+      change_request:
+        category:
+          1: "category 1"
+          2: "category 2"
+
+  block:
+    - name: Create first category
+      servicenow.itsm.api:
+        resource: sys_choice
+        action: post
+        data:
+          name: change_request
+          element: category
+          value: 1
+          label: category 1
+      register: first_category
+    
+    - set_fact:
+        first_category: "{{ first_category.record.sys_id }}"
+    
+    - name: Create second category
+      servicenow.itsm.api:
+        resource: sys_choice
+        action: post
+        data:
+          name: change_request
+          element: category
+          value: 2
+          label: category 2
+      register: second_category
+    
+    - set_fact:
+        second_category: "{{ second_category.record.sys_id }}"
+
+    - name: Create change_request 
+      servicenow.itsm.change_request:
+        change_request_mapping: "{{ mapping.change_request }}"
+        requested_by: admin
+        state: new
+        type: standard
+        template: Clear BGP sessions on a Cisco router - 1
+        priority: low
+        risk: low
+        impact: low
+        short_description: some short description
+        category: category 1
+      register: chg_request
+
+    - ansible.builtin.assert:
+        that:
+          - chg_request is changed
+          - chg_request.record.state == "new"
+          - chg_request.record.type == "standard"
+          - chg_request.record.priority == "low"
+          - chg_request.record.risk == "low"
+          - chg_request.record.impact == "low"
+          - chg_request.record.category == "category 1"
+    
+    - name: Update change_request with new category
+      servicenow.itsm.change_request:
+        change_request_mapping: "{{ mapping.change_request }}"
+        number: "{{ chg_request.record.number }}"
+        category: category 2
+    
+    - name: Get change_request 
+      servicenow.itsm.change_request_info:
+        change_request_mapping: "{{ mapping.change_request }}"
+        number: "{{ chg_request.record.number }}"
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result.records[0].category == "category 2"
+    
+    - name: Delete change_request
+      servicenow.itsm.change_request:
+        sys_id: "{{ chg_request.record.sys_id }}"
+        state: absent
+    
+    - name: Delete change_request choices
+      servicenow.itsm.api:
+        resource: sys_choice
+        action: delete
+        sys_id: "{{ item }}"
+      loop:
+        - first_category
+        - second_category

--- a/tests/integration/targets/inventory/files/reference_fields.now.yml
+++ b/tests/integration/targets/inventory/files/reference_fields.now.yml
@@ -11,5 +11,4 @@ compose:
   location_name: lookup('ansible.builtin.vars', 'location.name')
   street: lookup('ansible.builtin.vars', 'location.street')
 
-strict: false
-display_value: false
+strict: true

--- a/tests/integration/targets/inventory/files/reference_fields.now.yml
+++ b/tests/integration/targets/inventory/files/reference_fields.now.yml
@@ -11,4 +11,5 @@ compose:
   location_name: lookup('ansible.builtin.vars', 'location.name')
   street: lookup('ansible.builtin.vars', 'location.street')
 
-strict: true
+strict: false
+display_value: false


### PR DESCRIPTION
This PR removes the hard coding of choices of category and allows mapping for the category so user can provide custom values

##### SUMMARY
Fixes #266 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`change_request`