### PR TITLE
New module: service_catalog_info - to retrieve information about service catalog along with categories and items

### DIFF
--- a/.github/workflows/integration_source.yml
+++ b/.github/workflows/integration_source.yml
@@ -183,3 +183,7 @@ jobs:
       - name: Run configuration_item_relations integration tests
         run: ansible-test integration configuration_item_relations
         working-directory: ${{ steps.identify.outputs.collection_path }}
+      
+      - name: Run service_catalog_info integration tests
+        run: ansible-test integration service_catalog_info
+        working-directory: ${{ steps.identify.outputs.collection_path }}

--- a/changelogs/fragments/service_catalog_info.yml
+++ b/changelogs/fragments/service_catalog_info.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - service_catalog_info - add service catalog info plugin (https://github.com/ansible-collections/servicenow.itsm/pull/342)

--- a/changelogs/fragments/service_catalog_info.yml
+++ b/changelogs/fragments/service_catalog_info.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - service_catalog_info - add service catalog info plugin (https://github.com/ansible-collections/servicenow.itsm/pull/342)

--- a/plugins/module_utils/service_catalog.py
+++ b/plugins/module_utils/service_catalog.py
@@ -88,7 +88,7 @@ class Catalog(ServiceCatalogObject):
     def to_ansible(self):
         self.data["categories"] = self.categories
         self.data["items"] = self.items
-        return super().to_ansible()
+        return super(Catalog, self).to_ansible()
 
 
 class Category(ServiceCatalogObject):
@@ -106,7 +106,7 @@ class Category(ServiceCatalogObject):
 
 class Item(ServiceCatalogObject):
     DISPLAY_FIELDS = ["sys_id", "short_description", "description",
-                      "availabiltiy", "mandatory_attachment", "request_method",
+                      "availability", "mandatory_attachment", "request_method",
                       "type", "sys_class_name", "catalogs", "name", "category", "order",
                       "categories", "variables"]
 

--- a/plugins/module_utils/service_catalog.py
+++ b/plugins/module_utils/service_catalog.py
@@ -45,12 +45,6 @@ class ServiceCatalogObject(object):
                 ansible_data[key] = self.data[key]
         return ansible_data
 
-    def valid(self):
-        for key in self.MANDATORY_FIELS:
-            if key not in self.data or not self.data[key]:
-                return False
-        return True
-
     @property
     def sys_id(self):
         return self.data["sys_id"] if "sys_id" in self.data else ""
@@ -59,7 +53,6 @@ class ServiceCatalogObject(object):
 class Catalog(ServiceCatalogObject):
     DISPLAY_FIELDS = ["sys_id", "description", "title",
                       "has_categories", "has_items", "categories", "sn_items"]
-    MANDATORY_FIELS = ["sys_id"]
 
     def __init__(self, data=None):
         if not data:
@@ -100,8 +93,6 @@ class Category(ServiceCatalogObject):
             self.data = dict()
         else:
             self.data = data
-        self.data = data
-        self.data = data
 
 
 class Item(ServiceCatalogObject):
@@ -115,7 +106,6 @@ class Item(ServiceCatalogObject):
             self.data = dict()
         else:
             self.data = data
-        self.data = data
 
 
 class ServiceCatalogClient(object):
@@ -150,7 +140,7 @@ class ServiceCatalogClient(object):
             "/".join([SN_BASE_PATH, "catalogs", catalog_id, "categories"]))
         if records:
             return [Category(record) for record in records]
-        return dict()
+        return []
 
     def get_items(self, catalog_id, query=None, batch_size=1000):
         """Returns the list of all items of the catalog `catalog_id`"""
@@ -164,7 +154,7 @@ class ServiceCatalogClient(object):
             "/".join([SN_BASE_PATH, "items"]), _query)
         if records:
             return [Item(record) for record in records]
-        return dict()
+        return []
 
     def get_item(self, id):
         if not id:

--- a/plugins/module_utils/service_catalog.py
+++ b/plugins/module_utils/service_catalog.py
@@ -58,7 +58,7 @@ class ServiceCatalogObject(object):
 
 class Catalog(ServiceCatalogObject):
     DISPLAY_FIELDS = ["sys_id", "description", "title",
-                      "has_categories", "has_items", "categories", "items"]
+                      "has_categories", "has_items", "categories", "sn_items"]
     MANDATORY_FIELS = ["sys_id"]
 
     def __init__(self, data=None):
@@ -87,7 +87,7 @@ class Catalog(ServiceCatalogObject):
 
     def to_ansible(self):
         self.data["categories"] = self.categories
-        self.data["items"] = self.items
+        self.data["sn_items"] = self.items
         return super(Catalog, self).to_ansible()
 
 

--- a/plugins/module_utils/service_catalog.py
+++ b/plugins/module_utils/service_catalog.py
@@ -34,7 +34,7 @@ class ServiceCatalogObject(object):
                 if isinstance(self.data[key], ServiceCatalogObject):
                     ansible_data[key] = self.data[key].to_ansible()
                     continue
-                if type(self.data[key]) is list:
+                if isinstance(self.data[key], list):
                     ansible_data[key] = []
                     for item in self.data[key]:
                         if isinstance(item, ServiceCatalogObject):

--- a/plugins/module_utils/service_catalog.py
+++ b/plugins/module_utils/service_catalog.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright: (c) 2024, Red Hat
+# Copyright: 2024, Contributors to the Ansible project
 #
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 

