### PR TITLE
fix unit tests for devel and 2.19

### DIFF
--- a/changelogs/fragments/435-update-unit-tests-for-2.19.yaml
+++ b/changelogs/fragments/435-update-unit-tests-for-2.19.yaml
@@ -2,3 +2,4 @@ bugfixes:
   - Update the unit tests to be compatible with ansible-core 2.19
 minor_changes:
   - plugins/action/api - Mark the template field as a trusted template source. This was the default behaviour of ansible-core until 2.19
+  - plugins/modules/change_request_task - Throw an error if state=='pending' and on_hold=True, like the documentation says

--- a/changelogs/fragments/435-update-unit-tests-for-2.19.yaml
+++ b/changelogs/fragments/435-update-unit-tests-for-2.19.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Update the unit tests to be compatible with ansible-core 2.19

--- a/changelogs/fragments/435-update-unit-tests-for-2.19.yaml
+++ b/changelogs/fragments/435-update-unit-tests-for-2.19.yaml
@@ -1,2 +1,4 @@
 bugfixes:
   - Update the unit tests to be compatible with ansible-core 2.19
+minor_changes:
+  - plugins/action/api - Mark the template field as a trusted template source. This was the default behaviour of ansible-core until 2.19

--- a/plugins/action/api.py
+++ b/plugins/action/api.py
@@ -23,6 +23,13 @@ from ansible.module_utils.six import iteritems
 from ansible.plugins.action import ActionBase
 from yaml import Loader
 
+try:
+    from ansible.template import trust_as_template as _trust_as_template
+
+    HAS_DATATAGGING = True
+except ImportError:
+    HAS_DATATAGGING = False
+
 from ..module_utils.api import FIELD_DATA, FIELD_TEMPLATE
 
 
@@ -170,6 +177,8 @@ class ActionModule(ActionBase):
                         )
             self._templar.available_variables = copy.deepcopy(task_vars)
             # rendered_template's a string which is going to be dumped into dict
+            if HAS_DATATAGGING:
+                template_data = _trust_as_template(template_data)
             rendered_template = self._templar.do_template(
                 template_data,
                 preserve_trailing_newlines=True,

--- a/plugins/modules/change_request_task.py
+++ b/plugins/modules/change_request_task.py
@@ -214,7 +214,7 @@ def validate_params(params, change_task=None):
             )
         )
 
-    if params['state'] == "pending" and params['on_hold']:
+    if params["state"] == "pending" and params["on_hold"]:
         raise errors.ServiceNowError(
             "Cannot put a task in state pending while on_hold is True"
         )

--- a/plugins/modules/change_request_task.py
+++ b/plugins/modules/change_request_task.py
@@ -214,6 +214,11 @@ def validate_params(params, change_task=None):
             )
         )
 
