### PR TITLE
Filter Python 3.10 and Remove Tokyo

### DIFF
--- a/.github/workflows/integration_source.yml
+++ b/.github/workflows/integration_source.yml
@@ -28,6 +28,14 @@ on:
               "ansible-version": "stable-2.17",
               "python-version": "3.9"
             },
+            {
+              "ansible-version": "milestone",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "devel",
+              "python-version": "3.10"
+            },
           ]
         required: false
         type: string
@@ -52,15 +60,10 @@ jobs:
           - "3.11"
           - "3.12"
         servicenow-version:
-          - "tokyo"
           - "utah"
           - "vancouver"
           - "washington"
         include:
-          - servicenow-version: "tokyo"
-            sn_host_secret: SN_HOST_TOKYO
-            sn_username_secret: SN_USERNAME_TOKYO
-            sn_password_secret: SN_PASSWORD_TOKYO
           - servicenow-version: "utah"
             sn_host_secret: SN_HOST_UTAH
             sn_username_secret: SN_USERNAME_UTAH

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -83,6 +83,10 @@ jobs:
             },
             {
               "ansible-version": "milestone",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "milestone",
               "python-version": "3.12"
             },
             {
@@ -96,5 +100,9 @@ jobs:
             {
               "ansible-version": "devel",
               "python-version": "3.9"
+            },
+            {
+              "ansible-version": "devel",
+              "python-version": "3.10"
             }
           ]

--- a/.github/workflows/unit_source.yml
+++ b/.github/workflows/unit_source.yml
@@ -37,8 +37,16 @@ on:
               "python-version": "3.9"
             },
             {
+              "ansible-version": "milestone",
+              "python-version": "3.10"
+            },
+            {
               "ansible-version": "devel",
               "python-version": "3.9"
+            },
+            {
+              "ansible-version": "devel",
+              "python-version": "3.10"
             }
           ]
         required: false

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The Ansible Collection for ServiceNow IT Service Management ([ITSM](https://www.
 | Washington DC      | 2.5.0+                      | TBA                  |
 | Vancouver          | 2.5.0+                      | TBA                  |
 | Utah               | 2.1.0+                      | TBA                  |
-| Tokyo              | 2.1.0+                      | TBA                  |
+| Tokyo              | 2.1.0-2.6.1                 | Q2 2024              |
 
 <!--start requires_ansible-->
 ## Ansible version compatibility

--- a/changelogs/fragments/remove_tokyo.yml
+++ b/changelogs/fragments/remove_tokyo.yml
@@ -1,0 +1,3 @@
+---
+deprecated_features:
+  - tests - Drop testing of Tokyo, as it is no longer supported by ServiceNow


### PR DESCRIPTION
##### SUMMARY
Unit and Sanity tests fail on Python 3.10. Exclude it.
Tokyo is no longer supported by ServiceNow. Remove it.

##### COMPONENT NAME
Tests

