### PR TITLE
Add nightly scheduled workflow to run tests daily at midnight

### DIFF
--- a/.github/workflows/nightly_builds.yaml
+++ b/.github/workflows/nightly_builds.yaml
@@ -1,0 +1,42 @@
+---
+    name: all_green
+    
+    concurrency:
+      group: ${{ github.head_ref }}
+      cancel-in-progress: true
+    
+    on:
+        schedule:
+            - cron: '0 0 * * *'  # At 00:00 UTC every day
+    
+    jobs:
+      safe-to-test:
+        if: ${{ github.event.label.name == 'safe to test' }} || ${{ github.event.action != 'labeled' }}
+        uses: ansible-network/github_actions/.github/workflows/safe-to-test.yml@main
+      linters:
+        uses: ./.github/workflows/linters.yml  # use the callable linters job to run tests
+      sanity:
+        uses: ./.github/workflows/sanity.yml  # use the callable sanity job to run tests
+      units:
+        uses: ./.github/workflows/units.yml  # use the callable units job to run tests
+      integrations:
+        uses: ./.github/workflows/integration.yml
+        secrets: inherit
+        needs:
+          - safe-to-test
+      all_green:
+        if: ${{ always() }}
+        needs:
+          - linters
+          - sanity
+          - units
+          - integrations
+        runs-on: ubuntu-latest
+        steps:
+          - run: >-
+              python -c "assert set([
+              '${{ needs.linters.result }}',
+              '${{ needs.sanity.result }}',
+              '${{ needs.units.result }}'
+              ]) == {'success'}"
+    


### PR DESCRIPTION
##### SUMMARY
running the same jobs as the pushed-triggered workflow
running at 00:00 UTC every day

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
nightly_builds.yaml
