### PR TITLE
Set absolute path for test sample file and full name for module

### DIFF
--- a/.github/workflows/integration_source.yml
+++ b/.github/workflows/integration_source.yml
@@ -131,6 +131,7 @@ jobs:
           echo "sn_host: '${{ env.SN_HOST }}'" >> ${{ steps.identify.outputs.collection_path }}/tests/integration/integration_config.yml
           echo "sn_username: '${{ env.SN_USERNAME }}'" >> ${{ steps.identify.outputs.collection_path }}/tests/integration/integration_config.yml
           echo "sn_password: '${{ env.SN_PASSWORD }}'" >> ${{ steps.identify.outputs.collection_path }}/tests/integration/integration_config.yml
+          echo "collection_base_dir: '${{ steps.identify.outputs.collection_path }}'" >> ${{ steps.identify.outputs.collection_path }}/tests/integration/integration_config.yml
 
       - name: Run itsm_api integration tests
         run: ansible-test integration itsm_api

--- a/tests/integration/targets/attachment/tasks/main.yml
+++ b/tests/integration/targets/attachment/tasks/main.yml
@@ -18,7 +18,7 @@
         risk: low
         impact: low
         attachments:
-          - path: targets/attachment/res/sample_file1.txt
+          - path: "{{ collection_base_dir }}/tests/integration/targets/attachment/res/sample_file1.txt"
       check_mode: true
       register: result
 
@@ -49,9 +49,9 @@
       servicenow.itsm.change_request: &cr-update
         number: "{{ test_result.record.number }}"
         attachments:
-          - path: targets/attachment/res/sample_file1.txt
+          - path: "{{ collection_base_dir }}/tests/integration/targets/attachment/res/sample_file1.txt"
             name: sample_file1.txt
-          - path: targets/attachment/res/sample_file1.txt
+          - path: "{{ collection_base_dir }}/tests/integration/targets/attachment/res/sample_file1.txt"
             name: sample_file2.txt
       check_mode: true
       register: result
@@ -78,7 +78,7 @@
       servicenow.itsm.change_request:
         number: "{{ test_result.record.number }}"
         attachments:
-          - path: targets/attachment/res/sample_file2.txt
+          - path: "{{ collection_base_dir }}/tests/integration/targets/attachment/res/sample_file2.txt"
             name: sample_file1.txt
       register: result
 
@@ -130,7 +130,7 @@
         install_status: on_order
         operational_status: non_operational
         attachments:
-          - path: targets/attachment/res/sample_file1.txt
+          - path: "{{ collection_base_dir }}/tests/integration/targets/attachment/res/sample_file1.txt"
       check_mode: true
       register: ci_result
 
@@ -158,9 +158,9 @@
       servicenow.itsm.configuration_item: &ci-update
         sys_id: "{{ test_result.record.sys_id }}"
         attachments:
-          - path: targets/attachment/res/sample_file1.txt
+          - path: "{{ collection_base_dir }}/tests/integration/targets/attachment/res/sample_file1.txt"
             name: sample_file1.txt
-          - path: targets/attachment/res/sample_file1.txt
+          - path: "{{ collection_base_dir }}/tests/integration/targets/attachment/res/sample_file1.txt"
             name: sample_file2.txt
       check_mode: true
       register: result
@@ -187,7 +187,7 @@
       servicenow.itsm.configuration_item:
         sys_id: "{{ test_result.record.sys_id }}"
         attachments:
-          - path: targets/attachment/res/sample_file2.txt
+          - path: "{{ collection_base_dir }}/tests/integration/targets/attachment/res/sample_file2.txt"
             name: sample_file1.txt
       register: result
 
@@ -240,7 +240,7 @@
         impact: low
         urgency: low
         attachments:
-          - path: targets/attachment/res/sample_file1.txt
+          - path: "{{ collection_base_dir }}/tests/integration/targets/attachment/res/sample_file1.txt"
       check_mode: true
       register: result
 
@@ -268,9 +268,9 @@
       servicenow.itsm.incident: &incident-update
         number: "{{ test_result.record.number }}"
         attachments:
