### PR TITLE
Backward-compatible query limiting feature

### DIFF
--- a/changelogs/fragments/query_limiting.yml
+++ b/changelogs/fragments/query_limiting.yml
@@ -1,0 +1,7 @@
+---
+minor_changes:
+ - inventory - The inventory plugin now supports limiting the number of columns
+   returned in the query. Users who wish to use this feature in conjunction with
+   compose will need to add columns referenced by compose to the query
+   additional_columns option. The default case preserves backwards compatibility
+   by not limiting the columns returned.

--- a/tests/integration/targets/inventory/files/constructed_fail.now.yml
+++ b/tests/integration/targets/inventory/files/constructed_fail.now.yml
@@ -1,0 +1,33 @@
+---
+plugin: servicenow.itsm.now
+table: cmdb_ci_ec2_instance
+
+query_only_columns:
+  - state
+  - environment
+  - fqdn
+  - ip_address
+  - name
+
+columns:
+  - state
+  - environment
+  - fqdn
+  - ip_address
+  - failme
+
+compose:
+  ansible_host: fqdn
+  name: name
+  ip_address: ip_address
+  env: environment
+
+groups:
+  production: |
+    environment == "Production"
+
+  development: |
+    environment == "Development"
+
+  os_OS1: |
+    guest_os_fullname == "OS1"

--- a/tests/integration/targets/inventory/files/constructed_limit_additional.now.yml
+++ b/tests/integration/targets/inventory/files/constructed_limit_additional.now.yml
@@ -1,0 +1,31 @@
+---
+plugin: servicenow.itsm.now
+table: cmdb_ci_ec2_instance
+
+query_limit_columns: true
+
+columns:
+  - state
+  - environment
+  - fqdn
+  - ip_address
+  - name
+
+query_additional_columns:
+  - guest_os_fullname
+
+compose:
+  ansible_host: fqdn
+  name: name
+  ip_address: ip_address
+  env: environment
+
+groups:
+  production: |
+    environment == "Production"
+
+  development: |
+    environment == "Development"
+
+  os_OS1: |
+    guest_os_fullname == "OS1"

--- a/tests/integration/targets/inventory/files/constructed_limit_bare.now.yml
+++ b/tests/integration/targets/inventory/files/constructed_limit_bare.now.yml
@@ -1,0 +1,29 @@
+---
+plugin: servicenow.itsm.now
+table: cmdb_ci_ec2_instance
+
+query_limit_columns: true
+
+columns:
+  - state
+  - environment
+  - fqdn
+  - ip_address
+  - name
+  - guest_os_fullname
+
+compose:
+  ansible_host: fqdn
+  name: name
+  ip_address: ip_address
+  env: environment
+
+groups:
+  production: |
+    environment == "Production"
+
+  development: |
+    environment == "Development"
+
+  os_OS1: |
+    guest_os_fullname == "OS1"

--- a/tests/integration/targets/inventory/playbooks/constructed_fail.yml
+++ b/tests/integration/targets/inventory/playbooks/constructed_fail.yml
@@ -1,0 +1,12 @@
+---
+- name: Test constructed options designed to fail
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - block:
+        - name: Make sure we have 0 groups as expected
+          ansible.builtin.assert:
+            that:
+              - groups.all | length == 0  # Also includes all and ungrouped
+              - groups.ungrouped | length == 0

--- a/tests/integration/targets/inventory/playbooks/constructed_limit_additional.yml
+++ b/tests/integration/targets/inventory/playbooks/constructed_limit_additional.yml
@@ -1,0 +1,68 @@
+---
+- name: Test constructed limit options
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - block:
+        - name: Create imaginary VMs
+          servicenow.itsm.configuration_item:
+            name: i{{ item }}
+            sys_class_name: cmdb_ci_ec2_instance
+            ip_address: 10.1.0.{{ item }}
+            environment: "{{ (item % 2 == 0) | ansible.builtin.ternary('development', 'production') }}"
+            other:
+              fqdn: f{{ item }}.example.com
+              guest_os_fullname: "{{ (item < 106) | ansible.builtin.ternary('OS0', 'OS1') }}"
+              vm_inst_id: i{{ item }}
+          loop: "{{ range(101, 109) | list }}"
+          register: vms
+
+        - name: Reload inventory
+          ansible.builtin.meta: refresh_inventory
+
+        - name: Make sure we have all expected groups
+          ansible.builtin.assert:
+            that:
+              - groups.all | length == 8  # Also includes all and ungrouped
+              - groups.ungrouped | length == 0
+              - groups.development | sort | list == ["i102", "i104", "i106", "i108"]
+              - groups.production | sort | list == ["i101", "i103",  "i105", "i107"]
+              - groups.os_OS1 | sort | list == ["i106", "i107", "i108"]
+              - "'OS0' not in groups"
+
+        - name: Check i106
+          ansible.builtin.assert:
+            that:
+              - hostvars.i106.inventory_hostname == "i106"
+              - hostvars.i106.ansible_host == "f106.example.com"
+              - hostvars.i106.name == "i106"
+              - hostvars.i106.ip_address == "10.1.0.106"
+              - hostvars.i106.env == "Development"
+
+        - name: Check i107
+          ansible.builtin.assert:
+            that:
+              - hostvars.i107.inventory_hostname == "i107"
+              - hostvars.i107.ansible_host == "f107.example.com"
+              - hostvars.i107.name == "i107"
+              - hostvars.i107.ip_address == "10.1.0.107"
+              - hostvars.i107.env == "Production"
+
+        - name: Check i108
+          ansible.builtin.assert:
+            that:
+              - hostvars.i108.inventory_hostname == "i108"
+              - hostvars.i108.ansible_host == "f108.example.com"
+              - hostvars.i108.name == "i108"
+              - hostvars.i108.ip_address == "10.1.0.108"
+              - hostvars.i108.env == "Development"
+
+      always:
+        - name: Delete VMs
+          servicenow.itsm.configuration_item:
+            state: absent
+            sys_id: "{{ item.record.sys_id }}"
+          loop: "{{ vms.results }}"
+          loop_control:
+            label: "{{ item.record.name }}"