--- a/plugins/module_utils/service_catalog.py
+++ b/plugins/module_utils/service_catalog.py
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2024, Red Hat
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+SN_BASE_PATH = "api/sn_sc/servicecatalog"
+
+
+class ItemContent(object):
+    FULL = 1
+    BRIEF = 2
+    NONE = 3
+
+    @classmethod
+    def from_str(self, s):
+        if s == "full":
+            return ItemContent.FULL
+        if s == "brief":
+            return ItemContent.BRIEF
+        return ItemContent.NONE
+
+
+class ServiceCatalogObject(object):
+    def to_ansible(self):
+        """Filters out the fields which we don't want to return like `header_icon`"""
+        ansible_data = dict()
+        for key in self.DISPLAY_FIELDS:
+            if key in self.data:
+                if isinstance(self.data[key], ServiceCatalogObject):
+                    ansible_data[key] = self.data[key].to_ansible()
+                    continue
+                if type(self.data[key]) is list:
+                    ansible_data[key] = []
+                    for item in self.data[key]:
+                        if isinstance(item, ServiceCatalogObject):
+                            ansible_data[key].append(item.to_ansible())
+                        else:
+                            ansible_data[key].append(item)
+                    continue
+                ansible_data[key] = self.data[key]
+        return ansible_data
+
+    def valid(self):
+        for key in self.MANDATORY_FIELS:
+            if key not in self.data or not self.data[key]:
+                return False
+        return True
+
+    @property
+    def sys_id(self):
+        return self.data["sys_id"] if "sys_id" in self.data else ""
+
+
+class Catalog(ServiceCatalogObject):
+    DISPLAY_FIELDS = ["sys_id", "description", "title",
+                      "has_categories", "has_items", "categories", "items"]
+    MANDATORY_FIELS = ["sys_id"]
+
+    def __init__(self, data=dict()):
+        self.data = data
+        self._categories = []
+        self._items = []
+
+    @property
+    def categories(self):
+        return self._categories
+
+    @categories.setter
+    def categories(self, categories):
+        self._categories = categories
+
+    @property
+    def items(self):
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        self._items = items
+
+    def to_ansible(self):
+        self.data["categories"] = self.categories
+        self.data["items"] = self.items
+        return super().to_ansible()
+
+
+class Category(ServiceCatalogObject):
+    DISPLAY_FIELDS = ["sys_id", "description", "title",
+                      "full_description", "subcategories"]
+
+    def __init__(self, data=dict()):
+        self.data = data
+
+
+class Item(ServiceCatalogObject):
+    DISPLAY_FIELDS = ["sys_id", "short_description", "description",
+                      "availabiltiy", "mandatory_attachment", "request_method",
+                      "type", "sys_class_name", "catalogs", "name", "category", "order",
+                      "categories", "variables"]
+
+    def __init__(self, data=dict()):
+        self.data = data
+
+
+class ServiceCatalogClient(object):
+    """Wraps the generic client with Service Catalog specific methods"""
+
+    def __init__(self, generic_client):
+        if not generic_client:
+            raise ValueError("generic client cannot be none")
+        self.generic_client = generic_client
+
+    def get_catalogs(self):
+        """Returns the list of all catalogs"""
+        records = self.generic_client.list_records("/".join([SN_BASE_PATH, "catalogs"]))
+        if records:
+            return [Catalog(record) for record in records]
+        return []
+
+    def get_catalog(self, id):
+        """Returns the catalog identified by id"""
+        if not id:
+            raise ValueError("catalog sys_id is missing")
+        record = self.generic_client.get_record_by_sys_id("/".join([SN_BASE_PATH, "catalogs"]), id)
+        if record:
+            return Catalog(record)
+        return None
+
+    def get_categories(self, catalog_id):
+        """Returns the list of all categories of the catalog `catalog_id`"""
+        if not id:
+            raise ValueError("catalog sys_id is missing")
+        records = self.generic_client.list_records(
+            "/".join([SN_BASE_PATH, "catalogs", catalog_id, "categories"]))
+        if records:
+            return [Category(record) for record in records]
+        return dict()
+
+    def get_items(self, catalog_id, query=None, batch_size=1000):
+        """Returns the list of all items of the catalog `catalog_id`"""
+        if not id:
+            raise ValueError("catalog sys_id is missing")
+        _query = dict(sysparm_catalog=catalog_id)
+        if query:
+            _query.update(query)
+        self.generic_client.batch_size = batch_size
+        records = self.generic_client.list_records(
+            "/".join([SN_BASE_PATH, "items"]), _query)
+        if records:
+            return [Item(record) for record in records]
+        return dict()
+
+    def get_item(self, id):
+        if not id:
+            raise ValueError("item sys_id is missing")
+        return Item(self.generic_client.get_record_by_sys_id("/".join([SN_BASE_PATH, "items"]), id))
+
+

--- a/plugins/module_utils/service_catalog.py
+++ b/plugins/module_utils/service_catalog.py
@@ -17,7 +17,7 @@ class ItemContent(object):
     NONE = 3
 
     @classmethod
-    def from_str(self, s):
+    def from_str(cls, s):
         if s == "full":
             return ItemContent.FULL
         if s == "brief":
@@ -61,8 +61,11 @@ class Catalog(ServiceCatalogObject):
                       "has_categories", "has_items", "categories", "items"]
     MANDATORY_FIELS = ["sys_id"]
 
-    def __init__(self, data=dict()):
-        self.data = data
+    def __init__(self, data=None):
+        if not data:
+            self.data = dict()
+        else:
+            self.data = data
         self._categories = []
         self._items = []
 
@@ -92,7 +95,12 @@ class Category(ServiceCatalogObject):
     DISPLAY_FIELDS = ["sys_id", "description", "title",
                       "full_description", "subcategories"]
 
-    def __init__(self, data=dict()):
+    def __init__(self, data=None):
+        if not data:
+            self.data = dict()
+        else:
+            self.data = data
+        self.data = data
         self.data = data
 
 
@@ -102,7 +110,11 @@ class Item(ServiceCatalogObject):
                       "type", "sys_class_name", "catalogs", "name", "category", "order",
                       "categories", "variables"]
 
-    def __init__(self, data=dict()):
+    def __init__(self, data=None):
+        if not data:
+            self.data = dict()
+        else:
+            self.data = data
         self.data = data
 
 
@@ -158,5 +170,3 @@ class ServiceCatalogClient(object):
         if not id:
             raise ValueError("item sys_id is missing")
         return Item(self.generic_client.get_record_by_sys_id("/".join([SN_BASE_PATH, "items"]), id))
-
-

--- a/plugins/modules/service_catalog_info.py
+++ b/plugins/modules/service_catalog_info.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 
 
 DOCUMENTATION = r"""
-module: configuration_item_relations
+module: service_catalog_info
 
 author:
   - Cosmin Tupangiu (@tupyy)
@@ -51,6 +51,7 @@ options:
          - Query for item content
          - For more information, please refer to
            U(https://developer.servicenow.com/dev.do#!/reference/api/utah/rest/c_ServiceCatalogAPI#servicecat-GET-items)
+        type: str
 """
 
 EXAMPLES = r"""
@@ -104,66 +105,67 @@ records:
   description:
     - List of catalogs.
   returned: success
-  type: List
+  type: list
   sample:
-    "records": [
-    {
-        "categories": [
-            {
-                "description": "Datacenter hardware and services to the support business\n\t\t\tsystems.\n\t\t",
-                "full_description": null,
-                "subcategories": [
-                    {
-                        "sys_id": "d67c446ec0a80165000335aa37eafbc1",
-                        "title": "Services"
-                    }
-                ],
-                "sys_id": "803e95e1c3732100fca206e939ba8f2a",
-                "title": "Infrastructure"
-            },
-            {
-                "description": "Request for IT services to be performed",
-                "full_description": null,
-                "subcategories": [],
-                "sys_id": "d67c446ec0a80165000335aa37eafbc1",
-                "title": "Services"
-            }
-        ],
-        "description": "Products and services for the IT department",
-        "has_categories": true,
-        "has_items": true,
-        "items": [
-            {
-                "catalogs": [
-                    {
-                        "active": true,
-                        "sys_id": "e0d08b13c3330100c8b837659bba8fb4",
-                        "title": "Service Catalog"
-                    },
-                    {
-                        "active": true,
-                        "sys_id": "742ce428d7211100f2d224837e61036d",
-                        "title": "Technical Catalog"
-                    }
-                ],
-                "category": {
-                    "sys_id": "e15706fc0a0a0aa7007fc21e1ab70c2f",
-                    "title": "Can We Help You?"
-                },
-                "description": "<p>Here you can request a new Knowledge Base to be used. A Knowledge Base can be used to store Knowledge in an organization and anyone can request for a new one to be created.</p>",
-                "mandatory_attachment": false,
-                "name": "Request Knowledge Base",
-                "order": 0,
-                "request_method": "",
-                "short_description": "Request for a Knowledge Base",
-                "sys_class_name": "sc_cat_item_producer",
-                "sys_id": "81c887819f203100d8f8700c267fcfb5",
-                "type": "record_producer"
-            },
-        ],
-        "sys_id": "742ce428d7211100f2d224837e61036d",
-        "title": "Technical Catalog"
-    }]
+    [
+      {
+      "categories": [
+          {
+              "description": "Datacenter hardware and services to the support business\n\t\t\tsystems.\n\t\t",
+              "full_description": null,
+              "subcategories": [
+                  {
+                      "sys_id": "d67c446ec0a80165000335aa37eafbc1",
+                      "title": "Services"
+                  }
+              ],
+              "sys_id": "803e95e1c3732100fca206e939ba8f2a",
+              "title": "Infrastructure"
+          },
+          {
+              "description": "Request for IT services to be performed",
+              "full_description": null,
+              "subcategories": [],
+              "sys_id": "d67c446ec0a80165000335aa37eafbc1",
+              "title": "Services"
+          }
+      ],
+      "description": "Products and services for the IT department",
+      "has_categories": true,
+      "has_items": true,
+      "items": [
+          {
+              "catalogs": [
+                  {
+                      "active": true,
+                      "sys_id": "e0d08b13c3330100c8b837659bba8fb4",
+                      "title": "Service Catalog"
+                  },
+                  {
+                      "active": true,
+                      "sys_id": "742ce428d7211100f2d224837e61036d",
+                      "title": "Technical Catalog"
+                  }
+              ],
+              "category": {
+                  "sys_id": "e15706fc0a0a0aa7007fc21e1ab70c2f",
+                  "title": "Can We Help You?"
+              },
+              "description": "<p>Some description</p>",
+              "mandatory_attachment": false,
+              "name": "Request Knowledge Base",
+              "order": 0,
+              "request_method": "",
+              "short_description": "Request for a Knowledge Base",
+              "sys_class_name": "sc_cat_item_producer",
+              "sys_id": "81c887819f203100d8f8700c267fcfb5",
+              "type": "record_producer"
+          },
+      ],
+      "sys_id": "742ce428d7211100f2d224837e61036d",
+      "title": "Technical Catalog"
+      }
+    ]
 """
 
 from ..module_utils import arguments, client, errors, generic
