### PR TITLE
add test vars role dependency to all tests

### DIFF
--- a/changelogs/fragments/460-add-test-vars-setup-role.yml
+++ b/changelogs/fragments/460-add-test-vars-setup-role.yml
@@ -1,0 +1,5 @@
+---
+trivial:
+  - tests/integration - Add test var setup role as dependency to all tests. This adds a consistent
+    setup to all tests, checks that auth variables are set as expected, and creates a thread safe
+    id that will be used in a future pr

--- a/tests/integration/targets/api_authentication/meta/main.yml
+++ b/tests/integration/targets/api_authentication/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_test_vars

--- a/tests/integration/targets/itsm_api/meta/main.yml
+++ b/tests/integration/targets/itsm_api/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_test_vars

--- a/tests/integration/targets/itsm_api_generic/meta/main.yml
+++ b/tests/integration/targets/itsm_api_generic/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_test_vars

--- a/tests/integration/targets/itsm_attachment/meta/main.yml
+++ b/tests/integration/targets/itsm_attachment/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_test_vars

--- a/tests/integration/targets/itsm_attachment_info/meta/main.yml
+++ b/tests/integration/targets/itsm_attachment_info/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_test_vars

--- a/tests/integration/targets/itsm_attachment_upload/meta/main.yml
+++ b/tests/integration/targets/itsm_attachment_upload/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_test_vars

--- a/tests/integration/targets/itsm_change_request/meta/main.yml
+++ b/tests/integration/targets/itsm_change_request/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_test_vars

--- a/tests/integration/targets/itsm_change_request_task/tasks/meta/main.yml
+++ b/tests/integration/targets/itsm_change_request_task/tasks/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_test_vars

--- a/tests/integration/targets/itsm_change_request_with_mapping/tasks/meta/main.yml
+++ b/tests/integration/targets/itsm_change_request_with_mapping/tasks/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_test_vars

--- a/tests/integration/targets/itsm_configuration_item/meta/main.yml
+++ b/tests/integration/targets/itsm_configuration_item/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_test_vars

--- a/tests/integration/targets/itsm_configuration_item_batch/tasks/meta/main.yml
+++ b/tests/integration/targets/itsm_configuration_item_batch/tasks/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_test_vars

--- a/tests/integration/targets/itsm_configuration_item_relations/tasks/meta/main.yml
+++ b/tests/integration/targets/itsm_configuration_item_relations/tasks/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_test_vars

--- a/tests/integration/targets/itsm_incident/meta/main.yml
+++ b/tests/integration/targets/itsm_incident/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_test_vars

--- a/tests/integration/targets/itsm_incident_with_mapping/meta/main.yml
+++ b/tests/integration/targets/itsm_incident_with_mapping/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_test_vars

--- a/tests/integration/targets/itsm_misc/meta/main.yml
+++ b/tests/integration/targets/itsm_misc/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_test_vars

--- a/tests/integration/targets/itsm_service_catalog/meta/main.yml
+++ b/tests/integration/targets/itsm_service_catalog/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_test_vars

--- a/tests/integration/targets/itsm_service_catalog_info/meta/main.yml
+++ b/tests/integration/targets/itsm_service_catalog_info/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_test_vars

--- a/tests/integration/targets/prepare_test_vars/meta/main.yml
+++ b/tests/integration/targets/prepare_test_vars/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_test_vars

--- a/tests/integration/targets/prepare_test_vars/meta/main.yml
+++ b/tests/integration/targets/prepare_test_vars/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_test_vars

--- a/tests/integration/targets/problem/meta/main.yml
+++ b/tests/integration/targets/problem/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_test_vars

--- a/tests/integration/targets/problem_task/tasks/meta/main.yml
+++ b/tests/integration/targets/problem_task/tasks/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_test_vars

--- a/tests/integration/targets/problem_with_mapping/meta/main.yml
+++ b/tests/integration/targets/problem_with_mapping/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_test_vars


### PR DESCRIPTION
##### SUMMARY
This change adds a consistent setup role to all integration tests. This provides two main benefits
1. all tests will have the same authentication variables setup, checked, and available to them
2. a unique test ID is generated for all tests. This will ensure all tests have a consistent unique ID and can be made thread safe

I will open a second PR to ensure tests are thread safe and use the unique test ID when possible

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
tests/integration
