### PR TITLE
Use a different assignement_group for each python/ansible combination

### DIFF
--- a/tests/integration/targets/change_request/tasks/main.yml
+++ b/tests/integration/targets/change_request/tasks/main.yml
@@ -3,415 +3,435 @@
     SN_USERNAME: "{{ sn_username }}"
     SN_PASSWORD: "{{ sn_password }}"
 
+  vars:
+    assignment_groups:
+      py3.9-ansible-2.15: network
+      py3.10-ansible-2.15: software
+      py3.11-ansible-2.15: hardware
+      py3.12-ansible-2.15: database
+      py3.9-ansible-2.16: Help Desk
+      py3.10-ansible-2.16: Openspace
+      py3.11-ansible-2.16: Problem Solving
+      py3.12-ansible-2.16: LDAP Admins
+      py3.9-milestone: CAB Approval
+      py3.10-milestone: Change Management
+      py3.11-milestone: eCAB Approval
+      py3.12-milestone: App Engine Admins
+      py3.9-devel: IT Securities
+      py3.10-devel: IT Finance CAB
+      py3.11-devel: Network CAB Managers
+      py3.12-devel: Service Desk
+      py3.12-ansible-2.16: database
+
   block:
-    - name: Create test change_request - check mode
-      servicenow.itsm.change_request: &create-change_request
-        requested_by: admin
-        state: new
-        type: standard
-        template: Clear BGP sessions on a Cisco router - 1
-        priority: low
-        risk: low
-        impact: low
-        short_description: some short description
-        attachments:
-          - path: targets/change_request/res/sample_file.txt
-      check_mode: true
-      register: result
-
-    - ansible.builtin.assert: &create-change_request-result
-        that:
-          - result is changed
-          - result.record.state == "new"
-          - result.record.type == "standard"
-          - result.record.priority == "low"
-          - result.record.risk == "low"
-          - result.record.impact == "low"
-          - result.record.attachments | length != 0
-          - result.record.attachments[0].file_name == "sample_file.txt"
-
-
-    - name: Create test change_request
-      servicenow.itsm.change_request: *create-change_request
-      register: test_result
-
-    - name: Copy test_result into result
-      set_fact:
-        result: "{{ test_result }}"
-
-    - ansible.builtin.assert: *create-change_request-result
-
-
-    - name: Make sure change_request exists
-      servicenow.itsm.change_request_info:
-        number: "{{ test_result.record.number }}"
-      register: result
-
-    - ansible.builtin.assert:
-        that:
-          - result.records[0].number == test_result.record.number
-          - result.records[0].type == "standard"
-          - result.records[0].priority == "low"
-          - result.records[0].risk == "low"
-          - result.records[0].impact == "low"
-          - "'Resend the complete BGP table to neighboring routers' in result.records[0].description"
-
-
-    - name: Update change_request with same priority, risk and impact - unchanged
-      servicenow.itsm.change_request:
-        requested_by: admin
-        number: "{{ test_result.record.number }}"
-        priority: low
-        risk: low
-        impact: low
-      register: result
-
-    - ansible.builtin.assert:
-        that:
-          - result is not changed
-
-
-    - name: Update state to scheduled without assignment_group - should throw an error
-      servicenow.itsm.change_request:
-        requested_by: admin
-        number: "{{ test_result.record.number }}"
-        state: scheduled
-      ignore_errors: true
-      register: result
-
-    - ansible.builtin.assert:
-        that:
-          - result is failed
-          - "'state is scheduled but all of the following are missing: assignment_group' in result.msg"
-
-
-    - name: Attempt to put the change request on hold without specifying the reason
-      servicenow.itsm.change_request:
-        number: "{{ test_result.record.number }}"
-        on_hold: true
-      ignore_errors: true
-      register: result
-
-    - ansible.builtin.assert:
-        that:
-          - result is failed
-          - "'on_hold is True but all of the following are missing: hold_reason'"
-
-
-    - name: Update change_request - check mode
-      servicenow.itsm.change_request: &update-change_request
-        requested_by: admin
-        number: "{{ test_result.record.number }}"
-        state: scheduled
-        assignment_group: network
-        priority: high
-        risk: high
-        impact: high
-      check_mode: true
-      register: result
+    # - name: Create test change_request - check mode
+    #   servicenow.itsm.change_request: &create-change_request
+    #     requested_by: admin
+    #     state: new
+    #     type: standard
+    #     template: Clear BGP sessions on a Cisco router - 1
+    #     priority: low
+    #     risk: low
+    #     impact: low
+    #     short_description: some short description
+    #     attachments:
+    #       - path: targets/change_request/res/sample_file.txt
+    #   check_mode: true
+    #   register: result
+
+    # - ansible.builtin.assert: &create-change_request-result
+    #     that:
+    #       - result is changed
+    #       - result.record.state == "new"
+    #       - result.record.type == "standard"
+    #       - result.record.priority == "low"
+    #       - result.record.risk == "low"
+    #       - result.record.impact == "low"
+    #       - result.record.attachments | length != 0
+    #       - result.record.attachments[0].file_name == "sample_file.txt"
+
+
+    # - name: Create test change_request
+    #   servicenow.itsm.change_request: *create-change_request
+    #   register: test_result
+
+    # - name: Copy test_result into result
+    #   set_fact:
+    #     result: "{{ test_result }}"
+
+    # - ansible.builtin.assert: *create-change_request-result
+
+
+    # - name: Make sure change_request exists
+    #   servicenow.itsm.change_request_info:
+    #     number: "{{ test_result.record.number }}"
+    #   register: result
+
+    # - ansible.builtin.assert:
+    #     that:
+    #       - result.records[0].number == test_result.record.number
+    #       - result.records[0].type == "standard"
+    #       - result.records[0].priority == "low"
+    #       - result.records[0].risk == "low"
+    #       - result.records[0].impact == "low"
+    #       - "'Resend the complete BGP table to neighboring routers' in result.records[0].description"
+
+
+    # - name: Update change_request with same priority, risk and impact - unchanged
+    #   servicenow.itsm.change_request:
+    #     requested_by: admin
+    #     number: "{{ test_result.record.number }}"
+    #     priority: low
+    #     risk: low
+    #     impact: low
+    #   register: result
+
+    # - ansible.builtin.assert:
+    #     that:
+    #       - result is not changed
+
+
+    # - name: Update state to scheduled without assignment_group - should throw an error
+    #   servicenow.itsm.change_request:
+    #     requested_by: admin
+    #     number: "{{ test_result.record.number }}"
+    #     state: scheduled
+    #   ignore_errors: true
+    #   register: result
+
+    # - ansible.builtin.assert:
+    #     that:
+    #       - result is failed
+    #       - "'state is scheduled but all of the following are missing: assignment_group' in result.msg"
+
+
+    # - name: Attempt to put the change request on hold without specifying the reason
+    #   servicenow.itsm.change_request:
+    #     number: "{{ test_result.record.number }}"
+    #     on_hold: true
+    #   ignore_errors: true
+    #   register: result
+
+    # - ansible.builtin.assert:
+    #     that:
+    #       - result is failed
+    #       - "'on_hold is True but all of the following are missing: hold_reason'"
+
+
+    # - name: Update change_request - check mode
+    #   servicenow.itsm.change_request: &update-change_request
+    #     requested_by: admin
+    #     number: "{{ test_result.record.number }}"
+    #     state: scheduled
+    #     assignment_group: network
+    #     priority: high
+    #     risk: high
+    #     impact: high
+    #   check_mode: true
+    #   register: result
 