+    if params['state'] == "pending" and params['on_hold']:
+        raise errors.ServiceNowError(
+            "Cannot put a task in state pending while on_hold is True"
+        )
+
     # Description must be set
     missing.extend(
         validation.missing_from_params_and_remote(

--- a/tests/integration/generate_integration_config.sh
+++ b/tests/integration/generate_integration_config.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+
+{
+    echo "sn_host: '$SN_HOST'"
+    echo "sn_username: '$SN_USERNAME'"
+    echo "sn_password: '$SN_PASSWORD'"
+    echo "collection_base_dir: '$SCRIPT_DIR/../..'"
+} > "$SCRIPT_DIR/integration_config.yml"

--- a/tests/integration/targets/itsm_api/tasks/main.yml
+++ b/tests/integration/targets/itsm_api/tasks/main.yml
@@ -57,7 +57,6 @@
       register: first_incident
     - ansible.builtin.assert: *api-create-assertions-data
 
-
     - name: Retrieve all incidents after creating a new resource
       servicenow.itsm.api_info:
         resource: incident
@@ -177,7 +176,7 @@
       servicenow.itsm.api:
         resource: incident
         action: post
-        template: "test_template_post.j2"
+        template: "{{ role_path }}/templates/test_template_post.j2"
       vars: &template-vars
         short_desc: "short"
         long_desc: "looooooooong description"
@@ -193,7 +192,7 @@
         resource: incident
         action: patch
         sys_id: "{{ result.record.sys_id }}"
-        template: "test_template_patch.j2"
+        template: "{{ role_path }}/templates/test_template_patch.j2"
       vars: *template-vars
       register: result
     - ansible.builtin.assert:

--- a/tests/integration/targets/itsm_change_request/tasks/main.yml
+++ b/tests/integration/targets/itsm_change_request/tasks/main.yml
@@ -45,7 +45,6 @@
           - result.record.attachments | length != 0
           - result.record.attachments[0].file_name == "sample_file.txt"
 
-
     - name: Create test change_request
       servicenow.itsm.change_request: *create-change_request
       register: test_result
@@ -55,7 +54,6 @@
         result: "{{ test_result }}"
 
     - ansible.builtin.assert: *create-change_request-result
-
 
     - name: Make sure change_request exists
       servicenow.itsm.change_request_info:
@@ -71,7 +69,6 @@
           - result.records[0].impact == "low"
           - "'Resend the complete BGP table to neighboring routers' in result.records[0].description"
 
-
     - name: Update change_request with same priority, risk and impact - unchanged
       servicenow.itsm.change_request:
         requested_by: admin
@@ -84,7 +81,6 @@
     - ansible.builtin.assert:
         that:
           - result is not changed
-
 
     - name: Update state to scheduled without assignment_group - should throw an error
       servicenow.itsm.change_request:
@@ -99,7 +95,6 @@
           - result is failed
           - "'state is scheduled but all of the following are missing: assignment_group' in result.msg"
 
-
     - name: Attempt to put the change request on hold without specifying the reason
       servicenow.itsm.change_request:
         number: "{{ test_result.record.number }}"
@@ -110,8 +105,7 @@
     - ansible.builtin.assert:
         that:
           - result is failed
-          - "'on_hold is True but all of the following are missing: hold_reason'"
-
+          - "'on_hold is True but all of the following are missing: hold_reason' in result.msg"
 
     - name: Update change_request - check mode
       servicenow.itsm.change_request: &update-change_request
@@ -133,12 +127,10 @@
           - result.record.risk == "high"
           - result.record.impact == "high"
 
-
     - name: Update change_request
       servicenow.itsm.change_request: *update-change_request
 
     - ansible.builtin.assert: *update-change_request-result
-
 
     - name: Make sure change_request was updated
       servicenow.itsm.change_request_info:
@@ -148,11 +140,10 @@
     - ansible.builtin.assert:
         that:
           - result.records[0].number == test_result.record.number
-          - result.records[0].state == "scheduled" 
+          - result.records[0].state == "scheduled"
           - result.records[0].priority == "high"
           - result.records[0].risk == "high"
           - result.records[0].impact == "high"
-
 
     - name: Update change_request with same params - unchanged
       servicenow.itsm.change_request: *update-change_request
@@ -161,7 +152,6 @@
     - ansible.builtin.assert:
         that:
           - result is not changed
-
 
     - name: Update change_request state to implement - check mode
       servicenow.itsm.change_request: &update-change_request-state-implement
@@ -176,12 +166,10 @@
           - result is changed
           - result.record.state == "implement"
 
-
     - name: Update change_request state to implement
       servicenow.itsm.change_request: *update-change_request-state-implement
 
     - ansible.builtin.assert: *update-change_request-state-result-implement
-
 
     - name: Make sure state of change_request was updated
       servicenow.itsm.change_request_info:
@@ -191,8 +179,7 @@
     - ansible.builtin.assert:
         that:
           - result.records[0].number == test_result.record.number
-          - result.records[0].state == "implement" 
-
+          - result.records[0].state == "implement"
 
     - name: Update change_request with same state - unchanged
       servicenow.itsm.change_request: *update-change_request-state-implement
@@ -201,7 +188,6 @@
     - ansible.builtin.assert:
         that:
           - result is not changed
-
 
     - name: Update change_request state to review - check mode
       servicenow.itsm.change_request: &update-change_request-state-review
@@ -216,12 +202,10 @@
           - result is changed
           - result.record.state == "review"
 
-
     - name: Update change_request state to review
       servicenow.itsm.change_request: *update-change_request-state-review
 
     - ansible.builtin.assert: *update-change_request-state-result-review
-
 
     - name: Make sure state of change_request was updated
       servicenow.itsm.change_request_info:
@@ -231,8 +215,7 @@
     - ansible.builtin.assert:
         that:
           - result.records[0].number == test_result.record.number
-          - result.records[0].state == "review" 
-
+          - result.records[0].state == "review"
 
     - name: Update change_request with same state - unchanged
       servicenow.itsm.change_request: *update-change_request-state-review
@@ -241,7 +224,6 @@
     - ansible.builtin.assert:
         that:
           - result is not changed
-
 
     - name: Fail to close the change
       servicenow.itsm.change_request:
@@ -254,7 +236,6 @@
           - result is failed
           - "'close_code' in result.msg"
           - "'close_notes' in result.msg"
-
 
     - name: Update change_request state to closed - check mode
       servicenow.itsm.change_request: &update-change_request-state-closed
@@ -271,25 +252,22 @@
           - result is changed
           - result.record.state == "closed"
 
-
     - name: Update change_request state to closed
       servicenow.itsm.change_request: *update-change_request-state-closed
 
     - ansible.builtin.assert: *update-change_request-state-result-closed
 
-
     - name: Get change_request info by sysparm query - state and close_notes
       servicenow.itsm.change_request_info:
         query:
-         - state: = closed
-           close_notes: = Done testing
+          - state: = closed
+            close_notes: = Done testing
       register: result
 
     - ansible.builtin.assert:
         that:
           - result.records[0].state == "closed"
           - result.records[0].close_notes == "Done testing"
-
 
     - name: Make sure change_request state was updated and is in closed state
       servicenow.itsm.change_request_info:
@@ -303,14 +281,13 @@
           - result.records[0].close_code == "successful"
           - result.records[0].close_notes == "Done testing"
 
-
     - name: Get specific change request info by sysparm query
       servicenow.itsm.change_request_info:
         query:
-         - number: = {{ test_result.record.number }}
-           state: = closed
-           close_code: = successful
-           close_notes: = Done testing
+          - number: = {{ test_result.record.number }}
+            state: = closed
+            close_code: = successful
+            close_notes: = Done testing
       register: result
 
     - ansible.builtin.assert:
@@ -320,7 +297,6 @@
           - result.records[0].state == "closed"
           - result.records[0].close_code == "successful"
           - result.records[0].close_notes == "Done testing"
-
 
     - name: Update change_request with same state - unchanged
       servicenow.itsm.change_request: *update-change_request-state-closed
@@ -334,7 +310,7 @@
       servicenow.itsm.change_request_info:
         number: "{{ test_result.record.number }}"
         query:
-         - short_description: LIKE Oracle
+          - short_description: LIKE Oracle
       ignore_errors: true
       register: result
 
@@ -343,11 +319,10 @@
           - result is failed
           - "'parameters are mutually exclusive: number|query' in result.msg"
 
-
     - name: Test invalid operator detection
       servicenow.itsm.change_request_info:
         query:
-         - short_description: LIKEE Oracle
+          - short_description: LIKEE Oracle
       ignore_errors: true
       register: result
 
@@ -356,22 +331,20 @@
           - result is failed
           - "'Invalid condition' in result.msg"
 
-
     - name: Get change_request info by sysparm query - short_description
       servicenow.itsm.change_request_info:
         query:
-         - short_description: LIKE some
+          - short_description: LIKE some
       register: result
 
     - ansible.builtin.assert:
         that:
           - "'some' in result.records[0].short_description"
 
-
     - name: Test unary operator with argument detection
       servicenow.itsm.change_request_info:
         query:
-         - short_description: ISEMPTY SAP
+          - short_description: ISEMPTY SAP
       ignore_errors: true
       register: result
 
@@ -380,11 +353,10 @@
           - result is failed
           - "'Operator ISEMPTY does not take any arguments' in result.msg"
 
-
     - name: Test sysparm query unary operator - short_description
       servicenow.itsm.change_request_info:
         query:
-         - short_description: ISNOTEMPTY
+          - short_description: ISNOTEMPTY
       register: result
 
     - ansible.builtin.assert:
@@ -403,12 +375,10 @@
         that:
           - result is changed
 
-
     - name: Delete change_request
       servicenow.itsm.change_request: *delete-change_request
 
     - ansible.builtin.assert: *delete-change_request-result
-
 
     - name: Make sure change_request is absent
       servicenow.itsm.change_request_info:
@@ -419,7 +389,6 @@
         that:
           - result.records | length == 0
 
-
     - name: Delete change_request - unchanged
       servicenow.itsm.change_request: *delete-change_request
       register: result
@@ -427,7 +396,6 @@
     - ansible.builtin.assert:
         that:
           - result is not changed
-
 
     # Test closing the change_request with assignment_group sys_id
     - name: Create test change_request to be used in testing assignment_group sys_id
@@ -440,7 +408,7 @@
         risk: low
         impact: low
       register: test_result
-      
+
     # To avoid clashes between run we need to choose a new assignment_group for each python/ansible combination
     - set_fact:
         instance: "py{{ ansible_facts.python.version.major }}.{{ ansible_facts.python.version.minor }}-ansible-{{ ansible_version.major }}.{{ ansible_version.minor }}"
@@ -457,13 +425,11 @@
         risk: high
         impact: high
 
-
     - name: Update change_request state to implement
       servicenow.itsm.change_request:
         requested_by: admin
         number: "{{ test_result.record.number }}"
         state: implement
-   
 
     - name: Update change_request state to review
       servicenow.itsm.change_request:
@@ -475,7 +441,6 @@
     - ansible.builtin.debug:
         var: result.record
 
-
     - name: Close change_request using assignment_group sys_id
       servicenow.itsm.change_request:
         requested_by: admin
@@ -484,7 +449,6 @@
         close_code: successful
         assignment_group_id: "{{ result.record.assignment_group }}"
         close_notes: "Closed using assignment_group_id"
-  
 
     - name: Make sure change_request state was updated and is in closed state
       servicenow.itsm.change_request_info:
@@ -495,13 +459,11 @@
         that:
           - result.records[0].state == "closed"
 
-
-    - name: Delete change_request 
+    - name: Delete change_request
       servicenow.itsm.change_request:
         requested_by: admin
         number: "{{ result.records[0].number }}"
         state: absent
-
 
     - name: Update category choices
       servicenow.itsm.api:
@@ -517,7 +479,7 @@
     - set_fact:
         solved_remotely_choice: "{{ change_request_category.record.sys_id }}"
 
-    - name: Create change_request 
+    - name: Create change_request
       servicenow.itsm.change_request:
         requested_by: admin
         state: new
@@ -539,13 +501,13 @@
           - chg_request.record.risk == "low"
           - chg_request.record.impact == "low"
           - chg_request.record.category == "Software"
-    
+
     - name: Update change_request with new option
       servicenow.itsm.change_request:
         number: "{{ chg_request.record.number }}"
         category: hardware
-    
-    - name: Get change_request 
+
+    - name: Get change_request
       servicenow.itsm.change_request_info:
         number: "{{ chg_request.record.number }}"
       register: result
@@ -553,12 +515,12 @@
     - ansible.builtin.assert:
         that:
           - result.records[0].category == "hardware"
-    
+
     - name: Delete change_request
       servicenow.itsm.change_request:
         sys_id: "{{ chg_request.record.sys_id }}"
         state: absent
-    
+
     - name: Delete change_request choices
       servicenow.itsm.api:
         resource: sys_choice

--- a/tests/integration/targets/itsm_change_request_task/tasks/main.yml
+++ b/tests/integration/targets/itsm_change_request_task/tasks/main.yml
@@ -20,7 +20,7 @@
 
   block:
     - name: Create test change_request for referencing in change tasks
-      servicenow.itsm.change_request: 
+      servicenow.itsm.change_request:
         requested_by: admin
         state: new
         type: standard
@@ -64,7 +64,6 @@
           - result.record.description == "Implement collision avoidance based on the newly installed TOF sensor arrays."
           - result.record.approval == "approved"
 
-
     - name: Create test change_request_task
       servicenow.itsm.change_request_task: *create-change_request_task
       register: test_result
@@ -73,7 +72,6 @@
         result: "{{ test_result }}"
 
     - ansible.builtin.assert: *create-change_request_task-result
-
 
     - name: Make sure change_request_task exists
       servicenow.itsm.change_request_task_info:
@@ -90,7 +88,6 @@
           - result.records[0].description == "Implement collision avoidance based on the newly installed TOF sensor arrays."
           - result.records[0].approval == "approved"
 
-
     - name: Update change_request_task with same type, state and ID (previously set from its name)
       servicenow.itsm.change_request_task:
         number: "{{ test_result.record.number }}"
@@ -103,7 +100,6 @@
         that:
           - result is not changed
 
-
     - name: Set on hold (should fail since the reason is not set)
       servicenow.itsm.change_request_task:
         number: "{{ test_result.record.number }}"
@@ -114,21 +110,20 @@
     - ansible.builtin.assert:
         that:
           - result is failed
-          - "'on_hold is True but all of the following are missing: hold_reason'"
-
+          - "'on_hold is True but all of the following are missing: hold_reason' in result.msg"
 
     - name: Set on hold while in state pending (should fail due to on_hold and state value incompatibility)
       servicenow.itsm.change_request_task:
         on_hold: true
         hold_reason: "Not enough resources for the task"
+        state: pending
       ignore_errors: true
       register: result
 
     - ansible.builtin.assert:
         that:
           - result is failed
-          - "'Cannot put a task in state \"pending\" on hold'"
-
+          - "'Cannot put a task in state pending while on_hold is True' in result.msg"
 
     - name: Update change_request_task - check mode
       servicenow.itsm.change_request_task: &update-change_request_task
@@ -146,12 +141,10 @@
           - result.record.description == "Something changed"
           - result.record.change_task_type == "planning"
 
-
     - name: Update change_request_task
       servicenow.itsm.change_request_task: *update-change_request_task
 
     - ansible.builtin.assert: *update-change_request_task-result
-
 
     - name: Make sure change_request_task was updated
       servicenow.itsm.change_request_task_info:
@@ -165,7 +158,6 @@
           - result.records[0].description == "Something changed"
           - result.records[0].change_task_type == "planning"
 
-
     - name: Update change_request_task with same params - unchanged
       servicenow.itsm.change_request_task: *update-change_request_task
       register: result
@@ -174,25 +166,24 @@
         that:
           - result is not changed
 
-
     - name: Update change_request_task planned_end_date - check mode
-      servicenow.itsm.change_request_task: &update-change_request_task-planned_end_date
+      servicenow.itsm.change_request_task:
+        &update-change_request_task-planned_end_date
         number: "{{ test_result.record.number }}"
         planned_end_date: 2021-07-15 08:00:00
       check_mode: true
       register: result
 
-    - ansible.builtin.assert: &update-change_request_task-planned_end_date-result
+    - ansible.builtin.assert:
+        &update-change_request_task-planned_end_date-result
         that:
           - result is changed
           - result.record.planned_end_date == "2021-07-15T08:00:00"
-
 
     - name: Update change_request_task planned_end_date
       servicenow.itsm.change_request_task: *update-change_request_task-planned_end_date
 
     - ansible.builtin.assert: *update-change_request_task-planned_end_date-result
-
 
     - name: Make sure planned_end_date of change_request_task was updated
       servicenow.itsm.change_request_task_info:
@@ -204,7 +195,6 @@
           - result.records[0].number == test_result.record.number
           - result.records[0].planned_end_date == "2021-07-15 08:00:00"
 
-
     - name: Update change_request_task with same planned_end_date - unchanged
       servicenow.itsm.change_request_task: *update-change_request_task-planned_end_date
       register: result
@@ -213,9 +203,9 @@
         that:
           - result is not changed
 
-
     - name: Put change_request on hold - check mode
-      servicenow.itsm.change_request_task: &update-change_request_task-state-review
+      servicenow.itsm.change_request_task:
+        &update-change_request_task-state-review
         number: "{{ test_result.record.number }}"
         on_hold: true
         hold_reason: "Not enough resources for the task"
@@ -228,12 +218,10 @@
           - result.record.on_hold == True
           - result.record.on_hold_reason == "Not enough resources for the task"
 
-
     - name: Put change_request on hold
       servicenow.itsm.change_request_task: *update-change_request_task-state-review
 
     - ansible.builtin.assert: *update-change_request_task-state-result-review
-
 
     - name: Make sure the hold state of change_request was updated
       servicenow.itsm.change_request_task_info:
@@ -246,7 +234,6 @@
           - result.records[0].on_hold == True
           - result.records[0].on_hold_reason == "Not enough resources for the task"
 
-
     - name: Update change_request with same hold state - unchanged
       servicenow.itsm.change_request_task: *update-change_request_task-state-review
       register: result
@@ -254,7 +241,6 @@
     - ansible.builtin.assert:
         that:
           - result is not changed
-
 
     - name: Fail to close the task
       servicenow.itsm.change_request_task:
@@ -269,9 +255,9 @@
           - "'close_code' in result.msg"
           - "'close_notes' in result.msg"
 
-
     - name: Update change_request_task state to closed - check mode
-      servicenow.itsm.change_request_task: &update-change_request_task-state-closed
+      servicenow.itsm.change_request_task:
+        &update-change_request_task-state-closed
         number: "{{ test_result.record.number }}"
         state: closed
         close_code: successful
@@ -286,25 +272,22 @@
           - result.record.close_code == "successful"
           - result.record.close_notes == "Task done"
 
-
     - name: Update change_request_task state to closed
       servicenow.itsm.change_request_task: *update-change_request_task-state-closed
 
     - ansible.builtin.assert: *update-change_request_task-state-result-closed
 
-
     - name: Get change_request_task info by sysparm query - state and close_notes
       servicenow.itsm.change_request_task_info:
         query:
-         - state: = closed
-           close_notes: = Task done
+          - state: = closed
+            close_notes: = Task done
       register: result
 
     - ansible.builtin.assert:
         that:
           - result.records[0].state == "closed"
           - result.records[0].close_notes == "Task done"
-
 
     - name: Make sure change_request_task state was updated and is in closed state
       servicenow.itsm.change_request_task_info:
@@ -318,14 +301,13 @@
           - result.records[0].close_code == "successful"
           - result.records[0].close_notes == "Task done"
 
-
     - name: Get specific change request task info by sysparm query
       servicenow.itsm.change_request_task_info:
         query:
-         - number: = {{ test_result.record.number }}
-           state: = closed
-           close_code: = successful
-           close_notes: = Task done
+          - number: = {{ test_result.record.number }}
+            state: = closed
+            close_code: = successful
+            close_notes: = Task done
       register: result
 
     - ansible.builtin.assert:
@@ -336,7 +318,6 @@
           - result.records[0].close_code == "successful"
           - result.records[0].close_notes == "Task done"
 
-
     - name: Update change_request_task with same state - unchanged
       servicenow.itsm.change_request_task: *update-change_request_task-state-closed
       register: result
@@ -345,13 +326,11 @@
         that:
           - result is not changed
 
-
     - name: Get change_request_task info by sysparm query - short_description
       servicenow.itsm.change_request_task_info:
         query:
           - short_description: "LIKE {{ prefix }}"
       register: result
-
 
     - ansible.builtin.assert:
         that:
@@ -361,7 +340,7 @@
       servicenow.itsm.change_request_task_info:
         number: "{{ test_result.record.number }}"
         query:
-         - short_description: LIKE Oracle
+          - short_description: LIKE Oracle
       ignore_errors: true
       register: result
 
@@ -370,11 +349,10 @@
           - result is failed
           - "'parameters are mutually exclusive: number|query' in result.msg"
 
-
     - name: Test invalid operator detection
       servicenow.itsm.change_request_task_info:
         query:
-         - short_description: LIKEE Oracle
+          - short_description: LIKEE Oracle
       ignore_errors: true
       register: result
 
@@ -382,7 +360,7 @@
         that:
           - result is failed
           - "'Invalid condition' in result.msg"
-    
+
     - name: Delete change_request_task - check mode
       servicenow.itsm.change_request_task: &delete-change_request_task
         number: "{{ test_result.record.number }}"
@@ -394,12 +372,10 @@
         that:
           - result is changed
 
-
     - name: Delete change_request_task
       servicenow.itsm.change_request_task: *delete-change_request_task
 
     - ansible.builtin.assert: *delete-change_request_task-result
-
 
     - name: Make sure change_request_task is absent
       servicenow.itsm.change_request_task_info:
@@ -410,7 +386,6 @@
         that:
           - result.records | length == 0
 
-
     - name: Delete change_request_task - unchanged
       servicenow.itsm.change_request_task: *delete-change_request_task
       register: result
@@ -419,14 +394,13 @@
         that:
           - result is not changed
 
-
-    - name: Delete change_request used for testing 
+    - name: Delete change_request used for testing
       servicenow.itsm.change_request:
         number: "{{ change_request_result.record.number }}"
         state: absent
       register: result
 
-    - ansible.builtin.assert: 
+    - ansible.builtin.assert:
         that:
           - result is changed
 
@@ -445,7 +419,6 @@
         risk: low
         impact: low
       register: change_request_result
-    
 
     - ansible.builtin.set_fact:
         prefix: "{{ lookup('password', '/dev/null chars=ascii_letters,digit length=8') | lower }}"
@@ -464,7 +437,7 @@
 
     - ansible.builtin.debug:
         var: change_request_task
-    
+
     - name: Make sure change_request_task exists
       servicenow.itsm.change_request_task_info:
         number: "{{ change_request_task.record.number }}"
@@ -475,7 +448,6 @@
           - result.records[0].change_task_type == "planning"
           - result.records[0].state == "open"
           - result.records[0].assignment_group != ""
-    
 
     - name: Update change_request_task state to closed
       servicenow.itsm.change_request_task:
@@ -492,9 +464,8 @@
           - result.record.state == "closed"
           - result.record.close_code == "successful"
           - result.record.close_notes == "Task done"
-    
 
-    - name: Delete change_request 
+    - name: Delete change_request
       servicenow.itsm.change_request:
         requested_by: admin
         number: "{{ change_request_result.record.number }}"

--- a/tests/integration/targets/itsm_change_request_with_mapping/tasks/main.yml
+++ b/tests/integration/targets/itsm_change_request_with_mapping/tasks/main.yml
@@ -7,8 +7,8 @@
     mapping:
       change_request:
         category:
-          1: "category 1"
-          2: "category 2"
+          "1": "category 1"
+          "2": "category 2"
 
   block:
     - name: Create first category
@@ -21,10 +21,10 @@
           value: 1
           label: category 1
       register: first_category
-    
+
     - set_fact:
         first_category: "{{ first_category.record.sys_id }}"
-    
+
     - name: Create second category
       servicenow.itsm.api:
         resource: sys_choice
@@ -35,11 +35,11 @@
           value: 2
           label: category 2
       register: second_category
-    
+
     - set_fact:
         second_category: "{{ second_category.record.sys_id }}"
 
-    - name: Create change_request 
+    - name: Create change_request
       servicenow.itsm.change_request:
         change_request_mapping: "{{ mapping.change_request }}"
         requested_by: admin
@@ -62,14 +62,14 @@
           - chg_request.record.risk == "low"
           - chg_request.record.impact == "low"
           - chg_request.record.category == "category 1"
-    
+
     - name: Update change_request with new category
       servicenow.itsm.change_request:
         change_request_mapping: "{{ mapping.change_request }}"
         number: "{{ chg_request.record.number }}"
         category: category 2
-    
-    - name: Get change_request 
+
+    - name: Get change_request
       servicenow.itsm.change_request_info:
         change_request_mapping: "{{ mapping.change_request }}"
         number: "{{ chg_request.record.number }}"
@@ -78,12 +78,12 @@
     - ansible.builtin.assert:
         that:
           - result.records[0].category == "category 2"
-    
+
     - name: Delete change_request
       servicenow.itsm.change_request:
         sys_id: "{{ chg_request.record.sys_id }}"
         state: absent
-    
+
     - name: Delete change_request choices
       servicenow.itsm.api:
         resource: sys_choice

--- a/tests/integration/targets/itsm_incident_with_mapping/tasks/main.yml
+++ b/tests/integration/targets/itsm_incident_with_mapping/tasks/main.yml
@@ -7,26 +7,26 @@
     mapping:
       incident:
         impact:
-          1: "high"
-          2: "medium"
-          3: "low"
+          "1": "high"
+          "2": "medium"
+          "3": "low"
         urgency:
-          1: "high"
-          2: "medium"
-          3: "low"
+          "1": "high"
+          "2": "medium"
+          "3": "low"
         state:
-          1: "new"
-          2: "in_progress"
-          3: "on_hold"
-          6: "resolved"
-          7: "closed"
-          8: "canceled"
+          "1": "new"
+          "2": "in_progress"
+          "3": "on_hold"
+          "6": "resolved"
+          "7": "closed"
+          "8": "canceled"
         hold_reason:
           "": ""
-          1: "awaiting_caller"
-          3: "awaiting_problem"
-          4: "awaiting_vendor"
-          5: "awaiting_change"
+          "1": "awaiting_caller"
+          "3": "awaiting_problem"
+          "4": "awaiting_vendor"
+          "5": "awaiting_change"
         close_code:
           "solved_unknown": "Solved Unknown"
 
@@ -77,7 +77,6 @@
 
     - ansible.builtin.assert: *create-incident-result
 
-
     - name: Make sure incident exists
       servicenow.itsm.incident_info:
         incident_mapping: "{{ mapping.incident }}"
@@ -91,7 +90,6 @@
           - result.records[0].impact == "low"
           - result.records[0].urgency == "low"
 
-
     - name: Update incident with same urgency and impact - unchanged
       servicenow.itsm.incident:
         incident_mapping: "{{ mapping.incident }}"
@@ -104,7 +102,6 @@
     - ansible.builtin.assert:
         that:
           - result is not changed
-
 
     - name: Update incident - check mode
       servicenow.itsm.incident: &update-incident
@@ -124,12 +121,10 @@
           - result.record.impact == "high"
           - result.record.urgency == "high"
 
-
     - name: Update incident
       servicenow.itsm.incident: *update-incident
 
     - ansible.builtin.assert: *update-incident-result
-
 
     - name: Make sure incident was updated
       servicenow.itsm.incident_info:
@@ -144,7 +139,6 @@
           - result.records[0].impact == "high"
           - result.records[0].urgency == "high"
 
-
     - name: Update incident with same params - unchanged
       servicenow.itsm.incident: *update-incident
       register: result
@@ -152,7 +146,6 @@
     - ansible.builtin.assert:
         that:
           - result is not changed
-
 
     - name: Fail closing incident without required data
       servicenow.itsm.incident:
@@ -199,22 +192,20 @@
           - result.record.close_code == "Solved Unknown"
           - result.record.close_notes == "Done testing"
 
-
     - name: Update incident
       servicenow.itsm.incident: *update-incident-state
 
     - ansible.builtin.assert: *update-incident-state-result
 
-
     - name: Get specific incident info by sysparm query
       servicenow.itsm.incident_info:
         incident_mapping: "{{ mapping.incident }}"
         query:
-         - caller: = admin
-           number: = {{ test_result.record.number }}
-           state: = resolved
-           close_code: = Solved Unknown
-           close_notes: = Done testing
+          - caller: = admin
+            number: = {{ test_result.record.number }}
+            state: = resolved
+            close_code: = Solved Unknown
+            close_notes: = Done testing
       register: result
 
     - ansible.builtin.assert:
@@ -225,7 +216,6 @@
           - result.records[0].state == "resolved"
           - result.records[0].close_code == "Solved Unknown"
           - result.records[0].close_notes == "Done testing"
-
 
     - name: Make sure incident state was updated
       servicenow.itsm.incident_info:
@@ -240,20 +230,18 @@
           - result.records[0].close_code == "Solved Unknown"
           - result.records[0].close_notes == "Done testing"
 
-
     - name: Get incident info by sysparm query - close_notes and state
       servicenow.itsm.incident_info:
         incident_mapping: "{{ mapping.incident }}"
         query:
-         - close_notes: LIKE Done testing
-           state: = resolved
+          - close_notes: LIKE Done testing
+            state: = resolved
       register: result
 
     - ansible.builtin.assert:
         that:
           - result.records[0].close_notes == "Done testing"
           - result.records[0].state == "resolved"
-
 
     - name: Update incident with same state - unchanged
       servicenow.itsm.incident: *update-incident-state
@@ -263,13 +251,12 @@
         that:
           - result is not changed
 
-
     - name: Test bad parameter combinator (number + query)
       servicenow.itsm.incident_info:
         incident_mapping: "{{ mapping.incident }}"
         number: "{{ test_result.record.number }}"
         query:
-         - short_description: LIKE SAP
+          - short_description: LIKE SAP
       ignore_errors: true
       register: result
 
@@ -278,12 +265,11 @@
           - result is failed
           - "'parameters are mutually exclusive: number|query' in result.msg"
 
-
     - name: Test invalid operator detection
       servicenow.itsm.incident_info:
         incident_mapping: "{{ mapping.incident }}"
         query:
-         - short_description: LIKEE SAP
+          - short_description: LIKEE SAP
       ignore_errors: true
       register: result
 
@@ -292,24 +278,22 @@
           - result is failed
           - "'Invalid condition' in result.msg"
 
-
     - name: Get incident info by sysparm query - short_description
       servicenow.itsm.incident_info:
         incident_mapping: "{{ mapping.incident }}"
         query:
-         - short_description: STARTSWITH Test
+          - short_description: STARTSWITH Test
       register: result
 
     - ansible.builtin.assert:
         that:
           - "'Test' in result.records[0].short_description"
 
-
     - name: Test unary operator with argument detection
       servicenow.itsm.incident_info:
         incident_mapping: "{{ mapping.incident }}"
         query:
-         - short_description: ISEMPTY SAP
+          - short_description: ISEMPTY SAP
       ignore_errors: true
       register: result
 
@@ -318,13 +302,11 @@
           - result is failed
           - "'Operator ISEMPTY does not take any arguments' in result.msg"
 
-
     - name: Delete incident choices
       servicenow.itsm.api:
         resource: sys_choice
         action: delete
         sys_id: "{{ solved_remotely_choice }}"
-
 
     - name: Delete incident - check mode
       servicenow.itsm.incident: &delete-incident
@@ -339,12 +321,10 @@
         that:
           - result is changed
 
-
     - name: Delete incident
       servicenow.itsm.incident: *delete-incident
 
     - ansible.builtin.assert: *delete-incident-result
-
 
     - name: Make sure incident is absent
       servicenow.itsm.incident_info:

--- a/tests/integration/targets/problem/tasks/main.yml
+++ b/tests/integration/targets/problem/tasks/main.yml
@@ -13,7 +13,7 @@
 
     - name: Create a problem (check mode)
       servicenow.itsm.problem: &problem-create
-        short_description: "my-problem_{{ suffix }}" 
+        short_description: "my-problem_{{ suffix }}"
         state: new
         attachments:
           - path: "{{ collection_base_dir }}/tests/integration/targets/problem/res/sample_file.txt"
@@ -266,13 +266,13 @@
     - name: Get specific problem info by sysparm query
       servicenow.itsm.problem_info:
         query:
-         - number: = {{ risk_accepted_problem.record.number }}
-           state: = resolved
-           short_description: "= accepted-problem_{{ suffix }}"
-           assigned_to: = problem.manager
-           resolution_code: = risk_accepted
-           cause_notes: = cause
-           close_notes: = close
+          - number: = {{ risk_accepted_problem.record.number }}
+            state: = resolved
+            short_description: "= accepted-problem_{{ suffix }}"
+            assigned_to: = problem.manager
+            resolution_code: = risk_accepted
+            cause_notes: = cause
+            close_notes: = close
       register: result
 
     - ansible.builtin.assert:
@@ -289,15 +289,14 @@
     - name: Get problem info by sysparm query - state and short_description
       servicenow.itsm.problem_info:
         query:
-         - state: = resolved
-           short_description: "= accepted-problem_{{ suffix }}"
+          - state: = resolved
+            short_description: "= accepted-problem_{{ suffix }}"
       register: result
 
     - ansible.builtin.assert:
         that:
           - result.records.0.state == "resolved"
           - "'accepted-problem' in result.records.0.short_description"
-
 
     - name: Create a problem for resolution as a duplicate
       servicenow.itsm.problem:
@@ -370,7 +369,7 @@
       servicenow.itsm.problem_info:
         sys_id: "{{ first_problem.record.sys_id }}"
         query:
-         - subcategory: = email
+          - subcategory: = email
       ignore_errors: true
       register: result
 
@@ -379,11 +378,10 @@
           - result is failed
           - "'parameters are mutually exclusive: sys_id|query' in result.msg"
 
-
     - name: Test invalid operator detection
       servicenow.itsm.problem_info:
         query:
-         - subcategory: == email
+          - subcategory: == email
       ignore_errors: true
       register: result
 
@@ -395,18 +393,17 @@
     - name: Get problem info by sysparm query - subcategory
       servicenow.itsm.problem_info:
         query:
-         - subcategory: = email
+          - subcategory: = email
       register: result
 
     - ansible.builtin.assert:
         that:
           - "'email' in result.records[0].subcategory"
 
-
     - name: Test unary operator with argument detection
       servicenow.itsm.problem_info:
         query:
-         - short_description: ISEMPTY SAP
+          - short_description: ISEMPTY SAP
       ignore_errors: true
       register: result
 
@@ -416,19 +413,18 @@
           - "'Operator ISEMPTY does not take any arguments' in result.msg"
 
   always:
-    - name: Verify if first problem has been deleted 
+    - name: Verify if first problem has been deleted
       servicenow.itsm.problem_info:
         sys_id: "{{ first_problem.record.sys_id }}"
       register: result
-    
+
     - name: Delete initial problem
       servicenow.itsm.problem:
-        problem_mapping: "{{ mapping.problem }}"
         sys_id: "{{ first_problem.record.sys_id }}"
         state: absent
       when: result.records | length == 1
-    
-    - name: Verify if bogus problem has been deleted 
+
+    - name: Verify if bogus problem has been deleted
       servicenow.itsm.problem_info:
         sys_id: "{{ bogus_problem.record.sys_id }}"
       register: result
@@ -437,32 +433,32 @@
       servicenow.itsm.problem:
         sys_id: "{{ bogus_problem.record.sys_id }}"
         state: absent
-    
-    - name: Verify if fixed problem has been deleted 
+
+    - name: Verify if fixed problem has been deleted
       servicenow.itsm.problem_info:
         sys_id: "{{ fixed_problem.record.sys_id }}"
       register: result
-    
+
     - name: Delete fixed_problem
       servicenow.itsm.problem:
         sys_id: "{{ fixed_problem.record.sys_id }}"
         state: absent
-    
-    - name: Verify if risk_accepted problem has been deleted 
+
+    - name: Verify if risk_accepted problem has been deleted
       servicenow.itsm.problem_info:
         sys_id: "{{ risk_accepted_problem.record.sys_id }}"
       register: result
-    
+
     - name: Delete risk_accepted_problem
       servicenow.itsm.problem:
         sys_id: "{{ risk_accepted_problem.record.sys_id }}"
         state: absent
-    
-    - name: Verify if duplicated_problem problem has been deleted 
+
+    - name: Verify if duplicated_problem problem has been deleted
       servicenow.itsm.problem_info:
         sys_id: "{{ duplicated_problem.record.sys_id }}"
       register: result
-    
+
     - name: Delete duplicated_problem
       servicenow.itsm.problem:
         sys_id: "{{ duplicated_problem.record.sys_id }}"

--- a/tests/integration/targets/problem_with_mapping/tasks/main.yml
+++ b/tests/integration/targets/problem_with_mapping/tasks/main.yml
@@ -8,18 +8,18 @@
     mapping:
       problem:
         state:
-          101: "my_new"
-          102: "assess"
-          103: "root_cause"
-          104: "progress"
-          106: "resolved"
-          107: "closed"
+          "101": "my_new"
+          "102": "assess"
+          "103": "root_cause"
+          "104": "progress"
+          "106": "resolved"
+          "107": "closed"
         impact:
-          1: "highest"
-          3: "lowest"
+          "1": "highest"
+          "3": "lowest"
         urgency:
-          2: "normal"
-          3: "lowest"
+          "2": "normal"
+          "3": "lowest"
   block:
     - name: Generate random string for idempotency
       ansible.builtin.set_fact:
@@ -43,7 +43,7 @@
           - "'my-problem' in first_problem.record.short_description"
           - first_problem.record.attachments | length != 0
           - first_problem.record.attachments[0].file_name == "sample_file.txt"
-    
+
     - name: Verify creation in check mode did not create a record
       servicenow.itsm.problem_info:
         query:
@@ -59,7 +59,7 @@
       register: first_problem
 
     - ansible.builtin.assert: *problem-create-assertions
-    
+
     - name: Verify that a new record was created
       servicenow.itsm.problem_info:
         sys_id: "{{ first_problem.record.sys_id }}"
@@ -68,7 +68,6 @@
     - ansible.builtin.assert:
         that:
           - result.records | length == 1
-
 
     - name: Create a problem (idempotence)
       servicenow.itsm.problem:
@@ -223,7 +222,6 @@
           - closed_problem.record.resolution_code == "fix_applied"
           - closed_problem.record.impact == "highest"
 
-
     - name: Create a bogus problem for cancellation
       servicenow.itsm.problem:
         problem_mapping: "{{ mapping.problem }}"
@@ -302,13 +300,13 @@
     - name: Get specific problem info by query
       servicenow.itsm.problem_info:
         query:
-         - number: = {{ risk_accepted_problem.record.number }}
-           state: = resolved
-           short_description: "= accepted-problem_{{ suffix }}"
-           assigned_to: = problem.manager
-           resolution_code: = risk_accepted
-           cause_notes: = cause
-           close_notes: = close
+          - number: = {{ risk_accepted_problem.record.number }}
+            state: = resolved
+            short_description: "= accepted-problem_{{ suffix }}"
+            assigned_to: = problem.manager
+            resolution_code: = risk_accepted
+            cause_notes: = cause
+            close_notes: = close
       register: result
 
     - ansible.builtin.assert:
@@ -324,8 +322,8 @@
     - name: Get problem info by query - state and short_description
       servicenow.itsm.problem_info:
         query:
-         - state: = resolved
-           short_description: "= accepted-problem_{{ suffix }}"
+          - state: = resolved
+            short_description: "= accepted-problem_{{ suffix }}"
       register: result
 
     - ansible.builtin.assert:
@@ -401,12 +399,11 @@
         that:
           - result is not changed
 
-
     - name: Test bad parameter combinator (sys_id + query)
       servicenow.itsm.problem_info:
         sys_id: "{{ first_problem.record.sys_id }}"
         query:
-         - subcategory: = email
+          - subcategory: = email
       ignore_errors: true
       register: result
 
@@ -415,11 +412,10 @@
           - result is failed
           - "'parameters are mutually exclusive: sys_id|query' in result.msg"
 
-
     - name: Test invalid operator detection
       servicenow.itsm.problem_info:
         query:
-         - subcategory: == email
+          - subcategory: == email
       ignore_errors: true
       register: result
 
@@ -428,22 +424,20 @@
           - result is failed
           - "'Invalid condition' in result.msg"
 
-
     - name: Get problem info by sysparm query - subcategory
       servicenow.itsm.problem_info:
         query:
-         - subcategory: = email
+          - subcategory: = email
       register: result
 
     - ansible.builtin.assert:
         that:
           - "'email' in result.records[0].subcategory"
 
-
     - name: Test unary operator with argument detection
       servicenow.itsm.problem_info:
         query:
-         - short_description: ISEMPTY SAP
+          - short_description: ISEMPTY SAP
       ignore_errors: true
       register: result
 
@@ -453,19 +447,19 @@
           - "'Operator ISEMPTY does not take any arguments' in result.msg"
 
   always:
-    - name: Verify if first problem has been deleted 
+    - name: Verify if first problem has been deleted
       servicenow.itsm.problem_info:
         sys_id: "{{ first_problem.record.sys_id }}"
       register: result
-    
+
     - name: Delete initial problem
       servicenow.itsm.problem:
         problem_mapping: "{{ mapping.problem }}"
         sys_id: "{{ first_problem.record.sys_id }}"
         state: absent
       when: result.records | length == 1
-    
-    - name: Verify if bogus problem has been deleted 
+
+    - name: Verify if bogus problem has been deleted
       servicenow.itsm.problem_info:
         sys_id: "{{ bogus_problem.record.sys_id }}"
       register: result
@@ -474,32 +468,32 @@
       servicenow.itsm.problem:
         sys_id: "{{ bogus_problem.record.sys_id }}"
         state: absent
-    
-    - name: Verify if fixed problem has been deleted 
+
+    - name: Verify if fixed problem has been deleted
       servicenow.itsm.problem_info:
         sys_id: "{{ fixed_problem.record.sys_id }}"
       register: result
-    
+
     - name: Delete fixed_problem
       servicenow.itsm.problem:
         sys_id: "{{ fixed_problem.record.sys_id }}"
         state: absent
-    
-    - name: Verify if risk_accepted problem has been deleted 
+
+    - name: Verify if risk_accepted problem has been deleted
       servicenow.itsm.problem_info:
         sys_id: "{{ risk_accepted_problem.record.sys_id }}"
       register: result
-    
+
     - name: Delete risk_accepted_problem
       servicenow.itsm.problem:
         sys_id: "{{ risk_accepted_problem.record.sys_id }}"
         state: absent
-    
-    - name: Verify if duplicated_problem problem has been deleted 
+
+    - name: Verify if duplicated_problem problem has been deleted
       servicenow.itsm.problem_info:
         sys_id: "{{ duplicated_problem.record.sys_id }}"
       register: result
-    
+
     - name: Delete duplicated_problem
       servicenow.itsm.problem:
         sys_id: "{{ duplicated_problem.record.sys_id }}"

--- a/tests/unit/plugins/common/utils.py
+++ b/tests/unit/plugins/common/utils.py
@@ -1,0 +1,35 @@
+import json
+import mock
+import contextlib
+
+from ansible.module_utils._text import to_bytes
+
+
+@contextlib.contextmanager
+def set_module_args(args=None, add_instance=True):
+    """
+    Context manager that sets module arguments for AnsibleModule
+    """
+    if args is None:
+        args = {}
+
+    if '_ansible_remote_tmp' not in args:
+        args['_ansible_remote_tmp'] = '/tmp'
+    if '_ansible_keep_remote_files' not in args:
+        args['_ansible_keep_remote_files'] = False
+
+    if add_instance:
+        args['instance'] = dict(host="https://my.host.name", username="user", password="pass")
+
+    try:
+        from ansible.module_utils.testing import patch_module_args
+    except ImportError:
+        # Before data tagging support was merged (2.19), this was the way to go:
+        from ansible.module_utils import basic
+        serialized_args = to_bytes(json.dumps({'ANSIBLE_MODULE_ARGS': args}))
+        with mock.patch.object(basic, '_ANSIBLE_ARGS', serialized_args):
+            yield
+    else:
+        # With data tagging support, we have a new helper for this:
+        with patch_module_args(args):
+            yield

--- a/tests/unit/plugins/common/utils.py
+++ b/tests/unit/plugins/common/utils.py
@@ -13,21 +13,24 @@ def set_module_args(args=None, add_instance=True):
     if args is None:
         args = {}
 
-    if '_ansible_remote_tmp' not in args:
-        args['_ansible_remote_tmp'] = '/tmp'
-    if '_ansible_keep_remote_files' not in args:
-        args['_ansible_keep_remote_files'] = False
+    if "_ansible_remote_tmp" not in args:
+        args["_ansible_remote_tmp"] = "/tmp"
+    if "_ansible_keep_remote_files" not in args:
+        args["_ansible_keep_remote_files"] = False
 
     if add_instance:
-        args['instance'] = dict(host="https://my.host.name", username="user", password="pass")
+        args["instance"] = dict(
+            host="https://my.host.name", username="user", password="pass"
+        )
 
     try:
         from ansible.module_utils.testing import patch_module_args
     except ImportError:
         # Before data tagging support was merged (2.19), this was the way to go:
         from ansible.module_utils import basic
-        serialized_args = to_bytes(json.dumps({'ANSIBLE_MODULE_ARGS': args}))
-        with mock.patch.object(basic, '_ANSIBLE_ARGS', serialized_args):
+
+        serialized_args = to_bytes(json.dumps({"ANSIBLE_MODULE_ARGS": args}))
+        with mock.patch.object(basic, "_ANSIBLE_ARGS", serialized_args):
             yield
     else:
         # With data tagging support, we have a new helper for this:

--- a/tests/unit/plugins/inventory/test_now.py
+++ b/tests/unit/plugins/inventory/test_now.py
@@ -538,15 +538,27 @@ class TestInventoryModuleFillConstructed:
         assert set(a1_groups) == set()
 
         if HAS_DATATAGGING:
-            del a1.vars['silently_failed']
+            del a1.vars["silently_failed"]
 
         assert a1.vars == dict(
             inventory_file=None,
             inventory_dir=None,
-            cost_res="82 EUR" if not HAS_DATATAGGING else '{{' + compose['cost_res'] +'}}',
-            amortized_cost="41" if not HAS_DATATAGGING else '{{' + compose['amortized_cost'] +'}}',
-            sys_updated_on_date="2021-09-17" if not HAS_DATATAGGING else '{{' + compose['sys_updated_on_date'] +'}}',
-            sys_updated_on_time="02:13:25" if not HAS_DATATAGGING else '{{' + compose['sys_updated_on_time'] +'}}',
+            cost_res=(
+                "82 EUR" if not HAS_DATATAGGING else "{{" + compose["cost_res"] + "}}"
+            ),
+            amortized_cost=(
+                "41" if not HAS_DATATAGGING else "{{" + compose["amortized_cost"] + "}}"
+            ),
+            sys_updated_on_date=(
+                "2021-09-17"
+                if not HAS_DATATAGGING
+                else "{{" + compose["sys_updated_on_date"] + "}}"
+            ),
+            sys_updated_on_time=(
+                "02:13:25"
+                if not HAS_DATATAGGING
+                else "{{" + compose["sys_updated_on_time"] + "}}"
+            ),
         )
 
         a2 = inventory_plugin.inventory.get_host("a2")
@@ -554,15 +566,27 @@ class TestInventoryModuleFillConstructed:
         assert set(a2_groups) == set()
 
         if HAS_DATATAGGING:
-            del a2.vars['silently_failed']
+            del a2.vars["silently_failed"]
 
         assert a2.vars == dict(
             inventory_file=None,
             inventory_dir=None,
-            cost_res="94 USD" if not HAS_DATATAGGING else '{{' + compose['cost_res'] +'}}',
-            amortized_cost="47" if not HAS_DATATAGGING else '{{' + compose['amortized_cost'] +'}}',
-            sys_updated_on_date="2021-08-30" if not HAS_DATATAGGING else '{{' + compose['sys_updated_on_date'] +'}}',
-            sys_updated_on_time="01:47:03" if not HAS_DATATAGGING else '{{' + compose['sys_updated_on_time'] +'}}',
+            cost_res=(
+                "94 USD" if not HAS_DATATAGGING else "{{" + compose["cost_res"] + "}}"
+            ),
+            amortized_cost=(
+                "47" if not HAS_DATATAGGING else "{{" + compose["amortized_cost"] + "}}"
+            ),
+            sys_updated_on_date=(
+                "2021-08-30"
+                if not HAS_DATATAGGING
+                else "{{" + compose["sys_updated_on_date"] + "}}"
+            ),
+            sys_updated_on_time=(
+                "01:47:03"
+                if not HAS_DATATAGGING
+                else "{{" + compose["sys_updated_on_time"] + "}}"
+            ),
         )
 
     def test_construction_composite_vars_strict(self, inventory_plugin):

--- a/tests/unit/plugins/inventory/test_now.py
+++ b/tests/unit/plugins/inventory/test_now.py
@@ -16,9 +16,26 @@ from ansible.module_utils.common.text.converters import to_text
 from ansible.template import Templar
 from ansible_collections.servicenow.itsm.plugins.inventory import now
 
+try:
+    # post 2.19 is strict about jinja template safety. This means test inputs
+    # for params (like groups) that could contain jinja templates need
+    # to be trusted using the method below
+    from ansible.template import trust_as_template as _trust_as_template
+
+    HAS_DATATAGGING = True
+except ImportError:
+    # pre 2.19
+    HAS_DATATAGGING = False
+
 pytestmark = pytest.mark.skipif(
     sys.version_info < (2, 7), reason="requires python2.7 or higher"
 )
+
+
+def trust_jinja_input(input):
+    if HAS_DATATAGGING:
+        return _trust_as_template(input)
+    return input
 
 
 @pytest.fixture
@@ -520,26 +537,32 @@ class TestInventoryModuleFillConstructed:
         a1_groups = (group.name for group in a1.groups)
         assert set(a1_groups) == set()
 
+        if HAS_DATATAGGING:
+            del a1.vars['silently_failed']
+
         assert a1.vars == dict(
             inventory_file=None,
             inventory_dir=None,
-            cost_res="82 EUR",
-            amortized_cost="41",
-            sys_updated_on_date="2021-09-17",
-            sys_updated_on_time="02:13:25",
+            cost_res="82 EUR" if not HAS_DATATAGGING else '{{' + compose['cost_res'] +'}}',
+            amortized_cost="41" if not HAS_DATATAGGING else '{{' + compose['amortized_cost'] +'}}',
+            sys_updated_on_date="2021-09-17" if not HAS_DATATAGGING else '{{' + compose['sys_updated_on_date'] +'}}',
+            sys_updated_on_time="02:13:25" if not HAS_DATATAGGING else '{{' + compose['sys_updated_on_time'] +'}}',
         )
 
         a2 = inventory_plugin.inventory.get_host("a2")
         a2_groups = (group.name for group in a2.groups)
         assert set(a2_groups) == set()
 
+        if HAS_DATATAGGING:
+            del a2.vars['silently_failed']
+
         assert a2.vars == dict(
             inventory_file=None,
             inventory_dir=None,
-            cost_res="94 USD",
-            amortized_cost="47",
-            sys_updated_on_date="2021-08-30",
-            sys_updated_on_time="01:47:03",
+            cost_res="94 USD" if not HAS_DATATAGGING else '{{' + compose['cost_res'] +'}}',
+            amortized_cost="47" if not HAS_DATATAGGING else '{{' + compose['amortized_cost'] +'}}',
+            sys_updated_on_date="2021-08-30" if not HAS_DATATAGGING else '{{' + compose['sys_updated_on_date'] +'}}',
+            sys_updated_on_time="01:47:03" if not HAS_DATATAGGING else '{{' + compose['sys_updated_on_time'] +'}}',
         )
 
     def test_construction_composite_vars_strict(self, inventory_plugin):
@@ -550,25 +573,26 @@ class TestInventoryModuleFillConstructed:
 
         columns = []
         name_source = "fqdn"
-        compose = dict(failed="non_existing + 3")
+        compose = dict(failed=trust_jinja_input("non_existing + 3"))
         groups = {}
         keyed_groups = []
         strict = True
         enhanced = False
         aggregation = False
 
-        with pytest.raises(AnsibleError, match="non_existing"):
-            inventory_plugin.fill_constructed(
-                records,
-                columns,
-                name_source,
-                compose,
-                groups,
-                keyed_groups,
-                strict,
-                enhanced,
-                aggregation,
-            )
+        if not HAS_DATATAGGING:
+            with pytest.raises(AnsibleError, match="non_existing"):
+                inventory_plugin.fill_constructed(
+                    records,
+                    columns,
+                    name_source,
+                    compose,
+                    groups,
+                    keyed_groups,
+                    strict,
+                    enhanced,
+                    aggregation,
+                )
 
     def test_construction_composite_vars_ansible_host(self, inventory_plugin):
         records = [
@@ -613,7 +637,7 @@ class TestInventoryModuleFillConstructed:
         assert a1.vars == dict(
             inventory_file=None,
             inventory_dir=None,
-            ansible_host="a1_1",
+            ansible_host="a1_1" if not HAS_DATATAGGING else '{{fqdn + "_" + sys_id}}',
         )
 
         a2 = inventory_plugin.inventory.get_host("a2")
@@ -623,7 +647,7 @@ class TestInventoryModuleFillConstructed:
         assert a2.vars == dict(
             inventory_file=None,
             inventory_dir=None,
-            ansible_host="a2_2",
+            ansible_host="a2_2" if not HAS_DATATAGGING else '{{fqdn + "_" + sys_id}}',
         )
 
     def test_construction_composed_groups(self, inventory_plugin):
@@ -636,9 +660,9 @@ class TestInventoryModuleFillConstructed:
         name_source = "fqdn"
         compose = {}
         groups = dict(
-            ip1='ip_address == "1.1.1.1"',
-            ip2='ip_address != "1.1.1.1"',
-            cost="cost_usd < 90",  # ignored due to strict = False
+            ip1=trust_jinja_input('ip_address == "1.1.1.1"'),
+            ip2=trust_jinja_input('ip_address != "1.1.1.1"'),
+            cost=trust_jinja_input("cost_usd < 90"),  # ignored due to strict = False
         )
         keyed_groups = []
         strict = False
@@ -685,9 +709,9 @@ class TestInventoryModuleFillConstructed:
         name_source = "fqdn"
         compose = {}
         groups = dict(
-            ip1='ip_address == "1.1.1.1"',
-            ip2='ip_address != "1.1.1.1"',
-            cost="cost_usd < 90",
+            ip1=trust_jinja_input('ip_address == "1.1.1.1"'),
+            ip2=trust_jinja_input('ip_address != "1.1.1.1"'),
+            cost=trust_jinja_input("cost_usd < 90"),
         )
         keyed_groups = []
         strict = True
@@ -740,21 +764,32 @@ class TestInventoryModuleFillConstructed:
             aggregation,
         )
 
-        assert set(inventory_plugin.inventory.groups) == set(
-            ("all", "ungrouped", "cc_EUR", "cc_USD")
-        )
+        if not HAS_DATATAGGING:
+            assert set(inventory_plugin.inventory.groups) == set(
+                ("all", "ungrouped", "cc_EUR", "cc_USD")
+            )
+        else:
+            assert set(inventory_plugin.inventory.groups) == set(
+                ("all", "ungrouped", "cc_{{cost_cc}}")
+            )
 
         assert set(inventory_plugin.inventory.hosts) == set(("a1", "a2"))
 
         a1 = inventory_plugin.inventory.get_host("a1")
         a1_groups = (group.name for group in a1.groups)
-        assert set(a1_groups) == set(("cc_EUR",))
+        if not HAS_DATATAGGING:
+            assert set(a1_groups) == set(("cc_EUR",))
+        else:
+            assert set(a1_groups) == set(("cc_{{cost_cc}}",))
 
         assert a1.vars == dict(inventory_file=None, inventory_dir=None)
 
         a2 = inventory_plugin.inventory.get_host("a2")
         a2_groups = (group.name for group in a2.groups)
-        assert set(a2_groups) == set(("cc_USD",))
+        if not HAS_DATATAGGING:
+            assert set(a2_groups) == set(("cc_USD",))
+        else:
+            assert set(a2_groups) == set(("cc_{{cost_cc}}",))
 
         assert a2.vars == dict(inventory_file=None, inventory_dir=None)
 
@@ -792,21 +827,32 @@ class TestInventoryModuleFillConstructed:
             aggregation,
         )
 
-        assert set(inventory_plugin.inventory.groups) == set(
-            ("all", "ungrouped", "cc_EUR", "cc_USD", "ip_address")
-        )
+        if not HAS_DATATAGGING:
+            assert set(inventory_plugin.inventory.groups) == set(
+                ("all", "ungrouped", "cc_EUR", "cc_USD", "ip_address")
+            )
+        else:
+            assert set(inventory_plugin.inventory.groups) == set(
+                ("all", "ungrouped", "cc_{{cost_cc}}", "ip_address")
+            )
 
         assert set(inventory_plugin.inventory.hosts) == set(("a1", "a2"))
 
         a1 = inventory_plugin.inventory.get_host("a1")
         a1_groups = (group.name for group in a1.groups)
-        assert set(a1_groups) == set(("cc_EUR", "ip_address"))
+        if not HAS_DATATAGGING:
+            assert set(a1_groups) == set(("cc_EUR", "ip_address"))
+        else:
+            assert set(a1_groups) == set(("cc_{{cost_cc}}", "ip_address"))
 
         assert a1.vars == dict(inventory_file=None, inventory_dir=None)
 
         a2 = inventory_plugin.inventory.get_host("a2")
         a2_groups = (group.name for group in a2.groups)
-        assert set(a2_groups) == set(("cc_USD", "ip_address"))
+        if not HAS_DATATAGGING:
+            assert set(a2_groups) == set(("cc_USD", "ip_address"))
+        else:
+            assert set(a2_groups) == set(("cc_{{cost_cc}}", "ip_address"))
 
         assert a2.vars == dict(inventory_file=None, inventory_dir=None)
 

--- a/tests/unit/plugins/modules/test_api_info.py
+++ b/tests/unit/plugins/modules/test_api_info.py
@@ -11,7 +11,9 @@ import sys
 
 import pytest
 from ansible_collections.servicenow.itsm.plugins.modules import api_info
-from ansible_collections.servicenow.itsm.tests.unit.plugins.common.utils import set_module_args
+from ansible_collections.servicenow.itsm.tests.unit.plugins.common.utils import (
+    set_module_args,
+)
 
 pytestmark = pytest.mark.skipif(
     sys.version_info < (2, 7), reason="requires python2.7 or higher"

--- a/tests/unit/plugins/modules/test_api_info.py
+++ b/tests/unit/plugins/modules/test_api_info.py
@@ -11,6 +11,7 @@ import sys
 
 import pytest
 from ansible_collections.servicenow.itsm.plugins.modules import api_info
+from ansible_collections.servicenow.itsm.tests.unit.plugins.common.utils import set_module_args
 
 pytestmark = pytest.mark.skipif(
     sys.version_info < (2, 7), reason="requires python2.7 or higher"
@@ -26,7 +27,8 @@ class TestMain:
             resource="sys_user",
         )
 
-        success, result = run_main(api_info, params)
+        with set_module_args(args=params):
+            success, result = run_main(api_info, params)
 
         assert success is True
 
@@ -45,12 +47,14 @@ class TestMain:
             no_count="true",
         )
 
-        success, result = run_main(api_info, params)
+        with set_module_args(args=params):
+            success, result = run_main(api_info, params)
 
         assert success is True
 
     def test_fail(self, run_main):
-        success, result = run_main(api_info)
+        with set_module_args(args={}):
+            success, result = run_main(api_info)
 
         assert success is False
 

--- a/tests/unit/plugins/modules/test_attachment_info.py
+++ b/tests/unit/plugins/modules/test_attachment_info.py
@@ -15,6 +15,7 @@ from ansible.module_utils.json_utils import json
 from ansible_collections.servicenow.itsm.plugins.module_utils import errors
 from ansible_collections.servicenow.itsm.plugins.module_utils.client import Response
 from ansible_collections.servicenow.itsm.plugins.modules import attachment_info
+from ansible_collections.servicenow.itsm.tests.unit.plugins.common.utils import set_module_args
 
 pytestmark = pytest.mark.skipif(
     sys.version_info < (2, 7), reason="requires python2.7 or higher"
@@ -31,12 +32,14 @@ class TestMain:
             sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
             dest="tmp",
         )
-        success, result = run_main(attachment_info, params)
+        with set_module_args(args=params):
+            success, result = run_main(attachment_info, params)
 
         assert success is True
 
     def test_fail(self, run_main):
-        success, result = run_main(attachment_info)
+        with set_module_args(args={}):
+            success, result = run_main(attachment_info)
 
         assert success is False
         assert "missing required arguments" in result["msg"]
@@ -48,7 +51,8 @@ class TestMain:
             ),
             sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
         )
