### PR TITLE
Fix crash when the "x-total-count" is not found in header

### DIFF
--- a/plugins/module_utils/snow.py
+++ b/plugins/module_utils/snow.py
@@ -35,7 +35,7 @@ class SNowClient:
             # When using this client for generic api, the header is not present anymore
             # and we need to find a new method to break from the loop
             # It can be removed from Table API but for it's better to keep it for now.
-            if response.headers["x-total-count"]:
+            if "x-total-count" in response.headers:
                 total = int(response.headers["x-total-count"])
             else:
                 if len(response.json["result"]) == 0:

--- a/tests/unit/plugins/modules/test_configuration_item_relations.py
+++ b/tests/unit/plugins/modules/test_configuration_item_relations.py
@@ -32,9 +32,7 @@ class TestEnsureAbsent:
                 parent_classname="cmdb_ci_linux_server",
                 name="Cools:Cooled by",
                 direction="outbound",
-                targets=[
-                    dict(sys_id="target_id_1", name="target")
-                ],
+                targets=[dict(sys_id="target_id_1", name="target")],
             )
         )
 
@@ -130,9 +128,7 @@ class TestEnsurePresent:
                 parent_classname="cmdb_ci_linux_server",
                 name="Cools:Cooled by",
                 direction="outbound",
-                targets=[
-                    dict(sys_id="target_id_1", name="target")
-                ],
+                targets=[dict(sys_id="target_id_1", name="target")],
             )
         )
 


### PR DESCRIPTION
This PR fix crashes when calling endpoints that don't have `x-total-count` in the header.


##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
snow.py