-    - ansible.builtin.assert: &update-change_request-result
-        that:
-          - result is changed
-          - result.record.state == "scheduled"
-          - result.record.priority == "high"
-          - result.record.risk == "high"
-          - result.record.impact == "high"
+    # - ansible.builtin.assert: &update-change_request-result
+    #     that:
+    #       - result is changed
+    #       - result.record.state == "scheduled"
+    #       - result.record.priority == "high"
+    #       - result.record.risk == "high"
+    #       - result.record.impact == "high"
 
 
-    - name: Update change_request
-      servicenow.itsm.change_request: *update-change_request
+    # - name: Update change_request
+    #   servicenow.itsm.change_request: *update-change_request
 
-    - ansible.builtin.assert: *update-change_request-result
+    # - ansible.builtin.assert: *update-change_request-result
 
 
-    - name: Make sure change_request was updated
-      servicenow.itsm.change_request_info:
-        number: "{{ test_result.record.number }}"
-      register: result
+    # - name: Make sure change_request was updated
+    #   servicenow.itsm.change_request_info:
+    #     number: "{{ test_result.record.number }}"
+    #   register: result
 
-    - ansible.builtin.assert:
-        that:
-          - result.records[0].number == test_result.record.number
-          - result.records[0].state == "scheduled" 
-          - result.records[0].priority == "high"
-          - result.records[0].risk == "high"
-          - result.records[0].impact == "high"
+    # - ansible.builtin.assert:
+    #     that:
+    #       - result.records[0].number == test_result.record.number
+    #       - result.records[0].state == "scheduled" 
+    #       - result.records[0].priority == "high"
+    #       - result.records[0].risk == "high"
+    #       - result.records[0].impact == "high"
 
 
-    - name: Update change_request with same params - unchanged
-      servicenow.itsm.change_request: *update-change_request
-      register: result
+    # - name: Update change_request with same params - unchanged
+    #   servicenow.itsm.change_request: *update-change_request
+    #   register: result
 
-    - ansible.builtin.assert:
-        that:
-          - result is not changed
+    # - ansible.builtin.assert:
+    #     that:
+    #       - result is not changed
 
 
-    - name: Update change_request state to implement - check mode
-      servicenow.itsm.change_request: &update-change_request-state-implement
-        requested_by: admin
-        number: "{{ test_result.record.number }}"
-        state: implement
-      check_mode: true
-      register: result
+    # - name: Update change_request state to implement - check mode
+    #   servicenow.itsm.change_request: &update-change_request-state-implement
+    #     requested_by: admin
+    #     number: "{{ test_result.record.number }}"
+    #     state: implement
+    #   check_mode: true
+    #   register: result
 
-    - ansible.builtin.assert: &update-change_request-state-result-implement
-        that:
-          - result is changed
-          - result.record.state == "implement"
+    # - ansible.builtin.assert: &update-change_request-state-result-implement
+    #     that:
+    #       - result is changed
+    #       - result.record.state == "implement"
 
 
-    - name: Update change_request state to implement
-      servicenow.itsm.change_request: *update-change_request-state-implement
+    # - name: Update change_request state to implement
+    #   servicenow.itsm.change_request: *update-change_request-state-implement
 
-    - ansible.builtin.assert: *update-change_request-state-result-implement
+    # - ansible.builtin.assert: *update-change_request-state-result-implement
 
 
-    - name: Make sure state of change_request was updated
-      servicenow.itsm.change_request_info:
-        number: "{{ test_result.record.number }}"
-      register: result
+    # - name: Make sure state of change_request was updated
+    #   servicenow.itsm.change_request_info:
+    #     number: "{{ test_result.record.number }}"
+    #   register: result
 
-    - ansible.builtin.assert:
-        that:
-          - result.records[0].number == test_result.record.number
-          - result.records[0].state == "implement" 
+    # - ansible.builtin.assert:
+    #     that:
+    #       - result.records[0].number == test_result.record.number
+    #       - result.records[0].state == "implement" 
 
 
-    - name: Update change_request with same state - unchanged
-      servicenow.itsm.change_request: *update-change_request-state-implement
-      register: result
+    # - name: Update change_request with same state - unchanged
+    #   servicenow.itsm.change_request: *update-change_request-state-implement
+    #   register: result
 
-    - ansible.builtin.assert:
-        that:
-          - result is not changed
+    # - ansible.builtin.assert:
+    #     that:
+    #       - result is not changed
 
 
-    - name: Update change_request state to review - check mode
-      servicenow.itsm.change_request: &update-change_request-state-review
-        requested_by: admin
-        number: "{{ test_result.record.number }}"
-        state: review
-      check_mode: true
-      register: result
+    # - name: Update change_request state to review - check mode
+    #   servicenow.itsm.change_request: &update-change_request-state-review
+    #     requested_by: admin
+    #     number: "{{ test_result.record.number }}"
+    #     state: review
+    #   check_mode: true
+    #   register: result
 
-    - ansible.builtin.assert: &update-change_request-state-result-review
-        that:
-          - result is changed
-          - result.record.state == "review"
+    # - ansible.builtin.assert: &update-change_request-state-result-review
+    #     that:
+    #       - result is changed
+    #       - result.record.state == "review"
 
 
-    - name: Update change_request state to review
-      servicenow.itsm.change_request: *update-change_request-state-review
+    # - name: Update change_request state to review
+    #   servicenow.itsm.change_request: *update-change_request-state-review
 
-    - ansible.builtin.assert: *update-change_request-state-result-review
+    # - ansible.builtin.assert: *update-change_request-state-result-review
 
 
-    - name: Make sure state of change_request was updated
-      servicenow.itsm.change_request_info:
-        number: "{{ test_result.record.number }}"
-      register: result
+    # - name: Make sure state of change_request was updated
+    #   servicenow.itsm.change_request_info:
+    #     number: "{{ test_result.record.number }}"
+    #   register: result
 
-    - ansible.builtin.assert:
-        that:
-          - result.records[0].number == test_result.record.number
-          - result.records[0].state == "review" 
+    # - ansible.builtin.assert:
+    #     that:
+    #       - result.records[0].number == test_result.record.number
+    #       - result.records[0].state == "review" 
 
 
-    - name: Update change_request with same state - unchanged
-      servicenow.itsm.change_request: *update-change_request-state-review
-      register: result
+    # - name: Update change_request with same state - unchanged
+    #   servicenow.itsm.change_request: *update-change_request-state-review
+    #   register: result
 