@@ -248,22 +250,20 @@ def main():
         ),
         items=dict(
             type="dict",
-            suboptions=dict(
-                type="dict",
-                options=dict(
-                    content=dict(
-                        type="str",
-                        choices=["brief", "full"],
-                        required=True
-                    ),
-                    query=dict(type="str")
-                )
+            options=dict(
+                content=dict(
+                    type="str",
+                    choices=["brief", "full"],
+                    required=True
+                ),
+                query=dict(type="str")
             )
         ),
     )
 
     module = AnsibleModule(
         argument_spec=module_args,
+        supports_check_mode=True,
     )
 
     try:

--- a/plugins/modules/service_catalog_info.py
+++ b/plugins/modules/service_catalog_info.py
@@ -176,19 +176,19 @@ def get_catalog_info(sc_client, catalog, with_categories=True, with_items=ItemCo
 
 def validate_params(params):
     missing = []
-    if "items" in params and "content" not in params["items"]:
-        missing.append(
-            'Missing required subparameter "content" of "items" paramter')
+    if "items" in params:
+        if "content" not in params["items"]:
+            missing.append(
+                'Missing required subparameter "content" of "items" paramter')
+        elif not params["items"]["content"]:
+            missing.append(
+                'Missing value for required subparameter "content" of "items"')
+        if "query" in params["items"] and not params["items"]["query"]:
+            missing.append('Missing value for "query" subparameter of "items"')
 
-    if not params["items"]["content"]:
+    if "sys_id" in params and not params["sys_id"]:
         missing.append(
-            'Missing value for required subparameter "content" of "items"')
-    elif params["items"]["content"] not in ("brief", "full"):
-        missing.append(
-            'Unknown value {0} for required subparameter "content" of "items"'.format(params["items"]["content"]))
-
-    if "query" in params["items"] and not params["items"]["query"]:
-        missing.extend('Missing value for "query" subparameter of "items"')
+            'Missing value for "sys_id"')
 
     if missing:
         raise errors.ServiceNowError(
@@ -200,12 +200,12 @@ def run(module, sc_client):
     validate_params(module.params)
 
     item_information = ItemContent.NONE
-    if module.params["items"]:
+    if "items" in module.params:
         item_information = ItemContent.from_str(module.params["items"]["content"])
 
     fetch_categories = module.params["categories"]
 
-    if module.params["sys_id"]:
+    if "sys_id" in module.params:
         catalog = get_catalog_info(
             sc_client,
             sc_client.get_catalog(module.params["sys_id"]),
@@ -240,7 +240,7 @@ def main():
                     choices=["brief", "full"],
                     required=True
                 ),
-                query=dict(type="str")
+                query=dict(type="str"),
             )
         ),
     )