-          - path: targets/attachment/res/sample_file1.txt
+          - path: "{{ collection_base_dir }}/tests/integration/targets/attachment/res/sample_file1.txt"
             name: sample_file1.txt
-          - path: targets/attachment/res/sample_file1.txt
+          - path: "{{ collection_base_dir }}/tests/integration/targets/attachment/res/sample_file1.txt"
             name: sample_file2.txt
       check_mode: true
       register: result
@@ -297,7 +297,7 @@
       servicenow.itsm.incident:
         number: "{{ test_result.record.number }}"
         attachments:
-          - path: targets/attachment/res/sample_file2.txt
+          - path: "{{ collection_base_dir }}/tests/integration/targets/attachment/res/sample_file2.txt"
             name: sample_file1.txt
       register: result
 
@@ -346,7 +346,7 @@
         short_description: my-problem
         state: new
         attachments:
-          - path: targets/attachment/res/sample_file1.txt
+          - path: "{{ collection_base_dir }}/tests/integration/targets/attachment/res/sample_file1.txt"
       register: first_problem
       check_mode: true
 
@@ -370,9 +370,9 @@
       servicenow.itsm.problem: &problem-update
         sys_id: "{{ first_problem.record.sys_id }}"
         attachments:
-          - path: targets/attachment/res/sample_file1.txt
+          - path: "{{ collection_base_dir }}/tests/integration/targets/attachment/res/sample_file1.txt"
             name: sample_file1.txt
-          - path: targets/attachment/res/sample_file1.txt
+          - path: "{{ collection_base_dir }}/tests/integration/targets/attachment/res/sample_file1.txt"
             name: sample_file2.txt
       check_mode: true
       register: result
@@ -399,7 +399,7 @@
       servicenow.itsm.problem:
         sys_id: "{{ first_problem.record.sys_id }}"
         attachments:
-          - path: targets/attachment/res/sample_file2.txt
+          - path: "{{ collection_base_dir }}/tests/integration/targets/attachment/res/sample_file2.txt"
             name: sample_file1.txt
       register: result
 

--- a/tests/integration/targets/attachment_info/tasks/main.yml
+++ b/tests/integration/targets/attachment_info/tasks/main.yml
@@ -16,7 +16,7 @@
         impact: low
         urgency: low
         attachments:
-          - path: targets/attachment_info/res/sample_file1.txt
+          - path: "{{ collection_base_dir }}/tests/integration/targets/attachment_info/res/sample_file1.txt"
       register: test_incident
 
     - ansible.builtin.assert:

--- a/tests/integration/targets/attachment_upload/tasks/main.yml
+++ b/tests/integration/targets/attachment_upload/tasks/main.yml
@@ -16,7 +16,7 @@
         impact: low
         urgency: low
         attachments:
-          - path: targets/attachment_upload/res/sample_file1.txt
+          - path: "{{ collection_base_dir }}/tests/integration/targets/attachment_upload/res/sample_file1.txt"
       register: test_incident
 
     - ansible.builtin.assert:
@@ -33,7 +33,7 @@
         table_name: incident
         table_sys_id: "{{ test_incident.record.sys_id }}"
         attachments:
-          - path: targets/attachment_upload/res/sample_file1.txt
+          - path: "{{ collection_base_dir }}/tests/integration/targets/attachment_upload/res/sample_file1.txt"
             name: sample_file1.txt
       register: result
 
@@ -52,7 +52,7 @@
         table_name: incident
         table_sys_id: "{{ test_incident.record.sys_id }}"
         attachments:
-          - path: targets/attachment_upload/res/sample_file2.txt
+          - path: "{{ collection_base_dir }}/tests/integration/targets/attachment_upload/res/sample_file2.txt"
             name: sample_file2.txt
       check_mode: true
       register: result
@@ -92,7 +92,7 @@
         table_name: incident
         table_sys_id: "{{ test_incident.record.sys_id }}"
         attachments:
-          - path: targets/attachment_upload/res/sample_file2.txt
+          - path: "{{ collection_base_dir }}/tests/integration/targets/attachment_upload/res/sample_file2.txt"
             name: sample_file1.txt
       register: result
 