-    - ansible.builtin.assert:
-        that:
-          - result is not changed
+    # - ansible.builtin.assert:
+    #     that:
+    #       - result is not changed
 
 
-    - name: Fail to close the change
-      servicenow.itsm.change_request:
-        number: "{{ test_result.record.number }}"
-        state: closed
-      ignore_errors: true
-      register: result
-    - ansible.builtin.assert:
-        that:
-          - result is failed
-          - "'close_code' in result.msg"
-          - "'close_notes' in result.msg"
+    # - name: Fail to close the change
+    #   servicenow.itsm.change_request:
+    #     number: "{{ test_result.record.number }}"
+    #     state: closed
+    #   ignore_errors: true
+    #   register: result
+    # - ansible.builtin.assert:
+    #     that:
+    #       - result is failed
+    #       - "'close_code' in result.msg"
+    #       - "'close_notes' in result.msg"
 
 
-    - name: Update change_request state to closed - check mode
-      servicenow.itsm.change_request: &update-change_request-state-closed
-        requested_by: admin
-        number: "{{ test_result.record.number }}"
-        state: closed
-        close_code: successful
-        close_notes: Done testing
-      check_mode: true
-      register: result
+    # - name: Update change_request state to closed - check mode
+    #   servicenow.itsm.change_request: &update-change_request-state-closed
+    #     requested_by: admin
+    #     number: "{{ test_result.record.number }}"
+    #     state: closed
+    #     close_code: successful
+    #     close_notes: Done testing
+    #   check_mode: true
+    #   register: result
 
-    - ansible.builtin.assert: &update-change_request-state-result-closed
-        that:
-          - result is changed
-          - result.record.state == "closed"
+    # - ansible.builtin.assert: &update-change_request-state-result-closed
+    #     that:
+    #       - result is changed
+    #       - result.record.state == "closed"
 
 
-    - name: Update change_request state to closed
-      servicenow.itsm.change_request: *update-change_request-state-closed
+    # - name: Update change_request state to closed
+    #   servicenow.itsm.change_request: *update-change_request-state-closed
 
-    - ansible.builtin.assert: *update-change_request-state-result-closed
+    # - ansible.builtin.assert: *update-change_request-state-result-closed
 
 
-    - name: Get change_request info by sysparm query - state and close_notes
-      servicenow.itsm.change_request_info:
-        query:
-         - state: = closed
-           close_notes: = Done testing
-      register: result
+    # - name: Get change_request info by sysparm query - state and close_notes
+    #   servicenow.itsm.change_request_info:
+    #     query:
+    #      - state: = closed
+    #        close_notes: = Done testing
+    #   register: result
 
-    - ansible.builtin.assert:
-        that:
-          - result.records[0].state == "closed"
-          - result.records[0].close_notes == "Done testing"
+    # - ansible.builtin.assert:
+    #     that:
+    #       - result.records[0].state == "closed"
+    #       - result.records[0].close_notes == "Done testing"
 
 
-    - name: Make sure change_request state was updated and is in closed state
-      servicenow.itsm.change_request_info:
-        number: "{{ test_result.record.number }}"
-      register: result
+    # - name: Make sure change_request state was updated and is in closed state
+    #   servicenow.itsm.change_request_info:
+    #     number: "{{ test_result.record.number }}"
+    #   register: result
 
-    - ansible.builtin.assert:
-        that:
-          - result.records[0].number == test_result.record.number
-          - result.records[0].state == "closed"
-          - result.records[0].close_code == "successful"
-          - result.records[0].close_notes == "Done testing"
-
+    # - ansible.builtin.assert:
+    #     that:
+    #       - result.records[0].number == test_result.record.number
+    #       - result.records[0].state == "closed"
+    #       - result.records[0].close_code == "successful"
+    #       - result.records[0].close_notes == "Done testing"
+
 
-    - name: Get specific change request info by sysparm query
-      servicenow.itsm.change_request_info:
-        query:
-         - number: = {{ test_result.record.number }}
-           state: = closed
-           close_code: = successful
-           close_notes: = Done testing
-      register: result
+    # - name: Get specific change request info by sysparm query
+    #   servicenow.itsm.change_request_info:
+    #     query:
+    #      - number: = {{ test_result.record.number }}
+    #        state: = closed
+    #        close_code: = successful
+    #        close_notes: = Done testing
+    #   register: result
 
-    - ansible.builtin.assert:
-        that:
-          - result.records | length == 1
-          - result.records[0].number == test_result.record.number
-          - result.records[0].state == "closed"
-          - result.records[0].close_code == "successful"
-          - result.records[0].close_notes == "Done testing"
+    # - ansible.builtin.assert:
+    #     that:
+    #       - result.records | length == 1
+    #       - result.records[0].number == test_result.record.number
+    #       - result.records[0].state == "closed"
+    #       - result.records[0].close_code == "successful"
+    #       - result.records[0].close_notes == "Done testing"
 
 
-    - name: Update change_request with same state - unchanged
-      servicenow.itsm.change_request: *update-change_request-state-closed
-      register: result
+    # - name: Update change_request with same state - unchanged
+    #   servicenow.itsm.change_request: *update-change_request-state-closed
+    #   register: result
 
-    - ansible.builtin.assert:
-        that:
-          - result is not changed
+    # - ansible.builtin.assert:
+    #     that:
+    #       - result is not changed
 
-    - name: Test bad parameter combinator (number + query)
-      servicenow.itsm.change_request_info:
-        number: "{{ test_result.record.number }}"
-        query:
-         - short_description: LIKE Oracle
-      ignore_errors: true
-      register: result
+    # - name: Test bad parameter combinator (number + query)
+    #   servicenow.itsm.change_request_info:
+    #     number: "{{ test_result.record.number }}"
+    #     query:
+    #      - short_description: LIKE Oracle
+    #   ignore_errors: true
+    #   register: result
 
-    - ansible.builtin.assert:
-        that:
-          - result is failed
-          - "'parameters are mutually exclusive: number|query' in result.msg"
+    # - ansible.builtin.assert:
+    #     that:
+    #       - result is failed
+    #       - "'parameters are mutually exclusive: number|query' in result.msg"
 
 
-    - name: Test invalid operator detection
-      servicenow.itsm.change_request_info:
-        query:
-         - short_description: LIKEE Oracle
-      ignore_errors: true
-      register: result
+    # - name: Test invalid operator detection
+    #   servicenow.itsm.change_request_info:
+    #     query:
+    #      - short_description: LIKEE Oracle
+    #   ignore_errors: true
+    #   register: result
 
-    - ansible.builtin.assert:
-        that:
-          - result is failed
-          - "'Invalid condition' in result.msg"
+    # - ansible.builtin.assert:
+    #     that:
+    #       - result is failed
+    #       - "'Invalid condition' in result.msg"
 
 
-    - name: Get change_request info by sysparm query - short_description
-      servicenow.itsm.change_request_info:
-        query:
-         - short_description: LIKE some
-      register: result
+    # - name: Get change_request info by sysparm query - short_description
+    #   servicenow.itsm.change_request_info:
+    #     query:
+    #      - short_description: LIKE some
+    #   register: result
 
