### PR TITLE
Fix nightly CI to not require safe-to-test

### DIFF
--- a/.github/workflows/all_green_check.yml
+++ b/.github/workflows/all_green_check.yml
@@ -2,7 +2,7 @@
 name: all_green
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.head_ref }}
   cancel-in-progress: true
 
 on: # yamllint disable-line rule:truthy
@@ -18,9 +18,6 @@ on: # yamllint disable-line rule:truthy
       - "stable-*"
     tags:
       - "*"
-
-  schedule:
-    - cron: "0 0 * * *" # timezone is UTC
 
 jobs:
   safe-to-test:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,36 @@
+---
+name: nightly
+
+concurrency:
+  group: ${{ github.run_id }}
+  cancel-in-progress: true
+
+on:
+  schedule:
+    - cron: "0 0 * * *"  # timezone is UTC
+
+jobs:
+  linters:
+    uses: ./.github/workflows/linters.yml
+  sanity:
+    uses: ./.github/workflows/sanity.yml
+  units:
+    uses: ./.github/workflows/units.yml
+  integrations:
+    uses: ./.github/workflows/integration.yml
+    secrets: inherit
+  nightly:
+    if: ${{ always() }}
+    needs:
+      - linters
+      - sanity
+      - units
+      - integrations
+    runs-on: ubuntu-latest
+    steps:
+      - run: >-
+          python -c "assert set([
+          '${{ needs.linters.result }}',
+          '${{ needs.sanity.result }}',
+          '${{ needs.units.result }}'
+          ]) == {'success'}"

--- a/changelogs/fragments/20250508-fix_nightly.yaml
+++ b/changelogs/fragments/20250508-fix_nightly.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Split nightly workflow out from all_green


### PR DESCRIPTION
##### SUMMARY
Fix nightly CI run by splitting it into a separate workflow without safe-to-test requirement

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
workflows