### PR TITLE
Call .get() from the dict, not the string

### DIFF
--- a/plugins/module_utils/generic.py
+++ b/plugins/module_utils/generic.py
@@ -111,7 +111,7 @@ class GenericClient(snow.SNowClient):
         if FIELD_SYS_ID in record:
             sys_id = record.get(FIELD_SYS_ID)
             if isinstance(sys_id, dict):
-                # records from Change Request API has FIELD_SYS_ID as dict
+                # records from Change Request API has sys_id as dict
                 return sys_id.get("value")
             return record.get(FIELD_SYS_ID)
 

--- a/plugins/module_utils/generic.py
+++ b/plugins/module_utils/generic.py
@@ -112,7 +112,7 @@ class GenericClient(snow.SNowClient):
             sys_id = record.get(FIELD_SYS_ID)
             if isinstance(sys_id, dict):
                 # records from Change Request API has FIELD_SYS_ID as dict
-                return FIELD_SYS_ID.get("value")
+                return sys_id.get("value")
             return record.get(FIELD_SYS_ID)
 
         # cmdb record


### PR DESCRIPTION
##### SUMMARY

This is currently trying to call `.get()` from a string, which causes the following to be raised:

```
AttributeError: 'str' object has no attribute 'get'
```

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

change_request

##### ADDITIONAL INFORMATION

Try and update a change request task using Ansible, and you will get this error. With this change applied locally it updates the records with no issues.