### PR TITLE
feature/no_dot_var - Replace "." in column name to "_"

### DIFF
--- a/changelogs/fragments/no_dot_var.yml
+++ b/changelogs/fragments/no_dot_var.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - replace "." in reference field colums to "_"
+  - plugins/inventory/now.py - replace "." in reference field column name to "_" in host variable

--- a/changelogs/fragments/no_dot_var.yml
+++ b/changelogs/fragments/no_dot_var.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - plugins/inventory/now.py - replace "." in reference field column name to "_" in host variable
+  - now.py - replace "." in reference field column name to "_" in host variable

--- a/changelogs/fragments/no_dot_var.yml
+++ b/changelogs/fragments/no_dot_var.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - replace "." in reference field colums to "_"

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -443,7 +443,7 @@ class InventoryModule(BaseInventoryPlugin, ConstructableWithLookup, Cacheable):
             )
 
         for k in columns:
-            self.inventory.set_variable(host, k.replace('.','_'), record[k])
+            self.inventory.set_variable(host, k.replace('.', '_'), record[k])
 
     def fill_constructed(
         self,

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -443,7 +443,7 @@ class InventoryModule(BaseInventoryPlugin, ConstructableWithLookup, Cacheable):
             )
 
         for k in columns:
-            self.inventory.set_variable(host, k.replace('.', '_'), record[k])
+            self.inventory.set_variable(host, k.replace(".", "_"), record[k])
 
     def fill_constructed(
         self,

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -443,7 +443,7 @@ class InventoryModule(BaseInventoryPlugin, ConstructableWithLookup, Cacheable):
             )
 
         for k in columns:
-            self.inventory.set_variable(host, k, record[k])
+            self.inventory.set_variable(host, k.replace('.','_'), record[k])
 
     def fill_constructed(
         self,

--- a/tests/integration/targets/inventory/files/no_dot_var.now.yml
+++ b/tests/integration/targets/inventory/files/no_dot_var.now.yml
@@ -1,0 +1,17 @@
+---
+plugin: servicenow.itsm.now
+table: cmdb_ci_server
+strict: false
+
+instance:
+  timeout: 1200
+
+columns:
+  - location.name
+  - support_group.name
+
+compose:
+  ansible_host: ip_address
+
+sysparm_query: nameSTARTSWITHmy-vm-
+...

--- a/tests/integration/targets/inventory/playbooks/no_dot_var.yml
+++ b/tests/integration/targets/inventory/playbooks/no_dot_var.yml
@@ -1,0 +1,44 @@
+---
+- name: Test sysparm_limit option
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - block:
+        - name: Create imaginary VMs
+          servicenow.itsm.configuration_item:
+            name: my-vm-{{ item }}
+            sys_class_name: cmdb_ci_server
+            ip_address: 10.1.0.{{ item }}
+            other:
+              state: "{{ (item % 4 == 0) | ansible.builtin.ternary('on', 'off') }}"
+              guest_os_fullname: "{{ (item < 105) | ansible.builtin.ternary('OS0', 'OS1') }}"
+          loop: "{{ range(100, 110) }}"
+          register: vms
+
+        - name: Reload inventory
+          ansible.builtin.meta: refresh_inventory
+
+        - ansible.builtin.debug:
+            var: groups
+
+        - ansible.builtin.debug:
+            var: hostvars["my-vm-100"]
+
+        - name: Verify the replaced variable names exist
+          ansible.builtin.assert:
+            that:
+              - groups["all"] | length == 10
+              - hostvars["my-vm-100"].location_name is defined
+              - hostvars["my-vm-100"].support_group_name is defined
+              - hostvars["my-vm-104"].location_name is defined
+              - hostvars["my-vm-104"].support_group_name is defined
+
+      always:
+        - name: Delete VMs
+          servicenow.itsm.configuration_item:
+            state: absent
+            sys_id: "{{ item.record.sys_id }}"
+          loop: "{{ vms.results }}"
+          loop_control:
+            label: "{{ item.record.name }}"


### PR DESCRIPTION
##### SUMMARY
The reference field columns are imported host variables with a "." in the name.  It is not a valid Ansible variable name.  This created problem in Ansible.  For exmample,  we can't use the host variable in constructed inventory.

This can be work around by creating composed variables.  However, since name with "." is not a valid Ansible variable name, we should just replace during import.

This change replace "." with underscore "_"

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Inventory plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
For example, columns defined in now.yml
```paste below
columns:
  - location.name
  - support_group.name
  - u_my_reference_table.u_my_reference_column
```
will be imported as host variables
```
location_name
support_group_name
u_my_reference_table_u_my_reference_column
```