-    - ansible.builtin.assert:
-        that:
-          - "'some' in result.records[0].short_description"
+    # - ansible.builtin.assert:
+    #     that:
+    #       - "'some' in result.records[0].short_description"
 
 
-    - name: Test unary operator with argument detection
-      servicenow.itsm.change_request_info:
-        query:
-         - short_description: ISEMPTY SAP
-      ignore_errors: true
-      register: result
+    # - name: Test unary operator with argument detection
+    #   servicenow.itsm.change_request_info:
+    #     query:
+    #      - short_description: ISEMPTY SAP
+    #   ignore_errors: true
+    #   register: result
 
-    - ansible.builtin.assert:
-        that:
-          - result is failed
-          - "'Operator ISEMPTY does not take any arguments' in result.msg"
+    # - ansible.builtin.assert:
+    #     that:
+    #       - result is failed
+    #       - "'Operator ISEMPTY does not take any arguments' in result.msg"
 
 
-    - name: Test sysparm query unary operator - short_description
-      servicenow.itsm.change_request_info:
-        query:
-         - short_description: ISNOTEMPTY
-      register: result
+    # - name: Test sysparm query unary operator - short_description
+    #   servicenow.itsm.change_request_info:
+    #     query:
+    #      - short_description: ISNOTEMPTY
+    #   register: result
 
-    - ansible.builtin.assert:
-        that:
-          - result.records[0].short_description != ""
+    # - ansible.builtin.assert:
+    #     that:
+    #       - result.records[0].short_description != ""
 
-    - name: Delete change_request - check mode
-      servicenow.itsm.change_request: &delete-change_request
-        requested_by: admin
-        number: "{{ test_result.record.number }}"
-        state: absent
-      check_mode: true
-      register: result
+    # - name: Delete change_request - check mode
+    #   servicenow.itsm.change_request: &delete-change_request
+    #     requested_by: admin
+    #     number: "{{ test_result.record.number }}"
+    #     state: absent
+    #   check_mode: true
+    #   register: result
 
-    - ansible.builtin.assert: &delete-change_request-result
-        that:
-          - result is changed
+    # - ansible.builtin.assert: &delete-change_request-result
+    #     that:
+    #       - result is changed
 
 
-    - name: Delete change_request
-      servicenow.itsm.change_request: *delete-change_request
+    # - name: Delete change_request
+    #   servicenow.itsm.change_request: *delete-change_request
 
-    - ansible.builtin.assert: *delete-change_request-result
+    # - ansible.builtin.assert: *delete-change_request-result
 
 
-    - name: Make sure change_request is absent
-      servicenow.itsm.change_request_info:
-        number: "{{ test_result.record.number }}"
-      register: result
+    # - name: Make sure change_request is absent
+    #   servicenow.itsm.change_request_info:
+    #     number: "{{ test_result.record.number }}"
+    #   register: result
 
-    - ansible.builtin.assert:
-        that:
-          - result.records | length == 0
+    # - ansible.builtin.assert:
+    #     that:
+    #       - result.records | length == 0
 
 
-    - name: Delete change_request - unchanged
-      servicenow.itsm.change_request: *delete-change_request
-      register: result
+    # - name: Delete change_request - unchanged
+    #   servicenow.itsm.change_request: *delete-change_request
+    #   register: result
 
-    - ansible.builtin.assert:
-        that:
-          - result is not changed
+    # - ansible.builtin.assert:
+    #     that:
+    #       - result is not changed
 
 
     # Test closing the change_request with assignment_group sys_id
@@ -426,13 +446,19 @@
         impact: low
       register: test_result
       
+    # To avoid clashes between run we need to choose a new assignment_group for each python/ansible combination
+    - set_fact:
+        instance: "py{{ ansible_facts.python.version.major }}.{{ ansible_facts.python.version.minor }}-ansible-{{ ansible_version.major }}.{{ ansible_version.minor }}"
+
+    - debug: var="{{ assignment_groups[instance] | default('network') }}"
+    - debug: var=instance
 
     - name: Update test change_request to scheduled
       servicenow.itsm.change_request:
         requested_by: admin
         number: "{{ test_result.record.number }}"
         state: scheduled
-        assignment_group: network
+        assignment_group: "{{ assignment_groups[instance] | default('network') }}"
         priority: high
         risk: high
         impact: high

--- a/tests/integration/targets/change_request/tasks/main.yml
+++ b/tests/integration/targets/change_request/tasks/main.yml
@@ -8,430 +8,425 @@
       py3.9-ansible-2.15: network
       py3.10-ansible-2.15: software
       py3.11-ansible-2.15: hardware
-      py3.12-ansible-2.15: database
+      py3.12-ansible-2.15: IT Securities CAB
       py3.9-ansible-2.16: Help Desk
       py3.10-ansible-2.16: Openspace
       py3.11-ansible-2.16: Problem Solving
       py3.12-ansible-2.16: LDAP Admins
-      py3.9-milestone: CAB Approval
-      py3.10-milestone: Change Management
-      py3.11-milestone: eCAB Approval
-      py3.12-milestone: App Engine Admins
-      py3.9-devel: IT Securities
-      py3.10-devel: IT Finance CAB
-      py3.11-devel: Network CAB Managers
-      py3.12-devel: Service Desk
-      py3.12-ansible-2.16: database
+      py3.9-ansible-2.18: IT Securities
+      py3.10-ansible-2.18: IT Finance CAB
+      py3.11-ansible-2.18: Network CAB Managers
+      py3.12-ansible-2.18: Service Desk
 
   block:
-    # - name: Create test change_request - check mode
-    #   servicenow.itsm.change_request: &create-change_request
-    #     requested_by: admin
-    #     state: new
-    #     type: standard
-    #     template: Clear BGP sessions on a Cisco router - 1
-    #     priority: low
-    #     risk: low
-    #     impact: low
-    #     short_description: some short description
-    #     attachments:
-    #       - path: targets/change_request/res/sample_file.txt
-    #   check_mode: true
-    #   register: result
-
-    # - ansible.builtin.assert: &create-change_request-result
-    #     that:
-    #       - result is changed
-    #       - result.record.state == "new"
-    #       - result.record.type == "standard"
-    #       - result.record.priority == "low"
-    #       - result.record.risk == "low"
-    #       - result.record.impact == "low"
-    #       - result.record.attachments | length != 0
-    #       - result.record.attachments[0].file_name == "sample_file.txt"
-
-
-    # - name: Create test change_request
-    #   servicenow.itsm.change_request: *create-change_request
-    #   register: test_result
-
-    # - name: Copy test_result into result
-    #   set_fact:
-    #     result: "{{ test_result }}"
-
-    # - ansible.builtin.assert: *create-change_request-result
-
-
-    # - name: Make sure change_request exists
-    #   servicenow.itsm.change_request_info:
-    #     number: "{{ test_result.record.number }}"
-    #   register: result
-
-    # - ansible.builtin.assert:
-    #     that:
-    #       - result.records[0].number == test_result.record.number
-    #       - result.records[0].type == "standard"
-    #       - result.records[0].priority == "low"
-    #       - result.records[0].risk == "low"
-    #       - result.records[0].impact == "low"
-    #       - "'Resend the complete BGP table to neighboring routers' in result.records[0].description"
-
-
-    # - name: Update change_request with same priority, risk and impact - unchanged
-    #   servicenow.itsm.change_request:
-    #     requested_by: admin
-    #     number: "{{ test_result.record.number }}"
-    #     priority: low
-    #     risk: low
-    #     impact: low
-    #   register: result
-
-    # - ansible.builtin.assert:
-    #     that:
-    #       - result is not changed
-
-
-    # - name: Update state to scheduled without assignment_group - should throw an error
-    #   servicenow.itsm.change_request:
-    #     requested_by: admin
-    #     number: "{{ test_result.record.number }}"
-    #     state: scheduled
-    #   ignore_errors: true
-    #   register: result
-
-    # - ansible.builtin.assert:
-    #     that:
-    #       - result is failed
-    #       - "'state is scheduled but all of the following are missing: assignment_group' in result.msg"
-
-
-    # - name: Attempt to put the change request on hold without specifying the reason
-    #   servicenow.itsm.change_request:
-    #     number: "{{ test_result.record.number }}"
-    #     on_hold: true
-    #   ignore_errors: true
-    #   register: result
-
-    # - ansible.builtin.assert:
-    #     that:
-    #       - result is failed
-    #       - "'on_hold is True but all of the following are missing: hold_reason'"
-
-
-    # - name: Update change_request - check mode
-    #   servicenow.itsm.change_request: &update-change_request
-    #     requested_by: admin
-    #     number: "{{ test_result.record.number }}"
-    #     state: scheduled
-    #     assignment_group: network
-    #     priority: high
-    #     risk: high
-    #     impact: high
-    #   check_mode: true
-    #   register: result
+    - name: Create test change_request - check mode
+      servicenow.itsm.change_request: &create-change_request
+        requested_by: admin
+        state: new
+        type: standard
+        template: Clear BGP sessions on a Cisco router - 1
+        priority: low
+        risk: low
+        impact: low
+        short_description: some short description
+        attachments:
+          - path: targets/change_request/res/sample_file.txt
+      check_mode: true
+      register: result
+
+    - ansible.builtin.assert: &create-change_request-result
+        that:
+          - result is changed
+          - result.record.state == "new"
+          - result.record.type == "standard"
+          - result.record.priority == "low"
+          - result.record.risk == "low"
+          - result.record.impact == "low"
+          - result.record.attachments | length != 0
+          - result.record.attachments[0].file_name == "sample_file.txt"
+
+
+    - name: Create test change_request
+      servicenow.itsm.change_request: *create-change_request
+      register: test_result
+
+    - name: Copy test_result into result
+      set_fact:
+        result: "{{ test_result }}"
+
+    - ansible.builtin.assert: *create-change_request-result
+
+
+    - name: Make sure change_request exists
+      servicenow.itsm.change_request_info:
+        number: "{{ test_result.record.number }}"
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result.records[0].number == test_result.record.number
+          - result.records[0].type == "standard"
+          - result.records[0].priority == "low"
+          - result.records[0].risk == "low"
+          - result.records[0].impact == "low"
+          - "'Resend the complete BGP table to neighboring routers' in result.records[0].description"
+
+
+    - name: Update change_request with same priority, risk and impact - unchanged
+      servicenow.itsm.change_request:
+        requested_by: admin
+        number: "{{ test_result.record.number }}"
+        priority: low
+        risk: low
+        impact: low
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result is not changed
+
+
+    - name: Update state to scheduled without assignment_group - should throw an error
+      servicenow.itsm.change_request:
+        requested_by: admin
+        number: "{{ test_result.record.number }}"
+        state: scheduled
+      ignore_errors: true
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'state is scheduled but all of the following are missing: assignment_group' in result.msg"
+
+
+    - name: Attempt to put the change request on hold without specifying the reason
+      servicenow.itsm.change_request:
+        number: "{{ test_result.record.number }}"
+        on_hold: true
+      ignore_errors: true
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'on_hold is True but all of the following are missing: hold_reason'"
+
+
+    - name: Update change_request - check mode
+      servicenow.itsm.change_request: &update-change_request
+        requested_by: admin
+        number: "{{ test_result.record.number }}"
+        state: scheduled
+        assignment_group: network
+        priority: high
+        risk: high
+        impact: high
+      check_mode: true
+      register: result
 
-    # - ansible.builtin.assert: &update-change_request-result
-    #     that:
-    #       - result is changed
-    #       - result.record.state == "scheduled"
-    #       - result.record.priority == "high"
-    #       - result.record.risk == "high"
-    #       - result.record.impact == "high"
+    - ansible.builtin.assert: &update-change_request-result
+        that:
+          - result is changed
+          - result.record.state == "scheduled"
+          - result.record.priority == "high"
+          - result.record.risk == "high"
+          - result.record.impact == "high"
 
 
-    # - name: Update change_request
-    #   servicenow.itsm.change_request: *update-change_request
+    - name: Update change_request
+      servicenow.itsm.change_request: *update-change_request
 
-    # - ansible.builtin.assert: *update-change_request-result
+    - ansible.builtin.assert: *update-change_request-result
 
 
-    # - name: Make sure change_request was updated
-    #   servicenow.itsm.change_request_info:
-    #     number: "{{ test_result.record.number }}"
-    #   register: result
+    - name: Make sure change_request was updated
+      servicenow.itsm.change_request_info:
+        number: "{{ test_result.record.number }}"
+      register: result
 
-    # - ansible.builtin.assert:
-    #     that:
-    #       - result.records[0].number == test_result.record.number
-    #       - result.records[0].state == "scheduled" 
-    #       - result.records[0].priority == "high"
-    #       - result.records[0].risk == "high"
-    #       - result.records[0].impact == "high"
+    - ansible.builtin.assert:
+        that:
+          - result.records[0].number == test_result.record.number
+          - result.records[0].state == "scheduled" 
+          - result.records[0].priority == "high"
+          - result.records[0].risk == "high"
+          - result.records[0].impact == "high"
 
 
-    # - name: Update change_request with same params - unchanged
-    #   servicenow.itsm.change_request: *update-change_request
-    #   register: result
+    - name: Update change_request with same params - unchanged
+      servicenow.itsm.change_request: *update-change_request
+      register: result
 
-    # - ansible.builtin.assert:
-    #     that:
-    #       - result is not changed
+    - ansible.builtin.assert:
+        that:
+          - result is not changed
 
 
-    # - name: Update change_request state to implement - check mode
-    #   servicenow.itsm.change_request: &update-change_request-state-implement
-    #     requested_by: admin
-    #     number: "{{ test_result.record.number }}"
-    #     state: implement
-    #   check_mode: true
-    #   register: result
+    - name: Update change_request state to implement - check mode
+      servicenow.itsm.change_request: &update-change_request-state-implement
+        requested_by: admin
+        number: "{{ test_result.record.number }}"
+        state: implement
+      check_mode: true
+      register: result
 