@@ -111,9 +111,9 @@
         table_name: incident
         table_sys_id: "{{ test_incident.record.sys_id }}"
         attachments:
-          - path: targets/attachment_upload/res/sample_file2.txt
+          - path: "{{ collection_base_dir }}/tests/integration/targets/attachment_upload/res/sample_file2.txt"
             name: sample_file1.txt
-          - path: targets/attachment_upload/res/sample_file1.txt
+          - path: "{{ collection_base_dir }}/tests/integration/targets/attachment_upload/res/sample_file1.txt"
             name: sample_file
       register: result
 
@@ -132,11 +132,11 @@
         table_name: incident
         table_sys_id: "{{ test_incident.record.sys_id }}"
         attachments:
-          - path: targets/attachment_upload/res/sample_file1.txt
+          - path: "{{ collection_base_dir }}/tests/integration/targets/attachment_upload/res/sample_file1.txt"
             name: sample_file1.txt # to be updated
-          - path: targets/attachment_upload/res/sample_file2.txt
+          - path: "{{ collection_base_dir }}/tests/integration/targets/attachment_upload/res/sample_file2.txt"
             name: sample_file2.txt # no update
-          - path: targets/attachment_upload/res/sample_file2.txt
+          - path: "{{ collection_base_dir }}/tests/integration/targets/attachment_upload/res/sample_file2.txt"
             name: sample_file3.txt # new
       register: result
 

--- a/tests/integration/targets/change_request/tasks/main.yml
+++ b/tests/integration/targets/change_request/tasks/main.yml
@@ -30,7 +30,7 @@
         impact: low
         short_description: some short description
         attachments:
-          - path: targets/change_request/res/sample_file.txt
+          - path: "{{ collection_base_dir }}/tests/integration/targets/change_request/res/sample_file.txt"
       check_mode: true
       register: result
 

--- a/tests/integration/targets/configuration_item/tasks/main.yml
+++ b/tests/integration/targets/configuration_item/tasks/main.yml
@@ -13,7 +13,7 @@
         install_status: on_order
         operational_status: non_operational
         attachments:
-          - path: targets/configuration_item/res/sample_file.txt
+          - path: "{{ collection_base_dir }}/tests/integration/targets/configuration_item/res/sample_file.txt"
       register: base_ci
       check_mode: true
 
@@ -320,7 +320,7 @@
         install_status: on_order
         operational_status: non_operational
         attachments:
-          - path: targets/configuration_item/res/sample_file.txt
+          - path: "{{ collection_base_dir }}/tests/integration/targets/configuration_item/res/sample_file.txt"
       register: base_ci
 
     - name: Get info and select only name

--- a/tests/integration/targets/configuration_item_batch/tasks/main.yml
+++ b/tests/integration/targets/configuration_item_batch/tasks/main.yml
@@ -22,7 +22,7 @@
 
 
     - name: Update existing CMDB -- check mode --
-      configuration_item_batch: &update_cmdb
+      servicenow.itsm.configuration_item_batch: &update_cmdb
         sys_class_name: cmdb_ci_ec2_instance
         id_column_set: vm_inst_id
         dataset:
@@ -41,9 +41,8 @@
         that:
           - ci is changed
 
-
     - name: Update existing CMDB
-      configuration_item_batch: *update_cmdb
+      servicenow.itsm.configuration_item_batch: *update_cmdb
       register: ci
 
     - ansible.builtin.assert:
@@ -52,7 +51,7 @@
 
 
     - name: Configuration item info
-      configuration_item_info:
+      servicenow.itsm.configuration_item_info:
         sys_class_name: cmdb_ci_ec2_instance
         query:
           - vm_inst_id: "= {{ ci.records_raw[0].vm_inst_id }}"
@@ -76,7 +75,7 @@
 
 
     - name: Update CMDB with data from AWS
-      configuration_item_batch: &state_check_params
+      servicenow.itsm.configuration_item_batch: &state_check_params
         sys_class_name: cmdb_ci_ec2_instance
         id_column_set: vm_inst_id
         dataset:
@@ -100,7 +99,7 @@
 
 
     - name: Configuration item info
-      configuration_item_info:
+      servicenow.itsm.configuration_item_info:
         sys_class_name: cmdb_ci_ec2_instance
         query:
           - vm_inst_id: "= {{ ci.records_raw[0].vm_inst_id }}"
@@ -112,7 +111,7 @@
           - result.records[0].ip_address in ('1.2.3.4','4.3.2.1') 
     
     - name: Configuration item info
-      configuration_item_info:
+      servicenow.itsm.configuration_item_info:
         sys_class_name: cmdb_ci_ec2_instance
         query:
           - vm_inst_id: "= {{ ci.records_raw[1].vm_inst_id }}"
@@ -125,7 +124,7 @@
 
 
     - name: Update CMDB with different data
-      configuration_item_batch:
+      servicenow.itsm.configuration_item_batch:
         sys_class_name: cmdb_ci_ec2_instance
         id_column_set: vm_inst_id
         dataset:
@@ -149,7 +148,7 @@
 
 
     - name: Configuration item info
-      configuration_item_info:
+      servicenow.itsm.configuration_item_info:
         sys_class_name: cmdb_ci_ec2_instance
         query:
           - vm_inst_id: "= {{ ci.records_raw[0].vm_inst_id }}"
@@ -172,7 +171,7 @@
           - result is changed
     
     - name: Configuration item info
-      configuration_item_info:
+      servicenow.itsm.configuration_item_info:
         sys_class_name: cmdb_ci_ec2_instance
         query:
           - vm_inst_id: "= {{ ci.records_raw[1].vm_inst_id }}"
@@ -196,7 +195,7 @@
 
 
     - name: Configuration item info
-      configuration_item_info:
+      servicenow.itsm.configuration_item_info:
         sys_class_name: cmdb_ci_ec2_instance
         query:
           - vm_inst_id: "= {{ ci.records_raw[0].vm_inst_id }}"

--- a/tests/integration/targets/incident/tasks/main.yml
+++ b/tests/integration/targets/incident/tasks/main.yml
@@ -12,7 +12,7 @@
         impact: low
         urgency: low
         attachments:
-          - path: targets/incident/res/sample_file.txt
+          - path: "{{ collection_base_dir }}/tests/integration/targets/incident/res/sample_file.txt"
       check_mode: true
       register: result
 

--- a/tests/integration/targets/incident_with_mapping/tasks/main.yml
+++ b/tests/integration/targets/incident_with_mapping/tasks/main.yml
@@ -54,7 +54,7 @@
         impact: low
         urgency: low
         attachments:
-          - path: targets/incident_with_mapping/res/sample_file.txt
+          - path: "{{ collection_base_dir }}/targets/incident_with_mapping/res/sample_file.txt"
       check_mode: true
       register: result
 

--- a/tests/integration/targets/problem/tasks/main.yml
+++ b/tests/integration/targets/problem/tasks/main.yml
@@ -14,7 +14,7 @@
         short_description: my-problem
         state: new
         attachments:
-          - path: targets/problem/res/sample_file.txt
+          - path: "{{ collection_base_dir }}/tests/integration/targets/problem/res/sample_file.txt"
       register: first_problem
       check_mode: true
     - ansible.builtin.assert: &problem-create-assertions

--- a/tests/integration/targets/problem_with_mapping/tasks/main.yml
+++ b/tests/integration/targets/problem_with_mapping/tasks/main.yml
@@ -31,7 +31,7 @@
         short_description: my-problem
         state: my_new
         attachments:
-          - path: targets/problem_with_mapping/res/sample_file.txt
+          - path: "{{ collection_base_dir }}/tests/integration/targets/problem_with_mapping/res/sample_file.txt"
       register: first_problem
       check_mode: true
     - ansible.builtin.assert: &problem-create-assertions


### PR DESCRIPTION
This PR changes the relative path of the integration sample file to absolute.
Also, it fixes the module's full path for `configuration_item_batch` tasks.

Fixes downstream CI pipeline.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Integration tests