### PR TITLE
Fix crash when SN_TIMEOUT is set

### DIFF
--- a/changelogs/fragments/inventory_timeout.yml
+++ b/changelogs/fragments/inventory_timeout.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - now - Fix crash when SN_TIMEOUT is set because is it passed as string instead of a number (https://github.com/ansible-collections/servicenow.itsm/pull/348).

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -498,6 +498,12 @@ class InventoryModule(BaseInventoryPlugin, ConstructableWithLookup, Cacheable):
                     return value
             return None
 
+        def get_timeout_from_env(default=120):
+            try:
+                return float(os.getenv("SN_TIMEOUT"))
+            except (ValueError, TypeError):
+                return default
+
         return dict(
             host=os.getenv("SN_HOST"),
             username=os.getenv("SN_USERNAME"),
@@ -506,7 +512,7 @@ class InventoryModule(BaseInventoryPlugin, ConstructableWithLookup, Cacheable):
             client_secret=get_secret_from_env(),
             refresh_token=os.getenv("SN_REFRESH_TOKEN"),
             grant_type=os.getenv("SN_GRANT_TYPE"),
-            timeout=os.getenv("SN_TIMEOUT"),
+            timeout=get_timeout_from_env(),
         )
 
     def _get_instance(self):

--- a/tests/unit/plugins/inventory/test_now.py
+++ b/tests/unit/plugins/inventory/test_now.py
@@ -162,7 +162,7 @@ class TestInstance:
                 SN_CLIENT_SECRET="client_secret",
                 SN_REFRESH_TOKEN="refresh_token",
                 SN_GRANT_TYPE="grant_type",
-                SN_TIMEOUT="timeout",
+                SN_TIMEOUT="100",
             ).get(key)
 
         mocker.patch("os.getenv", new=getenv)
@@ -176,7 +176,7 @@ class TestInstance:
             client_secret="client_secret",
             refresh_token="refresh_token",
             grant_type="grant_type",
-            timeout="timeout",
+            timeout=100,
         )
 
     def test_get_instance(self, inventory_plugin, mocker):
@@ -196,7 +196,87 @@ class TestInstance:
             client_secret="SN_CLIENT_SECRET",
             refresh_token="SN_REFRESH_TOKEN",
             grant_type="SN_GRANT_TYPE",
-            timeout="SN_TIMEOUT",
+            timeout=120,
+        )
+
+    def test_get_timeout_default_value(self, inventory_plugin, mocker):
+        def getenv(key):
+            return dict(
+                SN_HOST="host",
+                SN_USERNAME="username",
+                SN_PASSWORD="password",
+                SN_CLIENT_ID="client_id",
+                SN_CLIENT_SECRET="client_secret",
+                SN_REFRESH_TOKEN="refresh_token",
+                SN_GRANT_TYPE="grant_type",
+                SN_TIMEOUT="wrong_timeout",
+            ).get(key)
+
+        mocker.patch("os.getenv", new=getenv)
+
+        config = inventory_plugin._get_instance_from_env()
+        assert config == dict(
+            host="host",
+            username="username",
+            password="password",
+            client_id="client_id",
+            client_secret="client_secret",
+            refresh_token="refresh_token",
+            grant_type="grant_type",
+            timeout=120,
+        )
+
+    def test_get_timeout_missing_env_value(self, inventory_plugin, mocker):
+        def getenv(key):
+            return dict(
+                SN_HOST="host",
+                SN_USERNAME="username",
+                SN_PASSWORD="password",
+                SN_CLIENT_ID="client_id",
+                SN_CLIENT_SECRET="client_secret",
+                SN_REFRESH_TOKEN="refresh_token",
+                SN_GRANT_TYPE="grant_type",
+            ).get(key)
+
+        mocker.patch("os.getenv", new=getenv)
+
+        config = inventory_plugin._get_instance_from_env()
+        assert config == dict(
+            host="host",
+            username="username",
+            password="password",
+            client_id="client_id",
+            client_secret="client_secret",
+            refresh_token="refresh_token",
+            grant_type="grant_type",
+            timeout=120,
+        )
+
+    def test_get_timeout(self, inventory_plugin, mocker):
+        def getenv(key):
+            return dict(
+                SN_HOST="host",
+                SN_USERNAME="username",
+                SN_PASSWORD="password",
+                SN_CLIENT_ID="client_id",
+                SN_CLIENT_SECRET="client_secret",
+                SN_REFRESH_TOKEN="refresh_token",
+                SN_GRANT_TYPE="grant_type",
+                SN_TIMEOUT="50",
+            ).get(key)
+
+        mocker.patch("os.getenv", new=getenv)
+
+        config = inventory_plugin._get_instance_from_env()
+        assert config == dict(
+            host="host",
+            username="username",
+            password="password",
+            client_id="client_id",
+            client_secret="client_secret",
+            refresh_token="refresh_token",
+            grant_type="grant_type",
+            timeout=50,
         )
 
 


### PR DESCRIPTION
##### SUMMARY
Fix crash when SN_TIMEOUT is set.

SN_TIMEOUT is passed as `string` instead of `float`.

##### ISSUE TYPE
- Bugfix Pull Request

Fixes AAP-23059
##### COMPONENT NAME
inventory