### PR TITLE
Fix lint by using the right black version

### DIFF
--- a/tests/unit/plugins/module_utils/test_cmdb_relations.py
+++ b/tests/unit/plugins/module_utils/test_cmdb_relations.py
@@ -120,7 +120,6 @@ class TestCmdbRelation:
         ],
     )
     def test_not_equal(self, input1, input2):
-
         relation1 = cmdb_relation.CmdbRelation(input1)
         relation2 = cmdb_relation.CmdbRelation(input2)
 


### PR DESCRIPTION
This PR fix lint failures due to using an older black version.