-    # - ansible.builtin.assert: &update-change_request-state-result-implement
-    #     that:
-    #       - result is changed
-    #       - result.record.state == "implement"
+    - ansible.builtin.assert: &update-change_request-state-result-implement
+        that:
+          - result is changed
+          - result.record.state == "implement"
 
 
-    # - name: Update change_request state to implement
-    #   servicenow.itsm.change_request: *update-change_request-state-implement
+    - name: Update change_request state to implement
+      servicenow.itsm.change_request: *update-change_request-state-implement
 
-    # - ansible.builtin.assert: *update-change_request-state-result-implement
+    - ansible.builtin.assert: *update-change_request-state-result-implement
 
 
-    # - name: Make sure state of change_request was updated
-    #   servicenow.itsm.change_request_info:
-    #     number: "{{ test_result.record.number }}"
-    #   register: result
+    - name: Make sure state of change_request was updated
+      servicenow.itsm.change_request_info:
+        number: "{{ test_result.record.number }}"
+      register: result
 
-    # - ansible.builtin.assert:
-    #     that:
-    #       - result.records[0].number == test_result.record.number
-    #       - result.records[0].state == "implement" 
+    - ansible.builtin.assert:
+        that:
+          - result.records[0].number == test_result.record.number
+          - result.records[0].state == "implement" 
 
 
-    # - name: Update change_request with same state - unchanged
-    #   servicenow.itsm.change_request: *update-change_request-state-implement
-    #   register: result
+    - name: Update change_request with same state - unchanged
+      servicenow.itsm.change_request: *update-change_request-state-implement
+      register: result
 
-    # - ansible.builtin.assert:
-    #     that:
-    #       - result is not changed
+    - ansible.builtin.assert:
+        that:
+          - result is not changed
 
 
-    # - name: Update change_request state to review - check mode
-    #   servicenow.itsm.change_request: &update-change_request-state-review
-    #     requested_by: admin
-    #     number: "{{ test_result.record.number }}"
-    #     state: review
-    #   check_mode: true
-    #   register: result
+    - name: Update change_request state to review - check mode
+      servicenow.itsm.change_request: &update-change_request-state-review
+        requested_by: admin
+        number: "{{ test_result.record.number }}"
+        state: review
+      check_mode: true
+      register: result
 
-    # - ansible.builtin.assert: &update-change_request-state-result-review
-    #     that:
-    #       - result is changed
-    #       - result.record.state == "review"
+    - ansible.builtin.assert: &update-change_request-state-result-review
+        that:
+          - result is changed
+          - result.record.state == "review"
 
 
-    # - name: Update change_request state to review
-    #   servicenow.itsm.change_request: *update-change_request-state-review
+    - name: Update change_request state to review
+      servicenow.itsm.change_request: *update-change_request-state-review
 
-    # - ansible.builtin.assert: *update-change_request-state-result-review
+    - ansible.builtin.assert: *update-change_request-state-result-review
 
 
-    # - name: Make sure state of change_request was updated
-    #   servicenow.itsm.change_request_info:
-    #     number: "{{ test_result.record.number }}"
-    #   register: result
+    - name: Make sure state of change_request was updated
+      servicenow.itsm.change_request_info:
+        number: "{{ test_result.record.number }}"
+      register: result
 
-    # - ansible.builtin.assert:
-    #     that:
-    #       - result.records[0].number == test_result.record.number
-    #       - result.records[0].state == "review" 
+    - ansible.builtin.assert:
+        that:
+          - result.records[0].number == test_result.record.number
+          - result.records[0].state == "review" 
 
 
-    # - name: Update change_request with same state - unchanged
-    #   servicenow.itsm.change_request: *update-change_request-state-review
-    #   register: result
+    - name: Update change_request with same state - unchanged
+      servicenow.itsm.change_request: *update-change_request-state-review
+      register: result
 
-    # - ansible.builtin.assert:
-    #     that:
-    #       - result is not changed
+    - ansible.builtin.assert:
+        that:
+          - result is not changed
 
 
-    # - name: Fail to close the change
-    #   servicenow.itsm.change_request:
-    #     number: "{{ test_result.record.number }}"
-    #     state: closed
-    #   ignore_errors: true
-    #   register: result
-    # - ansible.builtin.assert:
-    #     that:
-    #       - result is failed
-    #       - "'close_code' in result.msg"
-    #       - "'close_notes' in result.msg"
+    - name: Fail to close the change
+      servicenow.itsm.change_request:
+        number: "{{ test_result.record.number }}"
+        state: closed
+      ignore_errors: true
+      register: result
+    - ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'close_code' in result.msg"
+          - "'close_notes' in result.msg"
 
 
-    # - name: Update change_request state to closed - check mode
-    #   servicenow.itsm.change_request: &update-change_request-state-closed
-    #     requested_by: admin
-    #     number: "{{ test_result.record.number }}"
-    #     state: closed
-    #     close_code: successful
-    #     close_notes: Done testing
-    #   check_mode: true
-    #   register: result
+    - name: Update change_request state to closed - check mode
+      servicenow.itsm.change_request: &update-change_request-state-closed
+        requested_by: admin
+        number: "{{ test_result.record.number }}"
+        state: closed
+        close_code: successful
+        close_notes: Done testing
+      check_mode: true
+      register: result
 
-    # - ansible.builtin.assert: &update-change_request-state-result-closed
-    #     that:
-    #       - result is changed
-    #       - result.record.state == "closed"
+    - ansible.builtin.assert: &update-change_request-state-result-closed
+        that:
+          - result is changed
+          - result.record.state == "closed"
 
 
-    # - name: Update change_request state to closed
-    #   servicenow.itsm.change_request: *update-change_request-state-closed
+    - name: Update change_request state to closed
+      servicenow.itsm.change_request: *update-change_request-state-closed
 
-    # - ansible.builtin.assert: *update-change_request-state-result-closed
+    - ansible.builtin.assert: *update-change_request-state-result-closed
 
 
-    # - name: Get change_request info by sysparm query - state and close_notes
-    #   servicenow.itsm.change_request_info:
-    #     query:
-    #      - state: = closed
-    #        close_notes: = Done testing
-    #   register: result
+    - name: Get change_request info by sysparm query - state and close_notes
+      servicenow.itsm.change_request_info:
+        query:
+         - state: = closed
+           close_notes: = Done testing
+      register: result
 
-    # - ansible.builtin.assert:
-    #     that:
-    #       - result.records[0].state == "closed"
-    #       - result.records[0].close_notes == "Done testing"
+    - ansible.builtin.assert:
+        that:
+          - result.records[0].state == "closed"
+          - result.records[0].close_notes == "Done testing"
 
 
-    # - name: Make sure change_request state was updated and is in closed state
-    #   servicenow.itsm.change_request_info:
-    #     number: "{{ test_result.record.number }}"
-    #   register: result
+    - name: Make sure change_request state was updated and is in closed state
+      servicenow.itsm.change_request_info:
+        number: "{{ test_result.record.number }}"
+      register: result
 
-    # - ansible.builtin.assert:
-    #     that:
-    #       - result.records[0].number == test_result.record.number
-    #       - result.records[0].state == "closed"
-    #       - result.records[0].close_code == "successful"
-    #       - result.records[0].close_notes == "Done testing"
-
+    - ansible.builtin.assert:
+        that:
+          - result.records[0].number == test_result.record.number
+          - result.records[0].state == "closed"
+          - result.records[0].close_code == "successful"
+          - result.records[0].close_notes == "Done testing"
+
 
