### PR TITLE
Add stable-2.17 targets with Python 3.10 exclusions

### DIFF
--- a/.github/workflows/integration_source.yml
+++ b/.github/workflows/integration_source.yml
@@ -29,6 +29,10 @@ on:
               "python-version": "3.9"
             },
             {
+              "ansible-version": "stable-2.17",
+              "python-version": "3.10"
+            },
+            {
               "ansible-version": "milestone",
               "python-version": "3.10"
             },
@@ -53,6 +57,7 @@ jobs:
         ansible-version:
           - stable-2.15
           - stable-2.16
+          - stable-2.17
           - milestone
           - devel
         python-version:

--- a/.github/workflows/unit_source.yml
+++ b/.github/workflows/unit_source.yml
@@ -33,6 +33,10 @@ on:
               "python-version": "3.9"
             },
             {
+              "ansible-version": "stable-2.17",
+              "python-version": "3.10"
+            },
+            {
               "ansible-version": "milestone",
               "python-version": "3.9"
             },


### PR DESCRIPTION
##### SUMMARY
Now that stable-2.17 is out add it explicitly

##### ISSUE TYPE
Test workflow update