--- a/tests/integration/targets/inventory/playbooks/constructed_limit_bare.yml
+++ b/tests/integration/targets/inventory/playbooks/constructed_limit_bare.yml
@@ -1,0 +1,68 @@
+---
+- name: Test constructed limit options without additional columns listed
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - block:
+        - name: Create imaginary VMs
+          servicenow.itsm.configuration_item:
+            name: i{{ item }}
+            sys_class_name: cmdb_ci_ec2_instance
+            ip_address: 10.1.0.{{ item }}
+            environment: "{{ (item % 2 == 0) | ansible.builtin.ternary('development', 'production') }}"
+            other:
+              fqdn: f{{ item }}.example.com
+              guest_os_fullname: "{{ (item < 106) | ansible.builtin.ternary('OS0', 'OS1') }}"
+              vm_inst_id: i{{ item }}
+          loop: "{{ range(101, 109) | list }}"
+          register: vms
+
+        - name: Reload inventory
+          ansible.builtin.meta: refresh_inventory
+
+        - name: Make sure we have all expected groups
+          ansible.builtin.assert:
+            that:
+              - groups.all | length == 8  # Also includes all and ungrouped
+              - groups.ungrouped | length == 0
+              - groups.development | sort | list == ["i102", "i104", "i106", "i108"]
+              - groups.production | sort | list == ["i101", "i103",  "i105", "i107"]
+              - groups.os_OS1 | sort | list == ["i106", "i107", "i108"]
+              - "'OS0' not in groups"
+
+        - name: Check i106
+          ansible.builtin.assert:
+            that:
+              - hostvars.i106.inventory_hostname == "i106"
+              - hostvars.i106.ansible_host == "f106.example.com"
+              - hostvars.i106.name == "i106"
+              - hostvars.i106.ip_address == "10.1.0.106"
+              - hostvars.i106.env == "Development"
+
+        - name: Check i107
+          ansible.builtin.assert:
+            that:
+              - hostvars.i107.inventory_hostname == "i107"
+              - hostvars.i107.ansible_host == "f107.example.com"
+              - hostvars.i107.name == "i107"
+              - hostvars.i107.ip_address == "10.1.0.107"
+              - hostvars.i107.env == "Production"
+
+        - name: Check i108
+          ansible.builtin.assert:
+            that:
+              - hostvars.i108.inventory_hostname == "i108"
+              - hostvars.i108.ansible_host == "f108.example.com"
+              - hostvars.i108.name == "i108"
+              - hostvars.i108.ip_address == "10.1.0.108"
+              - hostvars.i108.env == "Development"
+
+      always:
+        - name: Delete VMs
+          servicenow.itsm.configuration_item:
+            state: absent
+            sys_id: "{{ item.record.sys_id }}"
+          loop: "{{ vms.results }}"
+          loop_control:
+            label: "{{ item.record.name }}"


### PR DESCRIPTION
##### SUMMARY
Add a new parameter to limit queries to the database in inventory queries, inspired by @demonpig's approach

Fixes AAP-40052

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Inventory plugin

##### ADDITIONAL INFORMATION

Example usage:

This inventory would activate the query limiting feature by setting query_limit_columns to true. query_additional_columns need only list those columns that are not listed in the columns section; those will be included and the full list will be deduplicated before sending to the backend for processing.

The intention here is to limit the amount of data that the client must process when retrieving inventory data. This can be substantial. Note that the limiting of the query happens only when query_only_columns is specified; the default
behavior is to query the entire table as documentation examples and no doubt lots of deployed code already depend on.

```paste below
---
plugin: servicenow.itsm.now
table: cmdb_ci_ec2_instance
 
query_limit_columns: true

query_additional_columns:
  - name
 
columns:
  - state
  - environment
  - fqdn
  - ip_address
 
compose:
  ansible_host: fqdn
  name: name
  ip_address: ip_address
  env: environment
  schedule: schedule
 
groups:
  production: |
    environment == "Production"
 
  development: |
    environment == "Development"
 
  os_OS1: |
    guest_os_fullname == "OS1"
```
