### PR TITLE
Obtain records after populating

### DIFF
--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -797,6 +797,10 @@ class InventoryModule(BaseInventoryPlugin, ConstructableWithLookup, Cacheable):
 
         if not records:
             self.__populate_records_from_remote(enhanced, path, columns)
+            try:
+                records = self._cache[self.cache_key][self._cache_sub_key]
+            except KeyError:
+                pass
 
         self.fill_constructed(
             records,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The records list was not being updated after running __populate_records_from_remote() leading to no hosts being added.

Fixes #456 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
now.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