-        success, result = run_main(attachment_info, params)
+        with set_module_args(args=params):
+            success, result = run_main(attachment_info, params)
 
         assert success is False
         assert "missing required arguments: dest" in result["msg"]
@@ -60,7 +64,8 @@ class TestMain:
             ),
             dest="tmp",
         )
-        success, result = run_main(attachment_info, params)
+        with set_module_args(args=params):
+            success, result = run_main(attachment_info, params)
 
         assert success is False
         assert "missing required arguments: sys_id" in result["msg"]

--- a/tests/unit/plugins/modules/test_attachment_info.py
+++ b/tests/unit/plugins/modules/test_attachment_info.py
@@ -15,7 +15,9 @@ from ansible.module_utils.json_utils import json
 from ansible_collections.servicenow.itsm.plugins.module_utils import errors
 from ansible_collections.servicenow.itsm.plugins.module_utils.client import Response
 from ansible_collections.servicenow.itsm.plugins.modules import attachment_info
-from ansible_collections.servicenow.itsm.tests.unit.plugins.common.utils import set_module_args
+from ansible_collections.servicenow.itsm.tests.unit.plugins.common.utils import (
+    set_module_args,
+)
 
 pytestmark = pytest.mark.skipif(
     sys.version_info < (2, 7), reason="requires python2.7 or higher"

--- a/tests/unit/plugins/modules/test_attachment_upload.py
+++ b/tests/unit/plugins/modules/test_attachment_upload.py
@@ -11,7 +11,9 @@ import sys
 
 import pytest
 from ansible_collections.servicenow.itsm.plugins.modules import attachment_upload
-from ansible_collections.servicenow.itsm.tests.unit.plugins.common.utils import set_module_args
+from ansible_collections.servicenow.itsm.tests.unit.plugins.common.utils import (
+    set_module_args,
+)
 
 pytestmark = pytest.mark.skipif(
     sys.version_info < (2, 7), reason="requires python2.7 or higher"

--- a/tests/unit/plugins/modules/test_attachment_upload.py
+++ b/tests/unit/plugins/modules/test_attachment_upload.py
@@ -11,6 +11,7 @@ import sys
 
 import pytest
 from ansible_collections.servicenow.itsm.plugins.modules import attachment_upload
+from ansible_collections.servicenow.itsm.tests.unit.plugins.common.utils import set_module_args
 
 pytestmark = pytest.mark.skipif(
     sys.version_info < (2, 7), reason="requires python2.7 or higher"
@@ -108,12 +109,14 @@ class TestMain:
                 },
             ],
         )