--- a/plugins/modules/service_catalog_info.py
+++ b/plugins/modules/service_catalog_info.py
@@ -1,0 +1,280 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2024, Red Hat
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+DOCUMENTATION = r"""
+module: configuration_item_relations
+
+author:
+  - Cosmin Tupangiu (@tupyy)
+
+short_description: List ServiceNow service catalogs along with categories and items
+
+description:
+  - Retrive information about ServiceCatalogs
+  - For more information, refer to ServiceNow service catalog documentation at
+    U(https://developer.servicenow.com/dev.do#!/reference/api/tokyo/rest/c_ServiceCatalogAPI)
+
+version_added: 2.6.0
+
+extends_documentation_fragment:
+  - servicenow.itsm.instance
+  - servicenow.itsm.sys_id.info
+
+options:
+  categories:
+    description:
+      - If true the cateogies will be fetched from SN
+    type: bool
+  items:
+    description:
+      - List of options for fetching service catalog items.
+      - If set the items for each catalog will be fetched.
+    type: dict
+    suboptions:
+      content:
+        description:
+         - Content type of the item
+         - Set to full if the whole item will be fetched
+        type: str
+        choices: [full, brief]
+        required: true
+      query:
+        description:
+         - Query for item content
+         - For more information, please refer to
+           U(https://developer.servicenow.com/dev.do#!/reference/api/utah/rest/c_ServiceCatalogAPI#servicecat-GET-items)
+"""
+
+EXAMPLES = r"""
+- name: Return all catalogs without categories but with items (brief information)
+  servicenow.itsm.service_catalog_info:
+    instance:
+      host: "{{ sn_host }}"
+      username: "{{ sn_username }}"
+      password: "{{ sn_password }}"
+    categories: false
+    items:
+      content: brief
+
+- name: Return service catalog without categories but with items (brief information)
+  servicenow.itsm.service_catalog_info:
+    instance:
+      host: "{{ sn_host }}"
+      username: "{{ sn_username }}"
+      password: "{{ sn_password }}"
+    sys_id: "{{ service_catalog.sys_id }}"
+    categories: false
+    items:
+      content: brief
+
+- name: Return service catalog with categories and with items (full information)
+  servicenow.itsm.service_catalog_info:
+    instance:
+      host: "{{ sn_host }}"
+      username: "{{ sn_username }}"
+      password: "{{ sn_password }}"
+    sys_id: "{{ service_catalog.sys_id }}"
+    categories: true
+    items:
+      content: full
+
+- name: Return service catalog with categories and with all items containing word "iPhone"
+  servicenow.itsm.service_catalog_info:
+    instance:
+      host: "{{ sn_host }}"
+      username: "{{ sn_username }}"
+      password: "{{ sn_password }}"
+    sys_id: "{{ service_catalog.sys_id }}"
+    categories: true
+    items:
+      content: full
+      query: iPhone
+"""
+
+RETURN = r"""
+records:
+  description:
+    - List of catalogs.
+  returned: success
+  type: List
+  sample:
+    "records": [
+    {
+        "categories": [
+            {
+                "description": "Datacenter hardware and services to the support business\n\t\t\tsystems.\n\t\t",
+                "full_description": null,
+                "subcategories": [
+                    {
+                        "sys_id": "d67c446ec0a80165000335aa37eafbc1",
+                        "title": "Services"
+                    }
+                ],
+                "sys_id": "803e95e1c3732100fca206e939ba8f2a",
+                "title": "Infrastructure"
+            },
+            {
+                "description": "Request for IT services to be performed",
+                "full_description": null,
+                "subcategories": [],
+                "sys_id": "d67c446ec0a80165000335aa37eafbc1",
+                "title": "Services"
+            }
+        ],
+        "description": "Products and services for the IT department",
+        "has_categories": true,
+        "has_items": true,
+        "items": [
+            {
+                "catalogs": [
+                    {
+                        "active": true,
+                        "sys_id": "e0d08b13c3330100c8b837659bba8fb4",
+                        "title": "Service Catalog"
+                    },
+                    {
+                        "active": true,
+                        "sys_id": "742ce428d7211100f2d224837e61036d",
+                        "title": "Technical Catalog"
+                    }
+                ],
+                "category": {
+                    "sys_id": "e15706fc0a0a0aa7007fc21e1ab70c2f",
+                    "title": "Can We Help You?"
+                },
+                "description": "<p>Here you can request a new Knowledge Base to be used. A Knowledge Base can be used to store Knowledge in an organization and anyone can request for a new one to be created.</p>",
+                "mandatory_attachment": false,
+                "name": "Request Knowledge Base",
+                "order": 0,
+                "request_method": "",
+                "short_description": "Request for a Knowledge Base",
+                "sys_class_name": "sc_cat_item_producer",
+                "sys_id": "81c887819f203100d8f8700c267fcfb5",
+                "type": "record_producer"
+            },
+        ],
+        "sys_id": "742ce428d7211100f2d224837e61036d",
+        "title": "Technical Catalog"
+    }]
+"""
+
+from ..module_utils import arguments, client, errors, generic
+from ..module_utils.service_catalog import ItemContent, ServiceCatalogClient
+from ansible.module_utils.basic import AnsibleModule
+
+
+def get_catalog_info(sc_client, catalog, with_categories=True, with_items=ItemContent.BRIEF):
+    if with_categories:
+        catalog.categories = sc_client.get_categories(catalog.sys_id)
+
+    if with_items == ItemContent.NONE:
+        return catalog
+
+    items = sc_client.get_items(catalog.sys_id)
+    if with_items == ItemContent.BRIEF:
+        catalog.items = items
+        return catalog
+
+    catalog.items = [sc_client.get_item(item.sys_id) for item in items]
+
+    return catalog
+
+
+def validate_params(params):
+    missing = []
+    if "items" in params and "content" not in params["items"]:
+        missing.append(
+            'Missing required subparameter "content" of "items" paramter')
+
+    if not params["items"]["content"]:
+        missing.append(
+            'Missing value for required subparameter "content" of "items"')
+    elif params["items"]["content"] not in ("brief", "full"):
+        missing.append(
+            'Unknown value {0} for required subparameter "content" of "items"'.format(params["items"]["content"]))
+
+    if "query" in params["items"] and not params["items"]["query"]:
+        missing.extend('Missing value for "query" subparameter of "items"')
+
+    if missing:
+        raise errors.ServiceNowError(
+            "Missing required paramters: {0}". format(", ".join(missing))
+        )
+
+
+def run(module, sc_client):
+    validate_params(module.params)
+
+    item_information = ItemContent.NONE
+    if module.params["items"]:
+        item_information = ItemContent.from_str(module.params["items"]["content"])
+
+    fetch_categories = module.params["categories"]
+
+    if module.params["sys_id"]:
+        catalog = get_catalog_info(
+            sc_client,
+            sc_client.get_catalog(module.params["sys_id"]),
+            fetch_categories,
+            item_information
+        )
+        return [catalog.to_ansible()]
+
+    # fetch all catalogs
+    catalogs = []
+    for catalog in sc_client.get_catalogs():
+        catalog = get_catalog_info(sc_client, catalog, fetch_categories, item_information)
+        catalogs.append(catalog.to_ansible())
+
+    return catalogs
+
+
+def main():
+    module_args = dict(
+        arguments.get_spec(
+            "instance",
+            "sys_id",
+        ),
+        categories=dict(
+            type="bool",
+        ),
+        items=dict(
+            type="dict",
+            suboptions=dict(
+                type="dict",
+                options=dict(
+                    content=dict(
+                        type="str",
+                        choices=["brief", "full"],
+                        required=True
+                    ),
+                    query=dict(type="str")
+                )
+            )
+        ),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+    )
+
+    try:
+        snow_client = client.Client(**module.params["instance"])
+        generic_client = generic.GenericClient(snow_client)
+        sc_client = ServiceCatalogClient(generic_client)
+        records = run(module, sc_client)
+        module.exit_json(changed=False, records=records)
+    except errors.ServiceNowError as e:
+        module.fail_json(msg=str(e))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/service_catalog_info.py
+++ b/plugins/modules/service_catalog_info.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright: (c) 2024, Red Hat
+# Copyright: 2024, Contributors to the Ansible project
 #
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -18,9 +18,9 @@ author:
 short_description: List ServiceNow service catalogs along with categories and items
 
 description:
-  - Retrive information about ServiceCatalogs
+  - Retrieve information about ServiceCatalogs.
   - For more information, refer to ServiceNow service catalog documentation at
