### PR TITLE
prepare 2.9.2 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ servicenow.itsm Release Notes
 
 .. contents:: Topics
 
+v2.9.2
+======
+
 v2.9.1
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -509,3 +509,5 @@ releases:
     - 291_release_summary.yml
     - 451-inventory-bugfix.yml
     release_date: '2025-05-15'
+  2.9.2:
+    release_date: '2025-05-15'

--- a/docs/servicenow.itsm.api_info_module.rst
+++ b/docs/servicenow.itsm.api_info_module.rst
@@ -3,7 +3,7 @@
 servicenow.itsm.api_info module -- Manage ServiceNow GET requests
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.1).
+This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.2).
 
 It is not included in ``ansible-core``.
 To check whether it is installed, run ``ansible-galaxy collection list``.

--- a/docs/servicenow.itsm.api_module.rst
+++ b/docs/servicenow.itsm.api_module.rst
@@ -3,7 +3,7 @@
 servicenow.itsm.api module -- Manage ServiceNow POST, PATCH and DELETE requests
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.1).
+This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.2).
 
 It is not included in ``ansible-core``.
 To check whether it is installed, run ``ansible-galaxy collection list``.

--- a/docs/servicenow.itsm.attachment_info_module.rst
+++ b/docs/servicenow.itsm.attachment_info_module.rst
@@ -3,7 +3,7 @@
 servicenow.itsm.attachment_info module -- a module that users can use to download attachment using sys\_id
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.1).
+This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.2).
 
 It is not included in ``ansible-core``.
 To check whether it is installed, run ``ansible-galaxy collection list``.

--- a/docs/servicenow.itsm.attachment_upload_module.rst
+++ b/docs/servicenow.itsm.attachment_upload_module.rst
@@ -3,7 +3,7 @@
 servicenow.itsm.attachment_upload module -- Upload attachment to the selected table
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.1).
+This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.2).
 
 It is not included in ``ansible-core``.
 To check whether it is installed, run ``ansible-galaxy collection list``.

--- a/docs/servicenow.itsm.change_request_info_module.rst
+++ b/docs/servicenow.itsm.change_request_info_module.rst
@@ -3,7 +3,7 @@
 servicenow.itsm.change_request_info module -- List ServiceNow change requests
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.1).
+This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.2).
 
 It is not included in ``ansible-core``.
 To check whether it is installed, run ``ansible-galaxy collection list``.

--- a/docs/servicenow.itsm.change_request_module.rst
+++ b/docs/servicenow.itsm.change_request_module.rst
@@ -3,7 +3,7 @@
 servicenow.itsm.change_request module -- Manage ServiceNow change requests
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.1).
+This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.2).
 
 It is not included in ``ansible-core``.
 To check whether it is installed, run ``ansible-galaxy collection list``.

--- a/docs/servicenow.itsm.change_request_task_info_module.rst
+++ b/docs/servicenow.itsm.change_request_task_info_module.rst
@@ -3,7 +3,7 @@
 servicenow.itsm.change_request_task_info module -- List ServiceNow change request tasks
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.1).
+This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.2).
 
 It is not included in ``ansible-core``.
 To check whether it is installed, run ``ansible-galaxy collection list``.

--- a/docs/servicenow.itsm.change_request_task_module.rst
+++ b/docs/servicenow.itsm.change_request_task_module.rst
@@ -3,7 +3,7 @@
 servicenow.itsm.change_request_task module -- Manage ServiceNow change request tasks
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.1).
+This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.2).
 
 It is not included in ``ansible-core``.
 To check whether it is installed, run ``ansible-galaxy collection list``.

--- a/docs/servicenow.itsm.configuration_item_batch_module.rst
+++ b/docs/servicenow.itsm.configuration_item_batch_module.rst
@@ -3,7 +3,7 @@
 servicenow.itsm.configuration_item_batch module -- Manage ServiceNow configuration items in batch mode
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.1).
+This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.2).
 
 It is not included in ``ansible-core``.
 To check whether it is installed, run ``ansible-galaxy collection list``.

--- a/docs/servicenow.itsm.configuration_item_info_module.rst
+++ b/docs/servicenow.itsm.configuration_item_info_module.rst
@@ -3,7 +3,7 @@
 servicenow.itsm.configuration_item_info module -- List ServiceNow configuration item
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.1).
+This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.2).
 
 It is not included in ``ansible-core``.
 To check whether it is installed, run ``ansible-galaxy collection list``.

--- a/docs/servicenow.itsm.configuration_item_module.rst
+++ b/docs/servicenow.itsm.configuration_item_module.rst
@@ -3,7 +3,7 @@
 servicenow.itsm.configuration_item module -- Manage ServiceNow configuration items
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.1).
+This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.2).
 
 It is not included in ``ansible-core``.
 To check whether it is installed, run ``ansible-galaxy collection list``.