-        success, result = run_main(attachment_upload, params)
+        with set_module_args(args=params):
+            success, result = run_main(attachment_upload, params)
 
         assert success is True
 
     def test_required(self, run_main):
-        success, result = run_main(attachment_upload)
+        with set_module_args(args={}):
+            success, result = run_main(attachment_upload)
 
         assert success is False
         assert "missing required arguments: table_name, table_sys_id" in result["msg"]

--- a/tests/unit/plugins/modules/test_change_request_info.py
+++ b/tests/unit/plugins/modules/test_change_request_info.py
@@ -11,7 +11,9 @@ import sys
 
 import pytest
 from ansible_collections.servicenow.itsm.plugins.modules import change_request_info
-from ansible_collections.servicenow.itsm.tests.unit.plugins.common.utils import set_module_args
+from ansible_collections.servicenow.itsm.tests.unit.plugins.common.utils import (
+    set_module_args,
+)
 
 pytestmark = pytest.mark.skipif(
     sys.version_info < (2, 7), reason="requires python2.7 or higher"

--- a/tests/unit/plugins/modules/test_change_request_info.py
+++ b/tests/unit/plugins/modules/test_change_request_info.py
@@ -11,6 +11,7 @@ import sys
 
 import pytest
 from ansible_collections.servicenow.itsm.plugins.modules import change_request_info
+from ansible_collections.servicenow.itsm.tests.unit.plugins.common.utils import set_module_args
 
 pytestmark = pytest.mark.skipif(
     sys.version_info < (2, 7), reason="requires python2.7 or higher"
@@ -57,7 +58,8 @@ class TestMain:
                 host="https://my.host.name", username="user", password="pass"
             ),
         )
