### PR TITLE
Exclude 3.9 from 2.16 and 2.17 integration tests too

### DIFF
--- a/.github/workflows/integration_source.yml
+++ b/.github/workflows/integration_source.yml
@@ -27,7 +27,15 @@ on:
             },
             {
               "ansible-version": "stable-2.16",
+              "python-version": "3.9",
+            },
+            {
+              "ansible-version": "stable-2.16",
               "python-version": "3.13",
+            },
+            {
+              "ansible-version": "stable-2.17",
+              "python-version": "3.9"
             },
             {
               "ansible-version": "stable-2.17",


### PR DESCRIPTION
##### SUMMARY
Exclude Python 3.9 from integration tests against 2.16 and 2.17

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
workflow