--- a/docs/servicenow.itsm.configuration_item_relations_info_module.rst
+++ b/docs/servicenow.itsm.configuration_item_relations_info_module.rst
@@ -3,7 +3,7 @@
 servicenow.itsm.configuration_item_relations_info module -- Retreive ServiceNow relations of configuration items
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.1).
+This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.2).
 
 It is not included in ``ansible-core``.
 To check whether it is installed, run ``ansible-galaxy collection list``.

--- a/docs/servicenow.itsm.configuration_item_relations_module.rst
+++ b/docs/servicenow.itsm.configuration_item_relations_module.rst
@@ -3,7 +3,7 @@
 servicenow.itsm.configuration_item_relations module -- Manage ServiceNow relations between configuration items
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.1).
+This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.2).
 
 It is not included in ``ansible-core``.
 To check whether it is installed, run ``ansible-galaxy collection list``.

--- a/docs/servicenow.itsm.incident_info_module.rst
+++ b/docs/servicenow.itsm.incident_info_module.rst
@@ -3,7 +3,7 @@
 servicenow.itsm.incident_info module -- List ServiceNow incidents
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.1).
+This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.2).
 
 It is not included in ``ansible-core``.
 To check whether it is installed, run ``ansible-galaxy collection list``.

--- a/docs/servicenow.itsm.incident_module.rst
+++ b/docs/servicenow.itsm.incident_module.rst
@@ -3,7 +3,7 @@
 servicenow.itsm.incident module -- Manage ServiceNow incidents
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.1).
+This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.2).
 
 It is not included in ``ansible-core``.
 To check whether it is installed, run ``ansible-galaxy collection list``.

--- a/docs/servicenow.itsm.now_inventory.rst
+++ b/docs/servicenow.itsm.now_inventory.rst
@@ -3,7 +3,7 @@
 servicenow.itsm.now inventory -- Inventory source for ServiceNow table records.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-This inventory plugin is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.1).
+This inventory plugin is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.2).
 
 It is not included in ``ansible-core``.
 To check whether it is installed, run ``ansible-galaxy collection list``.

--- a/docs/servicenow.itsm.problem_info_module.rst
+++ b/docs/servicenow.itsm.problem_info_module.rst
@@ -3,7 +3,7 @@
 servicenow.itsm.problem_info module -- List ServiceNow problems
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.1).
+This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.2).
 
 It is not included in ``ansible-core``.
 To check whether it is installed, run ``ansible-galaxy collection list``.

--- a/docs/servicenow.itsm.problem_module.rst
+++ b/docs/servicenow.itsm.problem_module.rst
@@ -3,7 +3,7 @@
 servicenow.itsm.problem module -- Manage ServiceNow problems
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.1).
+This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.2).
 
 It is not included in ``ansible-core``.
 To check whether it is installed, run ``ansible-galaxy collection list``.

--- a/docs/servicenow.itsm.problem_task_info_module.rst
+++ b/docs/servicenow.itsm.problem_task_info_module.rst
@@ -3,7 +3,7 @@
 servicenow.itsm.problem_task_info module -- List ServiceNow problem tasks
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.1).
+This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.2).
 
 It is not included in ``ansible-core``.
 To check whether it is installed, run ``ansible-galaxy collection list``.

--- a/docs/servicenow.itsm.problem_task_module.rst
+++ b/docs/servicenow.itsm.problem_task_module.rst
@@ -3,7 +3,7 @@
 servicenow.itsm.problem_task module -- Manage ServiceNow problem tasks
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.1).
+This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.2).
 
 It is not included in ``ansible-core``.
 To check whether it is installed, run ``ansible-galaxy collection list``.

--- a/docs/servicenow.itsm.service_catalog_info_module.rst
+++ b/docs/servicenow.itsm.service_catalog_info_module.rst
@@ -3,7 +3,7 @@
 servicenow.itsm.service_catalog_info module -- List ServiceNow service catalogs along with categories and items
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.1).
+This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.2).
 
 It is not included in ``ansible-core``.
 To check whether it is installed, run ``ansible-galaxy collection list``.

--- a/docs/servicenow.itsm.service_catalog_module.rst
+++ b/docs/servicenow.itsm.service_catalog_module.rst
@@ -3,7 +3,7 @@
 servicenow.itsm.service_catalog module -- Manage ServiceNow service catalog cart
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.1).
+This module is part of the `servicenow.itsm collection <https://galaxy.ansible.com/ui/repo/published/servicenow/itsm/>`_ (version 2.9.2).
 
 It is not included in ``ansible-core``.
 To check whether it is installed, run ``ansible-galaxy collection list``.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: servicenow
 name: itsm
-version: 2.9.1
+version: 2.9.2
 readme: README.md
 authors:
   - Cosmin Tupangiu <ctupangi@redhat.com>


### PR DESCRIPTION
##### SUMMARY
Fix prior release

##### ISSUE TYPE
Release

##### ADDITIONAL INFORMATION
Release 2.9.1 is bad because the tag refers to the wrong commit. This will fix the previous release