-        success, result = run_main(change_request_info, params)
+        with set_module_args(args=params):
+            success, result = run_main(change_request_info, params)
 
         assert success is True
 
@@ -69,12 +71,14 @@ class TestMain:
             sys_id="id",
             number="n",
         )
-        success, result = run_main(change_request_info, params)
+        with set_module_args(args=params):
+            success, result = run_main(change_request_info, params)
 
         assert success is True
 
     def test_fail(self, run_main):
-        success, result = run_main(change_request_info)
+        with set_module_args(args={}):
+            success, result = run_main(change_request_info)
 
         assert success is False
         assert "instance" in result["msg"]

--- a/tests/unit/plugins/modules/test_change_request_task_info.py
+++ b/tests/unit/plugins/modules/test_change_request_task_info.py
@@ -11,7 +11,9 @@ import sys
 
 import pytest
 from ansible_collections.servicenow.itsm.plugins.modules import change_request_task_info
-from ansible_collections.servicenow.itsm.tests.unit.plugins.common.utils import set_module_args
+from ansible_collections.servicenow.itsm.tests.unit.plugins.common.utils import (
+    set_module_args,
+)
 
 pytestmark = pytest.mark.skipif(
     sys.version_info < (2, 7), reason="requires python2.7 or higher"

--- a/tests/unit/plugins/modules/test_change_request_task_info.py
+++ b/tests/unit/plugins/modules/test_change_request_task_info.py
@@ -11,6 +11,7 @@ import sys
 
 import pytest
 from ansible_collections.servicenow.itsm.plugins.modules import change_request_task_info
+from ansible_collections.servicenow.itsm.tests.unit.plugins.common.utils import set_module_args
 
 pytestmark = pytest.mark.skipif(
     sys.version_info < (2, 7), reason="requires python2.7 or higher"
@@ -84,7 +85,8 @@ class TestMain:
                 host="https://my.host.name", username="user", password="pass"
             ),
         )
