### PR TITLE
Fix service_catalog integration tests by creating a random user

### DIFF
--- a/tests/integration/targets/service_catalog/tasks/main.yml
+++ b/tests/integration/targets/service_catalog/tasks/main.yml
@@ -5,8 +5,31 @@
     SN_PASSWORD: "{{ sn_password }}"
 
   block:
+    - name: Set fact user passowrd
+      ansible.builtin.set_fact:
+        password: "demo_password"
+
+    - name: Create random user
+      servicenow.itsm.api:
+        resource: sys_user
+        action: post
+        query_params:
+          sysparm_input_display_value: true
+        data:
+          user_name: "{{ 'demo_username_' + lookup('password', '/dev/null chars=ascii_letters,digit length=8') | lower }}"
+          user_password: "{{ password }}"
+          first_name: "first_name"
+          last_name: Demouser
+          department: IT
+          email: "demo_username@example.com"
+          title: Demo user
+      register: user
+
     - name: Get all catalogs
       servicenow.itsm.service_catalog_info:
+      environment:
+        SN_USERNAME: "{{ user.record.user_name }}"
+        SN_PASSWORD: "{{ password }}"
       register: catalogs
 
     - ansible.builtin.set_fact:
@@ -20,6 +43,9 @@
         items_info: full
         items_query: New Email Account
         sys_id: "{{ service_catalog.sys_id }}"
+      environment:
+        SN_USERNAME: "{{ user.record.user_name }}"
+        SN_PASSWORD: "{{ password }}"
       register: result
         
     - debug:
@@ -37,6 +63,9 @@
             requested_for: abraham.lincoln
             variables:
               new_email: test@example.com
+      environment:
+        SN_USERNAME: "{{ user.record.user_name }}"
+        SN_PASSWORD: "{{ password }}"
       register: email_request
 
     - ansible.builtin.assert:
@@ -49,6 +78,9 @@
         items_info: full
         items_query: Ipad
         sys_id: "{{ service_catalog.sys_id }}"
+      environment:
+        SN_USERNAME: "{{ user.record.user_name }}"
+        SN_PASSWORD: "{{ password }}"
       register: result
 
     - ansible.builtin.assert:
@@ -62,6 +94,9 @@
           - sys_id: "{{ result.records[0].sn_items[0].sys_id }}"
             requested_for: abraham.lincoln
             quantity: 2
+      environment:
+        SN_USERNAME: "{{ user.record.user_name }}"
+        SN_PASSWORD: "{{ password }}"
       register: ipad_request
 
     - debug: var=ipad_request
@@ -77,6 +112,9 @@
           - sys_id: "{{ result.records[0].sn_items[0].sys_id }}"
             requested_for: abraham.lincoln
             quantity: 2
+      environment:
+        SN_USERNAME: "{{ user.record.user_name }}"
+        SN_PASSWORD: "{{ password }}"
       register: ipad_request_2
 
     - debug: var=ipad_request_2
@@ -84,3 +122,10 @@
     - ansible.builtin.assert:
         that:
           - ipad_request_2 is defined
+
+  always:
+    - name: Delete user
+      servicenow.itsm.api:
+        resource: sys_user
+        action: delete
+        sys_id: "{{ user.record.sys_id }}"


### PR DESCRIPTION
To avoid clashes between test runs, a random user is created before running service catalog integration tests.

##### SUMMARY
Fix service_catalog integration tests failures.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
service_catalog tests

