### PR TITLE
Add venv to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ __pycache__
 /tests/integration/integration_config.yml
 .coverage*
 htmlcov
+venv/
+.venv/


### PR DESCRIPTION
##### SUMMARY
This PR adds `venv` and `.venv` to gitignore