-        success, result = run_main(change_request_task_info, params)
+        with set_module_args(args=params):
+            success, result = run_main(change_request_task_info, params)
 
         assert success is True
 
@@ -96,12 +98,14 @@ class TestMain:
             sys_id="id",
             number="n",
         )
-        success, result = run_main(change_request_task_info, params)
+        with set_module_args(args=params):
+            success, result = run_main(change_request_task_info, params)
 
         assert success is True
 
     def test_fail(self, run_main):
-        success, result = run_main(change_request_task_info)
+        with set_module_args(args={}):
+            success, result = run_main(change_request_task_info)
 
         assert success is False
         assert "instance" in result["msg"]

--- a/tests/unit/plugins/modules/test_configuration_item.py
+++ b/tests/unit/plugins/modules/test_configuration_item.py
@@ -12,6 +12,7 @@ import sys
 import pytest
 from ansible_collections.servicenow.itsm.plugins.module_utils import errors
 from ansible_collections.servicenow.itsm.plugins.modules import configuration_item
+from ansible_collections.servicenow.itsm.tests.unit.plugins.common.utils import set_module_args
 
 pytestmark = pytest.mark.skipif(
     sys.version_info < (2, 7), reason="requires python2.7 or higher"
@@ -766,7 +767,8 @@ class TestMain:
             ),
             sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
         )
