### PR TITLE
Feature/handle duplicate records

### DIFF
--- a/changelogs/fragments/handle_duplicate_records.yml
+++ b/changelogs/fragments/handle_duplicate_records.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - ServiceNow returns duplicated records causing error at line referenced.pop("sys_id")
+  - Added check for records(sys_id) that are already processed with reference records

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -588,6 +588,7 @@ class InventoryModule(BaseInventoryPlugin, ConstructableWithLookup, Cacheable):
                 )
 
                 referenced_dict = dict((x["sys_id"], x) for x in referenced_records)
+                # Keep track of processed 'sys_id' to avoid popping it twice if there were duplicates returned by ServiceNow.
                 processed_records = []
                 for record in records:
                     referenced = referenced_dict.get(record["sys_id"], None)

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -591,9 +591,9 @@ class InventoryModule(BaseInventoryPlugin, ConstructableWithLookup, Cacheable):
                 processed_records = []
                 for record in records:
                     referenced = referenced_dict.get(record["sys_id"], None)
-                    if referenced and record["sys_id"] not in processed_records:
+                    if referenced:
+                        if record["sys_id"] not in processed_records: referenced.pop("sys_id")
                         processed_records.append(record["sys_id"])
-                        referenced.pop("sys_id")
                         for key, value in referenced.items():
                             record[key] = value
 

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -588,9 +588,11 @@ class InventoryModule(BaseInventoryPlugin, ConstructableWithLookup, Cacheable):
                 )
 
                 referenced_dict = dict((x["sys_id"], x) for x in referenced_records)
+                processed_records = []
                 for record in records:
                     referenced = referenced_dict.get(record["sys_id"], None)
-                    if referenced:
+                    if referenced and record["sys_id"] not in processed_records:
+                        processed_records.append(record["sys_id"])
                         referenced.pop("sys_id")
                         for key, value in referenced.items():
                             record[key] = value

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -592,7 +592,8 @@ class InventoryModule(BaseInventoryPlugin, ConstructableWithLookup, Cacheable):
                 for record in records:
                     referenced = referenced_dict.get(record["sys_id"], None)
                     if referenced:
-                        if record["sys_id"] not in processed_records: referenced.pop("sys_id")
+                        if record["sys_id"] not in processed_records:
+                            referenced.pop("sys_id")
                         processed_records.append(record["sys_id"])
                         for key, value in referenced.items():
                             record[key] = value


### PR DESCRIPTION
##### SUMMARY
When processing large number of records, ServiceNow returns duplicated records with the same 'sys_id' in the first fetch call.  It causes 'sys_id' error when processing reference_dict where it tries to pop the same 'sys_id' twice.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/inventory/now.py

##### ADDITIONAL INFORMATION
No change to how the plugin is being run.  The issue is in the returned data from ServiceNow.  This change should handle the duplicate records without causing the plugin to fail with error.  The duplicated records have the same sys_id, so they should be the same record.  Therefore, it should be OK to process it twice.