-    # - name: Get specific change request info by sysparm query
-    #   servicenow.itsm.change_request_info:
-    #     query:
-    #      - number: = {{ test_result.record.number }}
-    #        state: = closed
-    #        close_code: = successful
-    #        close_notes: = Done testing
-    #   register: result
+    - name: Get specific change request info by sysparm query
+      servicenow.itsm.change_request_info:
+        query:
+         - number: = {{ test_result.record.number }}
+           state: = closed
+           close_code: = successful
+           close_notes: = Done testing
+      register: result
 
-    # - ansible.builtin.assert:
-    #     that:
-    #       - result.records | length == 1
-    #       - result.records[0].number == test_result.record.number
-    #       - result.records[0].state == "closed"
-    #       - result.records[0].close_code == "successful"
-    #       - result.records[0].close_notes == "Done testing"
+    - ansible.builtin.assert:
+        that:
+          - result.records | length == 1
+          - result.records[0].number == test_result.record.number
+          - result.records[0].state == "closed"
+          - result.records[0].close_code == "successful"
+          - result.records[0].close_notes == "Done testing"
 
 
-    # - name: Update change_request with same state - unchanged
-    #   servicenow.itsm.change_request: *update-change_request-state-closed
-    #   register: result
+    - name: Update change_request with same state - unchanged
+      servicenow.itsm.change_request: *update-change_request-state-closed
+      register: result
 
-    # - ansible.builtin.assert:
-    #     that:
-    #       - result is not changed
+    - ansible.builtin.assert:
+        that:
+          - result is not changed
 
-    # - name: Test bad parameter combinator (number + query)
-    #   servicenow.itsm.change_request_info:
-    #     number: "{{ test_result.record.number }}"
-    #     query:
-    #      - short_description: LIKE Oracle
-    #   ignore_errors: true
-    #   register: result
+    - name: Test bad parameter combinator (number + query)
+      servicenow.itsm.change_request_info:
+        number: "{{ test_result.record.number }}"
+        query:
+         - short_description: LIKE Oracle
+      ignore_errors: true
+      register: result
 
-    # - ansible.builtin.assert:
-    #     that:
-    #       - result is failed
-    #       - "'parameters are mutually exclusive: number|query' in result.msg"
+    - ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'parameters are mutually exclusive: number|query' in result.msg"
 
 
-    # - name: Test invalid operator detection
-    #   servicenow.itsm.change_request_info:
-    #     query:
-    #      - short_description: LIKEE Oracle
-    #   ignore_errors: true
-    #   register: result
+    - name: Test invalid operator detection
+      servicenow.itsm.change_request_info:
+        query:
+         - short_description: LIKEE Oracle
+      ignore_errors: true
+      register: result
 
-    # - ansible.builtin.assert:
-    #     that:
-    #       - result is failed
-    #       - "'Invalid condition' in result.msg"
+    - ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'Invalid condition' in result.msg"
 
 
-    # - name: Get change_request info by sysparm query - short_description
-    #   servicenow.itsm.change_request_info:
-    #     query:
-    #      - short_description: LIKE some
-    #   register: result
+    - name: Get change_request info by sysparm query - short_description
+      servicenow.itsm.change_request_info:
+        query:
+         - short_description: LIKE some
+      register: result
 
-    # - ansible.builtin.assert:
-    #     that:
-    #       - "'some' in result.records[0].short_description"
+    - ansible.builtin.assert:
+        that:
+          - "'some' in result.records[0].short_description"
 
 
-    # - name: Test unary operator with argument detection
-    #   servicenow.itsm.change_request_info:
-    #     query:
-    #      - short_description: ISEMPTY SAP
-    #   ignore_errors: true
-    #   register: result
+    - name: Test unary operator with argument detection
+      servicenow.itsm.change_request_info:
+        query:
+         - short_description: ISEMPTY SAP
+      ignore_errors: true
+      register: result
 
-    # - ansible.builtin.assert:
-    #     that:
-    #       - result is failed
-    #       - "'Operator ISEMPTY does not take any arguments' in result.msg"
+    - ansible.builtin.assert:
+        that:
+          - result is failed
+          - "'Operator ISEMPTY does not take any arguments' in result.msg"
 
 
-    # - name: Test sysparm query unary operator - short_description
-    #   servicenow.itsm.change_request_info:
-    #     query:
-    #      - short_description: ISNOTEMPTY
-    #   register: result
+    - name: Test sysparm query unary operator - short_description
+      servicenow.itsm.change_request_info:
+        query:
+         - short_description: ISNOTEMPTY
+      register: result
 
-    # - ansible.builtin.assert:
-    #     that:
-    #       - result.records[0].short_description != ""
+    - ansible.builtin.assert:
+        that:
+          - result.records[0].short_description != ""
 
-    # - name: Delete change_request - check mode
-    #   servicenow.itsm.change_request: &delete-change_request
-    #     requested_by: admin
-    #     number: "{{ test_result.record.number }}"
-    #     state: absent
-    #   check_mode: true
-    #   register: result
+    - name: Delete change_request - check mode
+      servicenow.itsm.change_request: &delete-change_request
+        requested_by: admin
+        number: "{{ test_result.record.number }}"
+        state: absent
+      check_mode: true
+      register: result
 
-    # - ansible.builtin.assert: &delete-change_request-result
-    #     that:
-    #       - result is changed
+    - ansible.builtin.assert: &delete-change_request-result
+        that:
+          - result is changed
 
 
-    # - name: Delete change_request
-    #   servicenow.itsm.change_request: *delete-change_request
+    - name: Delete change_request
+      servicenow.itsm.change_request: *delete-change_request
 
-    # - ansible.builtin.assert: *delete-change_request-result
+    - ansible.builtin.assert: *delete-change_request-result
 
 
-    # - name: Make sure change_request is absent
-    #   servicenow.itsm.change_request_info:
-    #     number: "{{ test_result.record.number }}"
-    #   register: result
+    - name: Make sure change_request is absent
+      servicenow.itsm.change_request_info:
+        number: "{{ test_result.record.number }}"
+      register: result
 
-    # - ansible.builtin.assert:
-    #     that:
-    #       - result.records | length == 0
+    - ansible.builtin.assert:
+        that:
+          - result.records | length == 0
 
 
-    # - name: Delete change_request - unchanged
-    #   servicenow.itsm.change_request: *delete-change_request
-    #   register: result
+    - name: Delete change_request - unchanged
+      servicenow.itsm.change_request: *delete-change_request
+      register: result
 
-    # - ansible.builtin.assert:
-    #     that:
-    #       - result is not changed
+    - ansible.builtin.assert:
+        that:
+          - result is not changed
 
 
     # Test closing the change_request with assignment_group sys_id
@@ -450,7 +445,6 @@
     - set_fact:
         instance: "py{{ ansible_facts.python.version.major }}.{{ ansible_facts.python.version.minor }}-ansible-{{ ansible_version.major }}.{{ ansible_version.minor }}"
 
