### PR TITLE
Update workflow to allow integration tests to run with maintainer approval

### DIFF
--- a/.github/workflows/all_green_check.yml
+++ b/.github/workflows/all_green_check.yml
@@ -6,9 +6,11 @@ concurrency:
   cancel-in-progress: true
 
 on:  # yamllint disable-line rule:truthy
-  pull_request:
+  pull_request_target:
     types:
       - opened
+      - labeled
+      - unlabeled
       - reopened
       - synchronize
     branches:
@@ -18,6 +20,9 @@ on:  # yamllint disable-line rule:truthy
       - '*'
 
 jobs:
+  safe-to-test:
+    if: ${{ github.event.label.name == 'safe to test' }} || ${{ github.event.action != 'labeled' }}
+    uses: ansible-network/github_actions/.github/workflows/safe-to-test.yml@main
   linters:
     uses: ./.github/workflows/linters.yml  # use the callable linters job to run tests
   sanity:
@@ -27,6 +32,8 @@ jobs:
   integrations:
     uses: ./.github/workflows/integration.yml
     secrets: inherit
+    needs:
+      - safe-to-test
   all_green:
     if: ${{ always() }}
     needs:


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Use different workflow target to enable integration tests to run
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Github workflow

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

The existing trigger system cannot run the integration tests because they require secrets and those are not provided to forked repo PRs. This is github's mechanism to work around that. It also includes the addition of a new workflow, which requires the label "safe to test" applied to a PR to allow integration tests to run.
