### PR TITLE
inventory: Implement aggregation of multiple variable values

### DIFF
--- a/changelogs/fragments/inventory_aggregation.yml
+++ b/changelogs/fragments/inventory_aggregation.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - inventory: allow inventory to aggregate multiple hostvars for the same host. (https://github.com/ansible-collections/servicenow.itsm/pull/408)
+  - inventory - allow inventory to aggregate multiple hostvars for the same host. (https://github.com/ansible-collections/servicenow.itsm/pull/408)

--- a/changelogs/fragments/inventory_aggregation.yml
+++ b/changelogs/fragments/inventory_aggregation.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - inventory: allow inventory to aggregate multiple hostvars for the same host. (https://github.com/ansible-collections/servicenow.itsm/pull/408)

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -120,6 +120,12 @@ options:
     type: bool
     default: false
     version_added: 1.3.0
+  aggregation:
+    description:
+      - Enable multiple variable values aggregations.
+    type: bool
+    default: false
+    version_added: 2.7.0
   inventory_hostname_source:
     type: str
     description:
@@ -329,6 +335,7 @@ keyed_groups:
 
 
 import os
+import hashlib
 
 from ansible.errors import AnsibleParserError
 from ansible.inventory.group import to_safe_group_name as orig_safe
@@ -350,6 +357,76 @@ from ..module_utils.relations import (
     enhance_records_with_rel_groups,
 )
 from ..module_utils.table import TableClient
+
+
+class Aggregator:
+    def __init__(self, columns):
+        self.data = dict()
+        self.tmp = None
+
+    def add(self, host, key, value):
+        parent, child = self._split(key)
+        if not self.tmp:
+            self.tmp = dict()
+
+        if not child:
+            self.tmp[parent] = value
+        else:
+            tmp_parent_data = self.tmp.get(parent)
+            if not tmp_parent_data:
+                tmp_parent_data = dict()
+
+            parent_data = dict()
+            parent_data[child] = value
+            if isinstance(tmp_parent_data, str):
+                parent_data[parent] = tmp_parent_data
+            else:
+                for k, v in tmp_parent_data.items():
+                    parent_data[k] = v
+
+            self.tmp[parent] = parent_data
+
+    def commit(self, host):
+        if not self.tmp:
+            return
+        host_data = self.data.get(host, dict())
+        for k, v in self.tmp.items():
+            if k in host_data:
+                vv = host_data.get(k)
+                if isinstance(vv, list):
+                    if not self._is_exists(vv, v):
+                        vv.append(v)
+                continue
+            if isinstance(v, dict):
+                host_data[k] = [v]
+                continue
+            host_data[k] = v
+        self.tmp = None
+        self.data[host] = host_data
+
+    def aggregate(self, inventory):
+        for host, data in self.data.items():
+            for k, v in data.items():
+                inventory.set_variable(host, k, v)
+
+    def _split(self, column):
+        if "." not in column:
+            return column, ""
+        parts = column.split(".")
+        return parts[0], parts[1]
+
+    def _is_exists(self, items, item):
+        hash_v = self._hash_dict(item)
+        for i in items:
+            if self._hash_dict(i) == hash_v:
+                return True
+        return False
+
+    def _hash_dict(self, d):
+        h = hashlib.sha256()
+        d_sorted = str(dict(sorted(d.items())))
+        h.update(d_sorted.encode())
+        return h.hexdigest()
 
 
 def construct_sysparm_query(query, is_encoded_query):
@@ -445,6 +522,11 @@ class InventoryModule(BaseInventoryPlugin, ConstructableWithLookup, Cacheable):
         for k in columns:
             self.inventory.set_variable(host, k.replace(".", "_"), record[k])
 
+    def set_host_vars_aggregated(self, host, record, columns, aggregator):
+        for k in columns:
+            aggregator.add(host, k, record[k])
+        aggregator.commit(host)
+
     def fill_constructed(
         self,
         records,
@@ -455,16 +537,26 @@ class InventoryModule(BaseInventoryPlugin, ConstructableWithLookup, Cacheable):
         keyed_groups,
         strict,
         enhanced,
+        aggregation,
     ):
+        if aggregation:
+            aggregator = Aggregator(columns)
+
         for record in records:
             host = self.add_host(record, name_source)
             if host:
-                self.set_hostvars(host, record, columns)
+                if aggregation:
+                    self.set_host_vars_aggregated(host, record, columns, aggregator)
+                else:
+                    self.set_hostvars(host, record, columns)
+
                 self._set_composite_vars(compose, record, host, strict)
                 self._add_host_to_composed_groups(groups, record, host, strict)
                 self._add_host_to_keyed_groups(keyed_groups, record, host, strict)
                 if enhanced:
                     self.fill_enhanced_auto_groups(record, host)
+        if aggregation:
+            aggregator.aggregate(self.inventory)
 
     def fill_enhanced_auto_groups(self, record, host):
         for rel_group in record["relationship_groups"]:
@@ -569,6 +661,7 @@ class InventoryModule(BaseInventoryPlugin, ConstructableWithLookup, Cacheable):
             raise AnsibleParserError(e)
 
         enhanced = self.get_option("enhanced")
+        aggregation = self.get_option("aggregation")
 
         sysparm_limit = self.get_option("sysparm_limit")
         if sysparm_limit:
@@ -647,4 +740,5 @@ class InventoryModule(BaseInventoryPlugin, ConstructableWithLookup, Cacheable):
             self.get_option("keyed_groups"),
             self.get_option("strict"),
             enhanced,
+            aggregation,
         )


### PR DESCRIPTION
This PR fixes the aggregation of multiple host variable values. 

Let's say SNow returns something like this:
```
{'u_name': 'First_app', 'u_parent': 'tomcat_aqwidmvs', 'sys_id': 'a7dc8d0633a8d210392d0e570e5c7bb4', 'u_child': 'i101', 'u_level': '1', 'u_child.name': 'i101', 'u_child.ip_address': '10.1.0.101', 'u_parent.support_group': 'Application Development', 'u_parent.name': 'tomcat_aqwidmvs'}
{'u_name': 'Second app', 'u_parent': 'tomcat_pxgnodig', 'sys_id': 'f9fc8d0633a8d210392d0e570e5c7bff', 'u_child': 'i101', 'u_level': '1', 'u_child.name': 'i101', 'u_child.ip_address': '10.1.0.101', 'u_parent.support_group': 'Application Development', 'u_parent.name': 'tomcat_pxgnodig'}
```
For the same host, we have two records with different values: u_parent, u_parent.name, u_parent.support_group, u_parent.name.

This change will aggregate these values as follows:
```
all:
  children:
    ungrouped:
      hosts:
        i101:
          sys_id: a7dc8d0633a8d210392d0e570e5c7bb4
          u_child:
          - ip_address: 10.1.0.101
            name: i101
          u_level: '1'
          u_parent:
          - name: tomcat_aqwidmvs
            support_group: Application Development
            u_parent: tomcat_aqwidmvs
          - name: tomcat_pxgnodig
            support_group: Application Development
            u_parent: tomcat_pxgnodig
          u_type: active
```

To enable this aggregation, the inventory must have:
```
experimental_aggregation: true
```