### PR TITLE
fix inventory plugin syntax issue with fetch columns

### DIFF
--- a/changelogs/fragments/451-inventory-bugfix.yml
+++ b/changelogs/fragments/451-inventory-bugfix.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - inventory plugin - fix a syntax issue that causes the plugin to fail (https://github.com/ansible-collections/servicenow.itsm/issues/451)

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -852,7 +852,6 @@ class InventoryModule(BaseInventoryPlugin, ConstructableWithLookup, Cacheable):
         referenced_columns = [x for x in columns if "." in x]
         if referenced_columns:
             self.__fetch_referenced_columns(
-                self,
                 table_client,
                 table,
                 query,


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/servicenow.itsm/issues/451

After re-factoring the inventory plugin function for the linters, it looks like there is a syntax issue that was not caught by the tests. This change should fix that.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
inventory plugin