-    U(https://developer.servicenow.com/dev.do#!/reference/api/tokyo/rest/c_ServiceCatalogAPI)
+    U(https://developer.servicenow.com/dev.do#!/reference/api/utah/rest/c_ServiceCatalogAPI)
 
 version_added: 2.6.0
 
@@ -31,7 +31,7 @@ extends_documentation_fragment:
 options:
   categories:
     description:
-      - If true the cateogies will be fetched from SN
+      - If set to V(true), the categories will be fetched from ServiceNow.
     type: bool
   items:
     description:
@@ -41,14 +41,14 @@ options:
     suboptions:
       content:
         description:
-         - Content type of the item
-         - Set to full if the whole item will be fetched
+         - Content type of the item.
+         - Set to V(full), if the whole item will be fetched.
         type: str
         choices: [full, brief]
         required: true
       query:
         description:
-         - Query for item content
+         - Query for the item content.
          - For more information, please refer to
            U(https://developer.servicenow.com/dev.do#!/reference/api/utah/rest/c_ServiceCatalogAPI#servicecat-GET-items)
         type: str
@@ -57,20 +57,12 @@ options:
 EXAMPLES = r"""
 - name: Return all catalogs without categories but with items (brief information)
   servicenow.itsm.service_catalog_info:
-    instance:
-      host: "{{ sn_host }}"
-      username: "{{ sn_username }}"
-      password: "{{ sn_password }}"
     categories: false
     items:
       content: brief
 
 - name: Return service catalog without categories but with items (brief information)
   servicenow.itsm.service_catalog_info:
-    instance:
-      host: "{{ sn_host }}"
-      username: "{{ sn_username }}"
-      password: "{{ sn_password }}"
     sys_id: "{{ service_catalog.sys_id }}"
     categories: false
     items:
@@ -78,10 +70,6 @@ EXAMPLES = r"""
 
 - name: Return service catalog with categories and with items (full information)
   servicenow.itsm.service_catalog_info:
-    instance:
-      host: "{{ sn_host }}"
-      username: "{{ sn_username }}"
-      password: "{{ sn_password }}"
     sys_id: "{{ service_catalog.sys_id }}"
     categories: true
     items:
@@ -89,10 +77,6 @@ EXAMPLES = r"""
 
 - name: Return service catalog with categories and with all items containing word "iPhone"
   servicenow.itsm.service_catalog_info:
-    instance:
-      host: "{{ sn_host }}"
-      username: "{{ sn_username }}"
-      password: "{{ sn_password }}"
     sys_id: "{{ service_catalog.sys_id }}"
     categories: true
     items:

--- a/plugins/modules/service_catalog_info.py
+++ b/plugins/modules/service_catalog_info.py
@@ -33,55 +33,46 @@ options:
     description:
       - If set to V(true), the categories will be fetched from ServiceNow.
     type: bool
-  items:
+    default: False
+  items_info:
     description:
       - List of options for fetching service catalog items.
-      - If set the items for each catalog will be fetched.
-    type: dict
-    suboptions:
-      content:
-        description:
-         - Content type of the item.
-         - Set to V(full), if the whole item will be fetched.
-        type: str
-        choices: [full, brief]
-        required: true
-      query:
-        description:
-         - Query for the item content.
-         - For more information, please refer to
-           U(https://developer.servicenow.com/dev.do#!/reference/api/utah/rest/c_ServiceCatalogAPI#servicecat-GET-items)
-        type: str
+      - Set to V(full), if the whole item will be fetched.
+    type: str
+    choices: [full, brief, none]
+    default: none
+  items_query:
+    description:
+      - Query for the item content.
+      - For more information, please refer to
+        U(https://developer.servicenow.com/dev.do#!/reference/api/utah/rest/c_ServiceCatalogAPI#servicecat-GET-items)
+    type: str
 """
 
 EXAMPLES = r"""
 - name: Return all catalogs without categories but with items (brief information)
   servicenow.itsm.service_catalog_info:
     categories: false
-    items:
-      content: brief
+    items_info: brief
 
 - name: Return service catalog without categories but with items (brief information)
   servicenow.itsm.service_catalog_info:
     sys_id: "{{ service_catalog.sys_id }}"
     categories: false
-    items:
-      content: brief
+    items_info: full
 
 - name: Return service catalog with categories and with items (full information)
   servicenow.itsm.service_catalog_info:
     sys_id: "{{ service_catalog.sys_id }}"
     categories: true
-    items:
-      content: full
+    items_info: full
 
 - name: Return service catalog with categories and with all items containing word "iPhone"
   servicenow.itsm.service_catalog_info:
     sys_id: "{{ service_catalog.sys_id }}"
     categories: true
-    items:
-      content: full
-      query: iPhone
+    items_info: full
+    items_query: iPhone
 """
 
 RETURN = r"""
@@ -174,38 +165,12 @@ def get_catalog_info(sc_client, catalog, with_categories=True, with_items=ItemCo
     return catalog
 
 
-def validate_params(params):
-    missing = []
-    if "items" in params:
-        if "content" not in params["items"]:
-            missing.append(
-                'Missing required subparameter "content" of "items" paramter')
-        elif not params["items"]["content"]:
-            missing.append(
-                'Missing value for required subparameter "content" of "items"')
-        if "query" in params["items"] and not params["items"]["query"]:
-            missing.append('Missing value for "query" subparameter of "items"')
-
-    if "sys_id" in params and not params["sys_id"]:
-        missing.append(
-            'Missing value for "sys_id"')
-
-    if missing:
-        raise errors.ServiceNowError(
-            "Missing required paramters: {0}". format(", ".join(missing))
-        )
-
-
 def run(module, sc_client):
-    validate_params(module.params)
-
-    item_information = ItemContent.NONE
-    if "items" in module.params:
-        item_information = ItemContent.from_str(module.params["items"]["content"])
+    item_information = ItemContent.from_str(module.params["items_info"])
 
     fetch_categories = module.params["categories"]
 
-    if "sys_id" in module.params:
+    if "sys_id" in module.params and module.params["sys_id"]:
         catalog = get_catalog_info(
             sc_client,
             sc_client.get_catalog(module.params["sys_id"]),
@@ -231,18 +196,14 @@ def main():
         ),
         categories=dict(
             type="bool",
+            default=False,
         ),
-        items=dict(
-            type="dict",
-            options=dict(
-                content=dict(
-                    type="str",
-                    choices=["brief", "full"],
-                    required=True
-                ),
-                query=dict(type="str"),
-            )
+        items_info=dict(
+            type="str",
+            choices=["brief", "full", "none"],
+            default="none",
         ),
+        items_query=dict(type="str")
     )
 
     module = AnsibleModule(

--- a/tests/integration/targets/service_catalog_info/tasks/main.yml
+++ b/tests/integration/targets/service_catalog_info/tasks/main.yml
@@ -9,9 +9,10 @@
       servicenow.itsm.service_catalog_info:
       register: catalogs
 
+    - debug: var=catalogs
     - ansible.builtin.assert:
         that:
-          - catalogs | length == 4
+          - catalogs | length > 1
     
     - name: Get one catalog only
       servicenow.itsm.service_catalog_info:
@@ -25,7 +26,7 @@
           - catalog.records[0].categories | length > 0
           - catalog.records[0].sn_items | length == 0
     
-    - name: Get one catalog with categoies and items
+    - name: Get one catalog with categories and items
       servicenow.itsm.service_catalog_info:
         categories: true
         items_info: brief
@@ -38,6 +39,21 @@
           - catalog.records[0].categories | length > 0
           - catalog.records[0].sn_items is defined
           - catalog.records[0].sn_items | length > 0
+    
+    - name: Get one catalog with item filtered -- should return none --
+      servicenow.itsm.service_catalog_info:
+        categories: false
+        items_info: brief
+        items_query: some_not_existent_field
+        sys_id: "{{ catalogs.records[0].sys_id }}"
+      register: catalog
+
+    - ansible.builtin.assert:
+        that:
+          - catalog.records | length == 1
+          - catalog.records[0].categories | length == 0
+          - catalog.records[0].sn_items is defined
+          - catalog.records[0].sn_items | length == 0
     
     - name: Get one catalog with categoies and items -- full info --
       servicenow.itsm.service_catalog_info:

--- a/tests/integration/targets/service_catalog_info/tasks/main.yml
+++ b/tests/integration/targets/service_catalog_info/tasks/main.yml
@@ -1,0 +1,55 @@
+---
+- environment:
+    SN_HOST: "{{ sn_host }}"
+    SN_USERNAME: "{{ sn_username }}"
+    SN_PASSWORD: "{{ sn_password }}"
+
+  block:
+    - name: Get all catalogs
+      servicenow.itsm.service_catalog_info:
+      register: catalogs
+
+    - ansible.builtin.assert:
+        that:
+          - catalogs | length == 4
+    
+    - name: Get one catalog only
+      servicenow.itsm.service_catalog_info:
+        categories: true
+        sys_id: "{{ catalogs.records[0].sys_id }}"
+      register: catalog
+
+    - ansible.builtin.assert:
+        that:
+          - catalog.records | length == 1
+          - catalog.records[0].categories | length > 0
+          - catalog.records[0].sn_items | length == 0
+    
+    - name: Get one catalog with categoies and items
+      servicenow.itsm.service_catalog_info:
+        categories: true
+        items_info: brief
+        sys_id: "{{ catalogs.records[0].sys_id }}"
+      register: catalog
+
+    - ansible.builtin.assert:
+        that:
+          - catalog.records | length == 1
+          - catalog.records[0].categories | length > 0
+          - catalog.records[0].sn_items is defined
+          - catalog.records[0].sn_items | length > 0
+    
+    - name: Get one catalog with categoies and items -- full info --
+      servicenow.itsm.service_catalog_info:
+        categories: true
+        items_info: full
+        sys_id: "{{ catalogs.records[0].sys_id }}"
+      register: catalog
+
+    - ansible.builtin.assert:
+        that:
+          - catalog.records | length == 1
+          - catalog.records[0].categories | length > 0
+          - catalog.records[0].sn_items is defined
+          - catalog.records[0].sn_items | length > 0
+          - catalog.records[0].sn_items[0].variables | length > 0

--- a/tests/unit/plugins/module_utils/test_service_catalog.py
+++ b/tests/unit/plugins/module_utils/test_service_catalog.py
@@ -1,0 +1,292 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2024, Red Hat
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import pytest
+import sys
+
+from ansible_collections.servicenow.itsm.plugins.module_utils import service_catalog
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires python2.7 or higher"
+)
+
+
+class TestServiceCatalog:
+    def test_item_content(self):
+        data = (
+            (service_catalog.ItemContent.BRIEF, "brief"),
+            (service_catalog.ItemContent.FULL, "full"),
+            (service_catalog.ItemContent.NONE, "something else"),
+        )
+
+        for d in data:
+            item_content = service_catalog.ItemContent.from_str(d[1])
+            assert item_content == d[0]
+
+    def test_service_catalog_object(self):
+        class TestClass(service_catalog.Catalog):
+            DISPLAY_FIELDS = ["a", "b"]
+
+        c = TestClass(dict(a="a", b="b", c="c"))
+
+        ansible = c.to_ansible()
+
+        assert "c" not in ansible
+        assert "a" in ansible
+        assert "b" in ansible
+        assert ansible["a"] == "a"
+        assert ansible["b"] == "b"
+
+    def test_service_catalog_object_1(self):
+        class TestClass(service_catalog.Catalog):
+            DISPLAY_FIELDS = ["a", "b"]
+
+        class AnotherClass(service_catalog.Catalog):
+            DISPLAY_FIELDS = ["a1", "a2", "a3"]
+
+        another_one = AnotherClass(dict(a1="1", a2="2", a3="3"))
+        c = TestClass(dict(a=another_one, b="b", c="c"))
+
+        ansible = c.to_ansible()
+
+        assert "c" not in ansible
+        assert "a" in ansible
+        assert "b" in ansible
+        assert ansible["a"] == dict(a1="1", a2="2", a3="3")
+        assert ansible["b"] == "b"
+
+    def test_catalog_display_fields(self):
+        c = service_catalog.Catalog(
+            dict(
+                sys_id="1",
+                description="2",
+                title="3",
+                has_categories="4",
+                has_items="5",
+                categories="6",
+                items="7",
+                intruder="8",
+            )
+        )
+
+        ansible = c.to_ansible()
+
+        assert "sys_id" in ansible
+        assert "description" in ansible
+        assert "title" in ansible
+        assert "has_categories" in ansible
+        assert "has_items" in ansible
+        assert "categories" in ansible
+        assert "items" in ansible
+        assert "intruder" not in ansible
+
+    def test_category_display_fields(self):
+        c = service_catalog.Category(
+            dict(
+                sys_id="1",
+                description="2",
+                title="3",
+                subcategories="6",
+                full_description="7",
+                intruder="8",
+            )
+        )
+
+        ansible = c.to_ansible()
+
+        assert "sys_id" in ansible
+        assert "description" in ansible
+        assert "title" in ansible
+        assert "subcategories" in ansible
+        assert "full_description" in ansible
+        assert "intruder" not in ansible
+
+    def test_item_display_fields(self):
+        c = service_catalog.Item(
+            dict(
+                sys_id="1",
+                description="2",
+                short_description="3",
+                availability="4",
+                mandatory_attachment="5",
+                request_method="6",
+                type="6",
+                sys_class_name="7",
+                catalogs="8",
+                name="9",
+                category="10",
+                order="11",
+                categories="12",
+                variables="13",
+                intruder="8",
+            )
+        )
+
+        ansible = c.to_ansible()
+
+        assert "sys_id" in ansible
+        assert "description" in ansible
+        assert "short_description" in ansible
+        assert "availability" in ansible
+        assert "mandatory_attachment" in ansible
+        assert "request_method" in ansible
+        assert "type" in ansible
+        assert "sys_class_name" in ansible
+        assert "catalogs" in ansible
+        assert "name" in ansible
+        assert "category" in ansible
+        assert "order" in ansible
+        assert "categories" in ansible
+        assert "variables" in ansible
+        assert "intruder" not in ansible
+
+
+class TestServiceCatalogClient:
+    class GenericClientMock:
+        def __init__(self, retured_data):
+            self.retured_data = retured_data
+            self.call_params = []
+
+        def list_records(self, api, query=None):
+            self.call_params.append(api)
+            self.call_params.append(query)
+            return self.retured_data
+
+        def get_record_by_sys_id(self, api, sys_id):
+            self.call_params.extend([api, sys_id])
+            return self.retured_data
+
+    def test_get_catalogs(self):
+        data = dict(
+            sys_id="1",
+            description="2",
+            title="3",
+            has_categories="4",
+            has_items="5",
+            items="7",
+            intruder="8",
+        )
+
+        generic_client = self.GenericClientMock([data])
+        sc_client = service_catalog.ServiceCatalogClient(generic_client)
+
+        catalogs = sc_client.get_catalogs()
+
+        assert isinstance(catalogs, list)
+        assert isinstance(catalogs[0], service_catalog.Catalog)
+        assert catalogs[0].to_ansible() == service_catalog.Catalog(data).to_ansible()
+        assert generic_client.call_params[0] == "/".join(
+            [service_catalog.SN_BASE_PATH, "catalogs"]
+        )
+
+    def test_get_catalog(self):
+        data = dict(
+            sys_id="1",
+            description="2",
+            title="3",
+            has_categories="4",
+            has_items="5",
+            items="7",
+            intruder="8",
+        )
+
+        generic_client = self.GenericClientMock(data)
+        sc_client = service_catalog.ServiceCatalogClient(generic_client)
+
+        catalog = sc_client.get_catalog("id")
+
+        assert isinstance(catalog, service_catalog.Catalog)
+        assert catalog.to_ansible() == service_catalog.Catalog(data).to_ansible()
+        assert generic_client.call_params[0] == "/".join(
+            [service_catalog.SN_BASE_PATH, "catalogs"]
+        )
+        assert generic_client.call_params[1] == "id"
+
+    def test_get_categories(self):
+        data = dict(
+            sys_id="1",
+            description="2",
+            title="3",
+            subcategories="6",
+            full_description="7",
+            intruder="8",
+        )
+
+        generic_client = self.GenericClientMock([data])
+        sc_client = service_catalog.ServiceCatalogClient(generic_client)
+
+        categories = sc_client.get_categories("catalog_id")
+
+        assert isinstance(categories, list)
+        assert categories[0].to_ansible() == service_catalog.Category(data).to_ansible()
+        assert generic_client.call_params[0] == "/".join(
+            [service_catalog.SN_BASE_PATH, "catalogs", "catalog_id", "categories"]
+        )
+
+    def test_get_items(self):
+        data = dict(
+            sys_id="1",
+            description="2",
+            short_description="3",
+            availability="4",
+            mandatory_attachment="5",
+            request_method="6",
+            type="6",
+            sys_class_name="7",
+            catalogs="8",
+            name="9",
+            category="10",
+            order="11",
+            categories="12",
+            variables="13",
+            intruder="8",
+        )
+
+        generic_client = self.GenericClientMock([data])
+        sc_client = service_catalog.ServiceCatalogClient(generic_client)
+
+        items = sc_client.get_items("catalog_id")
+
+        assert isinstance(items, list)
+        assert items[0].to_ansible() == service_catalog.Item(data).to_ansible()
+        assert generic_client.call_params[0] == "/".join(
+            [service_catalog.SN_BASE_PATH, "items"]
+        )
+        assert generic_client.call_params[1] == dict(sysparm_catalog="catalog_id")
+
+    def test_get_item(self):
+        data = dict(
+            sys_id="1",
+            description="2",
+            short_description="3",
+            availability="4",
+            mandatory_attachment="5",
+            request_method="6",
+            type="6",
+            sys_class_name="7",
+            catalogs="8",
+            name="9",
+            category="10",
+            order="11",
+            categories="12",
+            variables="13",
+            intruder="8",
+        )
+
+        generic_client = self.GenericClientMock(data)
+        sc_client = service_catalog.ServiceCatalogClient(generic_client)
+
+        item = sc_client.get_item("item_id")
+
+        assert isinstance(item, service_catalog.Item)
+        assert item.to_ansible() == service_catalog.Item(data).to_ansible()
+        assert generic_client.call_params[0] == "/".join(
+            [service_catalog.SN_BASE_PATH, "items"]
+        )
+        assert generic_client.call_params[1] == "item_id"

--- a/tests/unit/plugins/module_utils/test_service_catalog.py
+++ b/tests/unit/plugins/module_utils/test_service_catalog.py
@@ -83,7 +83,7 @@ class TestServiceCatalog:
         assert "has_categories" in ansible
         assert "has_items" in ansible
         assert "categories" in ansible
-        assert "items" in ansible
+        assert "sn_items" in ansible
         assert "intruder" not in ansible
 
     def test_category_display_fields(self):

--- a/tests/unit/plugins/modules/test_service_catalog_info.py
+++ b/tests/unit/plugins/modules/test_service_catalog_info.py
@@ -153,7 +153,7 @@ class TestModule:
 
         assert len(records) == 1
         assert len(records[0]["categories"]) == 1
-        assert len(records[0]["items"]) == 1
+        assert len(records[0]["sn_items"]) == 1
         assert records[0]["categories"][0] == service_catalog.Category(category).to_ansible()
-        assert records[0]["items"][0] == service_catalog.Category(item).to_ansible()
+        assert records[0]["sn_items"][0] == service_catalog.Category(item).to_ansible()
         assert records[0]["sys_id"] == "1"

--- a/tests/unit/plugins/modules/test_service_catalog_info.py
+++ b/tests/unit/plugins/modules/test_service_catalog_info.py
@@ -11,7 +11,6 @@ import sys
 
 import pytest
 from ansible_collections.servicenow.itsm.plugins.module_utils import (
-    errors,
     service_catalog
 )
 from ansible_collections.servicenow.itsm.plugins.modules import (
@@ -21,61 +20,6 @@ from ansible_collections.servicenow.itsm.plugins.modules import (
 pytestmark = pytest.mark.skipif(
     sys.version_info < (2, 7), reason="requires python2.7 or higher"
 )
-
-
-class TestParamsValidation:
-    def test_validation_1(self):
-        params = dict(
-            instance=dict(
-                host="https://my.host.name", username="user", password="pass"
-            ),
-            categories=False,
-            items=dict(
-                content="brief",
-                query=""
-            )
-        )
-
-        with pytest.raises(errors.ServiceNowError):
-            service_catalog_info.validate_params(params)
-
-    def test_validation_2(self):
-        params = dict(
-            instance=dict(
-                host="https://my.host.name", username="user", password="pass"
-            ),
-            categories=False,
-            items=dict(
-                content=dict(),
-            )
-        )
-
-        with pytest.raises(errors.ServiceNowError):
-            service_catalog_info.validate_params(params)
-
-    def test_validation_3(self):
-        params = dict(
-            instance=dict(
-                host="https://my.host.name", username="user", password="pass"
-            ),
-            categories=False,
-            items=dict()
-        )
-
-        with pytest.raises(errors.ServiceNowError):
-            service_catalog_info.validate_params(params)
-
-    def test_validation_4(self):
-        params = dict(
-            instance=dict(
-                host="https://my.host.name", username="user", password="pass"
-            ),
-            sys_id="",
-            categories=False,
-        )
-
-        with pytest.raises(errors.ServiceNowError):
-            service_catalog_info.validate_params(params)
 
 
 class TestModule:
@@ -114,6 +58,7 @@ class TestModule:
                     host="https://my.host.name", username="user", password="pass"
                 ),
                 categories=False,
+                items_info="none"
             )
         )
 
@@ -138,6 +83,7 @@ class TestModule:
                 ),
                 sys_id="catalog_sys_id",
                 categories=False,
+                items_info="none"
             )
         )
 
@@ -161,6 +107,7 @@ class TestModule:
                     host="https://my.host.name", username="user", password="pass"
                 ),
                 categories=True,
+                items_info="none"
             )
         )
 
@@ -187,9 +134,7 @@ class TestModule:
                     host="https://my.host.name", username="user", password="pass"
                 ),
                 categories=True,
-                items=dict(
-                    content="brief"
-                )
+                items_info="brief"
             )
         )
 

--- a/tests/unit/plugins/modules/test_service_catalog_info.py
+++ b/tests/unit/plugins/modules/test_service_catalog_info.py
@@ -58,7 +58,8 @@ class TestModule:
                     host="https://my.host.name", username="user", password="pass"
                 ),
                 categories=False,
-                items_info="none"
+                items_info="none",
+                items_query=None
             )
         )
 
@@ -83,7 +84,8 @@ class TestModule:
                 ),
                 sys_id="catalog_sys_id",
                 categories=False,
-                items_info="none"
+                items_info="none",
+                items_query=None
             )
         )
 
@@ -107,7 +109,8 @@ class TestModule:
                     host="https://my.host.name", username="user", password="pass"
                 ),
                 categories=True,
-                items_info="none"
+                items_info="none",
+                items_query=None
             )
         )
 
@@ -134,7 +137,8 @@ class TestModule:
                     host="https://my.host.name", username="user", password="pass"
                 ),
                 categories=True,
-                items_info="brief"
+                items_info="brief",
+                items_query=None
             )
         )
 

--- a/tests/unit/plugins/modules/test_service_catalog_info.py
+++ b/tests/unit/plugins/modules/test_service_catalog_info.py
@@ -1,0 +1,214 @@
+# -*- coding: utf-8 -*-
+# Copyright: 2024, Contributors to the Ansible project
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+
+import pytest
+from ansible_collections.servicenow.itsm.plugins.module_utils import (
+    errors,
+    service_catalog
+)
+from ansible_collections.servicenow.itsm.plugins.modules import (
+    service_catalog_info,
+)
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires python2.7 or higher"
+)
+
+
+class TestParamsValidation:
+    def test_validation_1(self):
+        params = dict(
+            instance=dict(
+                host="https://my.host.name", username="user", password="pass"
+            ),
+            categories=False,
+            items=dict(
+                content="brief",
+                query=""
+            )
+        )
+
+        with pytest.raises(errors.ServiceNowError):
+            service_catalog_info.validate_params(params)
+
+    def test_validation_2(self):
+        params = dict(
+            instance=dict(
+                host="https://my.host.name", username="user", password="pass"
+            ),
+            categories=False,
+            items=dict(
+                content=dict(),
+            )
+        )
+
+        with pytest.raises(errors.ServiceNowError):
+            service_catalog_info.validate_params(params)
+
+    def test_validation_3(self):
+        params = dict(
+            instance=dict(
+                host="https://my.host.name", username="user", password="pass"
+            ),
+            categories=False,
+            items=dict()
+        )
+
+        with pytest.raises(errors.ServiceNowError):
+            service_catalog_info.validate_params(params)
+
+    def test_validation_4(self):
+        params = dict(
+            instance=dict(
+                host="https://my.host.name", username="user", password="pass"
+            ),
+            sys_id="",
+            categories=False,
+        )
+
+        with pytest.raises(errors.ServiceNowError):
+            service_catalog_info.validate_params(params)
+
+
+class TestModule:
+    class GenericClientMock:
+        def __init__(self, retured_data):
+            self.retured_data = retured_data
+            self.call_params = []
+
+        def list_records(self, api, query=None):
+            self.call_params.append(api)
+            self.call_params.append(query)
+            if "categories" in api:
+                if not isinstance(self.retured_data, tuple):
+                    raise ValueError("expected tuple in retured_data when looking for categories")
+                return self.retured_data[1]
+            if "items" in api:
+                if not isinstance(self.retured_data, tuple):
+                    raise ValueError("expected tuple in retured_data when looking for categories")
+                return self.retured_data[2]
+            if isinstance(self.retured_data, tuple):
+                return self.retured_data[0]
+            return self.retured_data
+
+        def get_record_by_sys_id(self, api, sys_id):
+            self.call_params.extend([api, sys_id])
+            return self.retured_data
+
+    def get_sc_client(self, data):
+        generic_client = self.GenericClientMock(data)
+        return service_catalog.ServiceCatalogClient(generic_client)
+
+    def test_get_without_categories(self, create_module):
+        module = create_module(
+            params=dict(
+                instance=dict(
+                    host="https://my.host.name", username="user", password="pass"
+                ),
+                categories=False,
+            )
+        )
+
+        data = dict(
+            sys_id="1",
+            description="2",
+            title="3",
+            has_categories="4",
+            has_items="5",
+        )
+
+        records = service_catalog_info.run(module, self.get_sc_client([data]))
+
+        assert len(records) == 1
+        assert records[0] == service_catalog.Catalog(data).to_ansible()
+
+    def test_get_by_sys_id(self, create_module):
+        module = create_module(
+            params=dict(
+                instance=dict(
+                    host="https://my.host.name", username="user", password="pass"
+                ),
+                sys_id="catalog_sys_id",
+                categories=False,
+            )
+        )
+
+        data = dict(
+            sys_id="catalog_sys_id",
+            description="2",
+            title="3",
+            has_categories="4",
+            has_items="5",
+        )
+
+        records = service_catalog_info.run(module, self.get_sc_client(data))
+
+        assert len(records) == 1
+        assert records[0] == service_catalog.Catalog(data).to_ansible()
+
+    def test_get_with_categories(self, create_module):
+        module = create_module(
+            params=dict(
+                instance=dict(
+                    host="https://my.host.name", username="user", password="pass"
+                ),
+                categories=True,
+            )
+        )
+
+        catalog = dict(
+            sys_id="1",
+            description="2",
+            title="3",
+            has_categories="4",
+            has_items="5",
+        )
+        category = dict(sys_id="category_sys_id")
+
+        records = service_catalog_info.run(module, self.get_sc_client(([catalog], [category])))
+
+        assert len(records) == 1
+        assert len(records[0]["categories"]) == 1
+        assert records[0]["categories"][0] == service_catalog.Category(category).to_ansible()
+        assert records[0]["sys_id"] == "1"
+
+    def test_get_with_categories_and_items(self, create_module):
+        module = create_module(
+            params=dict(
+                instance=dict(
+                    host="https://my.host.name", username="user", password="pass"
+                ),
+                categories=True,
+                items=dict(
+                    content="brief"
+                )
+            )
+        )
+
+        catalog = dict(
+            sys_id="1",
+            description="2",
+            title="3",
+            has_categories="4",
+            has_items="5",
+        )
+        category = dict(sys_id="category_sys_id")
+        item = dict(sys_id="item_sys_id")
+
+        records = service_catalog_info.run(
+            module, self.get_sc_client(([catalog], [category], [item])))
+
+        assert len(records) == 1
+        assert len(records[0]["categories"]) == 1
+        assert len(records[0]["items"]) == 1
+        assert records[0]["categories"][0] == service_catalog.Category(category).to_ansible()
+        assert records[0]["items"][0] == service_catalog.Category(item).to_ansible()
+        assert records[0]["sys_id"] == "1"


### PR DESCRIPTION
This PR adds a module to retrieve information about service catalog along with categories and items

##### SUMMARY
This is part of Service Catalog features.

##### ISSUE TYPE
- Feature Pull Request

##### ADDITIONAL INFORMATION
```paste below
- name: Return all catalogs without categories but with items (brief information)
  servicenow.itsm.service_catalog_info:
    categories: false
    items_info: brief

- name: Return service catalog without categories but with items (brief information)
  servicenow.itsm.service_catalog_info:
    instance:
    sys_id: "{{ service_catalog.sys_id }}"
    categories: false
    items_info: brief

- name: Return service catalog with categories and with items (full information)
  servicenow.itsm.service_catalog_info:
    instance:
    sys_id: "{{ service_catalog.sys_id }}"
    categories: true
    items_info: full
```