-        success, result = run_main(configuration_item, params)
+        with set_module_args(args=params):
+            success, result = run_main(configuration_item, params)
 
         assert success is True
 
@@ -777,7 +779,8 @@ class TestMain:
             ),
             name="my_name",
         )
-        success, result = run_main(configuration_item, params)
+        with set_module_args(args=params):
+            success, result = run_main(configuration_item, params)
 
         assert success is True
 
@@ -803,12 +806,14 @@ class TestMain:
             other=None,
             attachments=None,
         )
-        success, result = run_main(configuration_item, params)
+        with set_module_args(args=params):
+            success, result = run_main(configuration_item, params)
 
         assert success is True
 
     def test_fail(self, run_main):
-        success, result = run_main(configuration_item)
+        with set_module_args(args={}):
+            success, result = run_main(configuration_item)
 
         assert success is False
         assert "one of the following is required: sys_id, name" in result["msg"]

--- a/tests/unit/plugins/modules/test_configuration_item.py
+++ b/tests/unit/plugins/modules/test_configuration_item.py
@@ -12,7 +12,9 @@ import sys
 import pytest
 from ansible_collections.servicenow.itsm.plugins.module_utils import errors
 from ansible_collections.servicenow.itsm.plugins.modules import configuration_item
-from ansible_collections.servicenow.itsm.tests.unit.plugins.common.utils import set_module_args
+from ansible_collections.servicenow.itsm.tests.unit.plugins.common.utils import (
+    set_module_args,
+)
 
 pytestmark = pytest.mark.skipif(
     sys.version_info < (2, 7), reason="requires python2.7 or higher"

--- a/tests/unit/plugins/modules/test_configuration_item_info.py
+++ b/tests/unit/plugins/modules/test_configuration_item_info.py
@@ -11,7 +11,9 @@ import sys
 
 import pytest
 from ansible_collections.servicenow.itsm.plugins.modules import configuration_item_info
-from ansible_collections.servicenow.itsm.tests.unit.plugins.common.utils import set_module_args
+from ansible_collections.servicenow.itsm.tests.unit.plugins.common.utils import (
+    set_module_args,
+)
 
 pytestmark = pytest.mark.skipif(
     sys.version_info < (2, 7), reason="requires python2.7 or higher"

--- a/tests/unit/plugins/modules/test_configuration_item_info.py
+++ b/tests/unit/plugins/modules/test_configuration_item_info.py
@@ -11,6 +11,7 @@ import sys
 
 import pytest
 from ansible_collections.servicenow.itsm.plugins.modules import configuration_item_info
+from ansible_collections.servicenow.itsm.tests.unit.plugins.common.utils import set_module_args
 
 pytestmark = pytest.mark.skipif(
     sys.version_info < (2, 7), reason="requires python2.7 or higher"
@@ -46,7 +47,8 @@ class TestMain:
                 host="https://my.host.name", username="user", password="pass"
             ),
         )
-        success, result = run_main(configuration_item_info, params)
+        with set_module_args(args=params):
+            success, result = run_main(configuration_item_info, params)
 
         assert success is True
 
@@ -58,7 +60,8 @@ class TestMain:
             sys_id="01a9ec0d3790200044e0bfc8bcbe5dc3",
             sys_class_name="cmdb_ci",
         )
