### PR TITLE
Add value key to return data

### DIFF
--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -432,8 +432,8 @@ class InventoryModule(BaseInventoryPlugin, ConstructableWithLookup, Cacheable):
 
         inventory_hostname = record[name_source]
         if isinstance(inventory_hostname, dict):
-            if 'display_value' in inventory_hostname:
-                inventory_hostname = inventory_hostname['display_value']
+            if "display_value" in inventory_hostname:
+                inventory_hostname = inventory_hostname["display_value"]
             else:
                 msg = "Inventory hostname source column '{0}' is a dict but does not contain 'display_value'."
                 raise AnsibleParserError(msg.format(name_source))
@@ -459,14 +459,16 @@ class InventoryModule(BaseInventoryPlugin, ConstructableWithLookup, Cacheable):
         for k in columns:
             value = record.get(k)
             if isinstance(value, dict):
-                main_value = value.get('display_value') or value.get('value') or value
+                main_value = value.get("display_value") or value.get("value") or value
                 self.inventory.set_variable(host, k.replace(".", "_"), main_value)
 
                 if show_values:
-                    for sub_key in ['display_value', 'value']:
+                    for sub_key in ["display_value", "value"]:
                         sub_value = value.get(sub_key)
                         if sub_value and sub_value != main_value:
-                            self.inventory.set_variable(host, f"{k}_{sub_key}", sub_value)
+                            self.inventory.set_variable(
+                                host, f"{k}_{sub_key}", sub_value
+                            )
             else:
                 self.inventory.set_variable(host, k.replace(".", "_"), value)
 

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -151,6 +151,11 @@ options:
     type: int
     default: 1000
     version_added: 2.5.0