-    - debug: var="{{ assignment_groups[instance] | default('network') }}"
     - debug: var=instance
 
     - name: Update test change_request to scheduled

--- a/tests/integration/targets/change_request_task/tasks/main.yml
+++ b/tests/integration/targets/change_request_task/tasks/main.yml
@@ -3,6 +3,21 @@
     SN_USERNAME: "{{ sn_username }}"
     SN_PASSWORD: "{{ sn_password }}"
 
+  vars:
+    assignment_groups:
+      py3.9-ansible-2.15: network
+      py3.10-ansible-2.15: software
+      py3.11-ansible-2.15: hardware
+      py3.12-ansible-2.15: IT Securities CAB
+      py3.9-ansible-2.16: Help Desk
+      py3.10-ansible-2.16: Openspace
+      py3.11-ansible-2.16: Problem Solving
+      py3.12-ansible-2.16: LDAP Admins
+      py3.9-ansible-2.18: IT Securities
+      py3.10-ansible-2.18: IT Finance CAB
+      py3.11-ansible-2.18: Network CAB Managers
+      py3.12-ansible-2.18: Service Desk
+
   block:
     - name: Create test change_request for referencing in change tasks
       servicenow.itsm.change_request: 
@@ -415,6 +430,10 @@
         that:
           - result is changed
 
+    # To avoid clashes between run we need to choose a new assignment_group for each python/ansible combination
+    - set_fact:
+        instance: "py{{ ansible_facts.python.version.major }}.{{ ansible_facts.python.version.minor }}-ansible-{{ ansible_version.major }}.{{ ansible_version.minor }}"
+
     # Test closing change request task with assignment_group_id
     - name: Create test change_request for referencing in change tasks closure test with assignment_group_id
       servicenow.itsm.change_request:
@@ -436,7 +455,7 @@
         change_request_number: "{{ change_request_result.record.number }}"
         type: planning
         state: open
-        assignment_group: Network
+        assignment_group: "{{ assignment_groups[instance] | default('network') }}"
         short_description: "{{ prefix }} Implement collision avoidance"
         description: "Implement collision avoidance based on the newly installed TOF sensor arrays."
         other:

--- a/tests/unit/plugins/module_utils/test_cmdb_relations.py
+++ b/tests/unit/plugins/module_utils/test_cmdb_relations.py
@@ -76,42 +76,6 @@ class TestCmdbRelation:
 
         assert relation1 == relation2
 
-    @pytest.mark.parametrize(
-        "input1,input2",
-        [
-            (
-                dict(
-                    sys_id="relation_id",
-                    type=dict(value="relation_sys_id", display_value="relation_name"),
-                    target=dict(value="target_id", display_value="target_name"),
-                ),
-                dict(
-                    sys_id="relation_id1",
-                    type=dict(value="relation_sys_id", display_value="relation_name"),
-                    target=dict(value="target_id", display_value="target_name"),
-                ),
-            ),
-            (
-                dict(
-                    sys_id=None,
-                    type=dict(value="relation_sys_id", display_value="relation_name"),
-                    target=dict(value="target_id", display_value="target_name"),
-                ),
-                dict(
-                    sys_id=None,
-                    type=dict(value="relation_sys_id", display_value="relation_name"),
-                    target=dict(value="another_target_id", display_value="target_name"),
-                ),
-            ),
-        ],
-    )
-    def test_not_equal(self, input1, input2):
-
-        relation1 = cmdb_relation.CmdbRelation(input1)
-        relation2 = cmdb_relation.CmdbRelation(input2)
-
-        assert relation1 != relation2
-
     def test_to_json(self):
         input = dict(
             sys_id="relation_id",

--- a/tests/unit/plugins/module_utils/test_cmdb_relations.py
+++ b/tests/unit/plugins/module_utils/test_cmdb_relations.py
@@ -103,23 +103,10 @@ class TestCmdbRelation:
                     target=dict(value="another_target_id", display_value="target_name"),
                 ),
             ),
-            (
-                dict(
-                    sys_id=None,
-                    type=dict(value="relation_sys_id", display_value="relation_name"),
-                    target=dict(value="target_id", display_value="target_name"),
-                ),
-                dict(
-                    sys_id=None,
-                    type=dict(
-                        value="another_relation_sys_id", display_value="relation_name"
-                    ),
-                    target=dict(value="target_id", display_value="target_name"),
-                ),
-            ),
         ],
     )
     def test_not_equal(self, input1, input2):
+
         relation1 = cmdb_relation.CmdbRelation(input1)
         relation2 = cmdb_relation.CmdbRelation(input2)
 

--- a/tests/unit/plugins/module_utils/test_cmdb_relations.py
+++ b/tests/unit/plugins/module_utils/test_cmdb_relations.py
@@ -76,6 +76,56 @@ class TestCmdbRelation:
 
         assert relation1 == relation2
 
+    @pytest.mark.parametrize(
+        "input1,input2",
+        [
+            (
+                dict(
+                    sys_id="relation_id",
+                    type=dict(value="relation_sys_id", display_value="relation_name"),
+                    target=dict(value="target_id", display_value="target_name"),
+                ),
+                dict(
+                    sys_id="relation_id1",
+                    type=dict(value="relation_sys_id", display_value="relation_name"),
+                    target=dict(value="target_id", display_value="target_name"),
+                ),
+            ),
+            (
+                dict(
+                    sys_id=None,
+                    type=dict(value="relation_sys_id", display_value="relation_name"),
+                    target=dict(value="target_id", display_value="target_name"),
+                ),
+                dict(
+                    sys_id=None,
+                    type=dict(value="relation_sys_id", display_value="relation_name"),
+                    target=dict(value="another_target_id", display_value="target_name"),
+                ),
+            ),
+            (
+                dict(
+                    sys_id=None,
+                    type=dict(value="relation_sys_id", display_value="relation_name"),
+                    target=dict(value="target_id", display_value="target_name"),
+                ),
+                dict(
+                    sys_id=None,
+                    type=dict(
+                        value="another_relation_sys_id", display_value="relation_name"
+                    ),
+                    target=dict(value="target_id", display_value="target_name"),
+                ),
+            ),
+        ],
+    )
+    def test_not_equal(self, input1, input2):
+
+        relation1 = cmdb_relation.CmdbRelation(input1)
+        relation2 = cmdb_relation.CmdbRelation(input2)
+
+        assert relation1 != relation2
+
     def test_to_json(self):
         input = dict(
             sys_id="relation_id",

--- a/tests/unit/plugins/module_utils/test_cmdb_relations.py
+++ b/tests/unit/plugins/module_utils/test_cmdb_relations.py
@@ -120,7 +120,6 @@ class TestCmdbRelation:
         ],
     )
     def test_not_equal(self, input1, input2):
-
         relation1 = cmdb_relation.CmdbRelation(input1)
         relation2 = cmdb_relation.CmdbRelation(input2)
 


### PR DESCRIPTION
Tests fail because multiple parallel executions use the same assignement_group on the same instance.


##### ISSUE TYPE
- Bugfix Pull Request