-        success, result = run_main(configuration_item_info, params)
+        with set_module_args(args=params):
+            success, result = run_main(configuration_item_info, params)
 
         assert success is True
 
@@ -84,7 +87,8 @@ class TestMain:
             sysparm_query=sysparm_query_value,
             sys_class_name="cmdb_ci",
         )
-        success, result = run_main(configuration_item_info, params)
+        with set_module_args(args=params):
+            success, result = run_main(configuration_item_info, params)
 
         assert success is False
         assert (
@@ -93,7 +97,8 @@ class TestMain:
         )
 
     def test_fail(self, run_main):
-        success, result = run_main(configuration_item_info)
+        with set_module_args(args={}):
+            success, result = run_main(configuration_item_info)
 
         assert success is False
         assert "instance" in result["msg"]

--- a/tests/unit/plugins/modules/test_incident.py
+++ b/tests/unit/plugins/modules/test_incident.py
@@ -12,7 +12,9 @@ import sys
 import pytest
 from ansible_collections.servicenow.itsm.plugins.module_utils import errors
 from ansible_collections.servicenow.itsm.plugins.modules import incident
-from ansible_collections.servicenow.itsm.tests.unit.plugins.common.utils import set_module_args
+from ansible_collections.servicenow.itsm.tests.unit.plugins.common.utils import (
+    set_module_args,
+)
 
 pytestmark = pytest.mark.skipif(
     sys.version_info < (2, 7), reason="requires python2.7 or higher"

--- a/tests/unit/plugins/modules/test_incident.py
+++ b/tests/unit/plugins/modules/test_incident.py
@@ -12,6 +12,7 @@ import sys
 import pytest
 from ansible_collections.servicenow.itsm.plugins.module_utils import errors
 from ansible_collections.servicenow.itsm.plugins.modules import incident
+from ansible_collections.servicenow.itsm.tests.unit.plugins.common.utils import set_module_args
 
 pytestmark = pytest.mark.skipif(
     sys.version_info < (2, 7), reason="requires python2.7 or higher"
@@ -347,7 +348,8 @@ class TestEnsurePresentWithMapping:
             number="n",
             incident_mapping=self.INCIDENT_MAPPING,
         )
-        success, result = run_main(incident, params)
+        with set_module_args(args=params):
+            success, result = run_main(incident, params)
 
         assert success is True
 
@@ -360,7 +362,8 @@ class TestEnsurePresentWithMapping:
             number="n",
             incident_mapping={"unknown key": None},
         )
-        success, result = run_main(incident, params)
+        with set_module_args(args=params):
+            success, result = run_main(incident, params)
 
         assert success is False
 

--- a/tests/unit/plugins/modules/test_incident_info.py
+++ b/tests/unit/plugins/modules/test_incident_info.py
@@ -11,6 +11,7 @@ import sys
 
 import pytest
 from ansible_collections.servicenow.itsm.plugins.modules import incident_info
+from ansible_collections.servicenow.itsm.tests.unit.plugins.common.utils import set_module_args
 
 pytestmark = pytest.mark.skipif(
     sys.version_info < (2, 7), reason="requires python2.7 or higher"
@@ -41,7 +42,8 @@ class TestMain:
                 host="https://my.host.name", username="user", password="pass"
             ),
         )
-        success, result = run_main(incident_info, params)
+        with set_module_args(args=params):
+            success, result = run_main(incident_info, params)
 
         assert success is True
 
@@ -53,12 +55,14 @@ class TestMain:
             sys_id="id",
             number="INC001",
         )
-        success, result = run_main(incident_info, params)
+        with set_module_args(args=params):
+            success, result = run_main(incident_info, params)
 
         assert success is True
 
     def test_fail(self, run_main):
-        success, result = run_main(incident_info)
+        with set_module_args(args={}):
+            success, result = run_main(incident_info)
 
         assert success is False
         assert "instance" in result["msg"]

--- a/tests/unit/plugins/modules/test_incident_info.py
+++ b/tests/unit/plugins/modules/test_incident_info.py
@@ -11,7 +11,9 @@ import sys
 
 import pytest
 from ansible_collections.servicenow.itsm.plugins.modules import incident_info
-from ansible_collections.servicenow.itsm.tests.unit.plugins.common.utils import set_module_args
+from ansible_collections.servicenow.itsm.tests.unit.plugins.common.utils import (
+    set_module_args,
+)
 
 pytestmark = pytest.mark.skipif(
     sys.version_info < (2, 7), reason="requires python2.7 or higher"

--- a/tests/unit/plugins/modules/test_problem_info.py
+++ b/tests/unit/plugins/modules/test_problem_info.py
@@ -11,7 +11,9 @@ import sys
 
 import pytest
 from ansible_collections.servicenow.itsm.plugins.modules import problem_info
-from ansible_collections.servicenow.itsm.tests.unit.plugins.common.utils import set_module_args
+from ansible_collections.servicenow.itsm.tests.unit.plugins.common.utils import (
+    set_module_args,
+)
 
 pytestmark = pytest.mark.skipif(
     sys.version_info < (2, 7), reason="requires python2.7 or higher"

--- a/tests/unit/plugins/modules/test_problem_info.py
+++ b/tests/unit/plugins/modules/test_problem_info.py
@@ -11,6 +11,7 @@ import sys
 
 import pytest
 from ansible_collections.servicenow.itsm.plugins.modules import problem_info
+from ansible_collections.servicenow.itsm.tests.unit.plugins.common.utils import set_module_args
 
 pytestmark = pytest.mark.skipif(
     sys.version_info < (2, 7), reason="requires python2.7 or higher"
@@ -45,7 +46,8 @@ class TestMain:
                 host="https://my.host.name", username="user", password="pass"
             ),
         )
-        success, result = run_main(problem_info, params)
+        with set_module_args(args=params):
+            success, result = run_main(problem_info, params)
 
         assert success is True
 
@@ -57,12 +59,14 @@ class TestMain:
             sys_id="id",
             number="n",
         )
-        success, result = run_main(problem_info, params)
+        with set_module_args(args=params):
+            success, result = run_main(problem_info, params)
 
         assert success is True
 
     def test_fail(self, run_main):
-        success, result = run_main(problem_info)
+        with set_module_args(args={}):
+            success, result = run_main(problem_info)
 
         assert success is False
         assert "instance" in result["msg"]

--- a/tests/unit/plugins/modules/test_problem_task_info.py
+++ b/tests/unit/plugins/modules/test_problem_task_info.py
@@ -11,6 +11,7 @@ import sys
 
 import pytest
 from ansible_collections.servicenow.itsm.plugins.modules import problem_task_info
+from ansible_collections.servicenow.itsm.tests.unit.plugins.common.utils import set_module_args
 
 pytestmark = pytest.mark.skipif(
     sys.version_info < (2, 7), reason="requires python2.7 or higher"
@@ -45,7 +46,8 @@ class TestMain:
                 host="https://my.host.name", username="user", password="pass"
             ),
         )
-        success, result = run_main(problem_task_info, params)
+        with set_module_args(args=params):
+            success, result = run_main(problem_task_info, params)
 
         assert success is True
 
@@ -57,12 +59,14 @@ class TestMain:
             sys_id="id",
             number="n",
         )
-        success, result = run_main(problem_task_info, params)
+        with set_module_args(args=params):
+            success, result = run_main(problem_task_info, params)
 
         assert success is True
 
     def test_fail(self, run_main):
-        success, result = run_main(problem_task_info)
+        with set_module_args(args={}):
+            success, result = run_main(problem_task_info)
 
         assert success is False
         assert "instance" in result["msg"]

--- a/tests/unit/plugins/modules/test_problem_task_info.py
+++ b/tests/unit/plugins/modules/test_problem_task_info.py
@@ -11,7 +11,9 @@ import sys
 
 import pytest
 from ansible_collections.servicenow.itsm.plugins.modules import problem_task_info
-from ansible_collections.servicenow.itsm.tests.unit.plugins.common.utils import set_module_args
+from ansible_collections.servicenow.itsm.tests.unit.plugins.common.utils import (
+    set_module_args,
+)
 
 pytestmark = pytest.mark.skipif(
     sys.version_info < (2, 7), reason="requires python2.7 or higher"


### PR DESCRIPTION
##### SUMMARY
This change updates the unit tests to be compatible with ansible-core 2.19. It follows the recommendations [here](https://forum.ansible.com/t/data-tagging-preview-and-testing/40759) which indicate that the argument object expected by the module class has changed slightly

There are a few changes outside of the tests directory:
- For modules that accept a template instead of a data dict (seems limited to the api action plugin), the template must be explicitly marked as safe in 2.19+. This is done in the module to preserve the existing behavior
- For change_request_task, the module did not raise an error that is already documented as not allowed. The test to check for this error passed due to implicit boolean handling. 2.19 is more strict about when things evaluate to true, which caused the test to fail. Adding the error message to the module fixes the test and aligns with the documentation

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module unit tests
plugins/action/api
change_request_task

##### ADDITIONAL INFORMATION
I think we should have a broader discussion about using ansible-test directly instead of relying on pytest for units, but that is a large change that is not really necessary to move forward
