### PR TITLE
Add new release note to cover documentation problem

### DIFF
--- a/changelogs/fragments/release_summary.yml
+++ b/changelogs/fragments/release_summary.yml
@@ -1,0 +1,2 @@
+---
+release_summary: "Fix docs issue with 2.6.2 release"


### PR DESCRIPTION
##### SUMMARY
Changelog and version number were not properly aligned. Cutting new release to fix.