+  show_values:
+    description:
+      - Whether to include the valu' field for dictionary-type columns in returned.
+    type: bool
+    default: false
 
 """
 
@@ -364,7 +369,7 @@ def construct_sysparm_query(query, is_encoded_query):
 def fetch_records(table_client, table, query, fields=None, is_encoded_query=False):
     snow_query = dict(
         # Make references and choice fields human-readable
-        sysparm_display_value=True,
+        sysparm_display_value="all",
     )
     if query:
         snow_query["sysparm_query"] = construct_sysparm_query(query, is_encoded_query)
@@ -426,6 +431,13 @@ class InventoryModule(BaseInventoryPlugin, ConstructableWithLookup, Cacheable):
             raise AnsibleParserError(msg.format(name_source))
 
         inventory_hostname = record[name_source]
+        if isinstance(inventory_hostname, dict):
+            if 'display_value' in inventory_hostname:
+                inventory_hostname = inventory_hostname['display_value']
+            else:
+                msg = "Inventory hostname source column '{0}' is a dict but does not contain 'display_value'."
+                raise AnsibleParserError(msg.format(name_source))
+
         if inventory_hostname:
             host = self.inventory.add_host(inventory_hostname)
             return host
@@ -442,8 +454,21 @@ class InventoryModule(BaseInventoryPlugin, ConstructableWithLookup, Cacheable):
                 "Invalid column names: {0}.".format(", ".join(missing))
             )
 
+        show_values = self.get_option("show_values")
+
         for k in columns:
-            self.inventory.set_variable(host, k.replace(".", "_"), record[k])
+            value = record.get(k)
+            if isinstance(value, dict):
+                main_value = value.get('display_value') or value.get('value') or value
+                self.inventory.set_variable(host, k.replace(".", "_"), main_value)
+
+                if show_values:
+                    for sub_key in ['display_value', 'value']:
+                        sub_value = value.get(sub_key)
+                        if sub_value and sub_value != main_value:
+                            self.inventory.set_variable(host, f"{k}_{sub_key}", sub_value)
+            else:
+                self.inventory.set_variable(host, k.replace(".", "_"), value)
 
     def fill_constructed(
         self,

--- a/tests/unit/plugins/inventory/test_now.py
+++ b/tests/unit/plugins/inventory/test_now.py
@@ -50,21 +50,21 @@ class TestFetchRecords:
         now.fetch_records(table_client, "table_name", None)
 
         table_client.list_records.assert_called_once_with(
-            "table_name", dict(sysparm_display_value=True)
+            "table_name", dict(sysparm_display_value='all')
         )
 
     def test_query(self, table_client):
         now.fetch_records(table_client, "table_name", [dict(my="!= value")])
 
         table_client.list_records.assert_called_once_with(
-            "table_name", dict(sysparm_display_value=True, sysparm_query="my!=value")
+            "table_name", dict(sysparm_display_value='all', sysparm_query="my!=value")
         )
 
     def test_no_query_with_fields(self, table_client):
         now.fetch_records(table_client, "table_name", None, fields=["a", "b", "c"])
 
         table_client.list_records.assert_called_once_with(
-            "table_name", dict(sysparm_display_value=True, sysparm_fields="a,b,c")
+            "table_name", dict(sysparm_display_value='all', sysparm_fields="a,b,c")
         )
 
 

--- a/tests/unit/plugins/inventory/test_now.py
+++ b/tests/unit/plugins/inventory/test_now.py
@@ -50,21 +50,21 @@ class TestFetchRecords:
         now.fetch_records(table_client, "table_name", None)
 
         table_client.list_records.assert_called_once_with(
-            "table_name", dict(sysparm_display_value='all')
+            "table_name", dict(sysparm_display_value="all")
         )
 
     def test_query(self, table_client):
         now.fetch_records(table_client, "table_name", [dict(my="!= value")])
 
         table_client.list_records.assert_called_once_with(
-            "table_name", dict(sysparm_display_value='all', sysparm_query="my!=value")
+            "table_name", dict(sysparm_display_value="all", sysparm_query="my!=value")
         )
 
     def test_no_query_with_fields(self, table_client):
         now.fetch_records(table_client, "table_name", None, fields=["a", "b", "c"])
 
         table_client.list_records.assert_called_once_with(
-            "table_name", dict(sysparm_display_value='all', sysparm_fields="a,b,c")
+            "table_name", dict(sysparm_display_value="all", sysparm_fields="a,b,c")
         )
 
 


### PR DESCRIPTION

##### SUMMARY
When receiving objetct that contain a dictionary with display_value, link and value, just the display_value was returned, now it returns also the value that is the sys_id.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
now.py

##### ADDITIONAL INFORMATION
In relation with this issue https://github.com/ansible-collections/servicenow.itsm/issues/317 , with the actual plugin inventory it just returns the display_value of objects, with the change the value (the sys_id) is also returned. 
This has been usefull to me when working with server inventories I wanted to get the email associated from the user (columns assigned_to and owneed_by) but just the name was returned so I couldn't resolve it to email (excepto for using LDAP modules), so with the change now the sys_id of the Persona (object) is returned so I can use the api_info module fetching with the sys_id and get the data like in my case the emaill

##### Before with one example
```

    "_meta": {
        "hostvars": {
            "Poller": {
                "assigned_to": "Mathuew",
                "owned_by": "Steven",
                "u_server_id": "i-123456"
            }
        }
    },
```

```
plugin: servicenow.itsm.now
table: cmdb_ci_server
sysparm_query: 'name=Poller'
columns: assigned_to, owned_by, u_server_id
```


AFTER 

```
    "_meta": {
        "hostvars": {
            "Poller": {
                "assigned_to": "Mathuew",
                "assigned_to_value": "123456789101123145",
                "owned_by": "Steven",
                "owned_by_value": "987654321",
                "u_server_id": "i-123456"
            }
        }
    },
```
Inventory adding the show_values argument

```
plugin: servicenow.itsm.now
table: cmdb_ci_server
sysparm_query: 'name=Poller'
columns: assigned_to, owned_by, u_server_id
show_values: true
```



