### PR TITLE
use unique_test_id in all tests instead of lookup

### DIFF
--- a/changelogs/fragments/465-use-unique-id-in-all-tests.yml
+++ b/changelogs/fragments/465-use-unique-id-in-all-tests.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - tests/integration - Use the unique_test_id variable in all tests that previously used a password lookup

--- a/tests/integration/targets/itsm_api/tasks/main.yml
+++ b/tests/integration/targets/itsm_api/tasks/main.yml
@@ -12,7 +12,7 @@
         query_params:
           sysparm_input_display_value: true
         data:
-          user_name: "{{ 'demo_username_' + lookup('password', '/dev/null chars=ascii_letters,digit length=8') | lower }}"
+          user_name: "{{ 'demo_username_' + unique_test_id }}"
           user_password: "demo_password"
           first_name: "first_name"
           last_name: Demouser
@@ -35,7 +35,7 @@
         resource: incident
         action: post
         data:
-          short_description: "{{ 'my-incident_' + lookup('password', '/dev/null chars=ascii_letters,digit length=8') | lower }}"
+          short_description: "{{ 'my-incident_' + unique_test_id }}"
           caller_id: employee
       register: base_api
       check_mode: true

--- a/tests/integration/targets/itsm_attachment/tasks/main.yml
+++ b/tests/integration/targets/itsm_attachment/tasks/main.yml
@@ -33,7 +33,6 @@
           - result.record.attachments | length == 1
           - result.record.attachments[0].file_name == "sample_file1.txt"
 
-
     - name: Create test change_request with attachment
       servicenow.itsm.change_request: *create-attachment
       register: test_result
@@ -43,7 +42,6 @@
         result: "{{ test_result }}"
 
     - ansible.builtin.assert: *create-attachment-result
-
 
     - name: Update change_request with same attachment, same name, add new (check_mode)
       servicenow.itsm.change_request: &cr-update
@@ -61,7 +59,6 @@
           - result is changed
           - result.record.attachments | map(attribute="file_name") | sort | list == ["sample_file1.txt", "sample_file2.txt"]
 
-
     - name: Update change_request with same attachment, same name, add new
       servicenow.itsm.change_request: *cr-update
       register: result
@@ -72,7 +69,6 @@
           - result.record.attachments | map(attribute="file_name") | sort | list == ["sample_file1.txt", "sample_file2.txt"]
           - result.record.attachments[0].hash == "6f2b0dec698566114435a23f15dcac848a40e1fd3e0eda4afe24a663dda23f2e"
           - result.record.attachments[1].hash == "6f2b0dec698566114435a23f15dcac848a40e1fd3e0eda4afe24a663dda23f2e"
-
 
     - name: Update change request with different attachment, same name
       servicenow.itsm.change_request:
@@ -87,7 +83,6 @@
           - result.record.attachments | map(attribute="file_name") | sort | list == ["sample_file1.txt", "sample_file2.txt"]
           - result.record.attachments | map(attribute="hash") | sort | list == ["6f2b0dec698566114435a23f15dcac848a40e1fd3e0eda4afe24a663dda23f2e", "f52a678046a6f06e5fca54b4c535b210f29cbaf1134f2b75197cf47078621902"]
 
-
     - name: Read the change request with attachments
       servicenow.itsm.change_request_info:
         number: "{{ test_result.record.number }}"
@@ -98,7 +93,6 @@
           - result.records[0].attachments | length == 2
           - result.records[0].attachments | map(attribute="file_name") | sort | list == ["sample_file1.txt", "sample_file2.txt"]
           - result.records[0].attachments | map(attribute="hash") | sort | list == ["6f2b0dec698566114435a23f15dcac848a40e1fd3e0eda4afe24a663dda23f2e", "f52a678046a6f06e5fca54b4c535b210f29cbaf1134f2b75197cf47078621902"]
-
 
     - name: Delete change request attachment - check mode
       servicenow.itsm.change_request: &delete-change_request-attachment
@@ -112,7 +106,6 @@
         that:
           - result is changed
 
-
     - name: Delete attachment
       servicenow.itsm.change_request: *delete-change_request-attachment
 
@@ -124,7 +117,7 @@
 
     - name: Create a base configuration item with attachment (check mode)
       servicenow.itsm.configuration_item: &ci-create
-        name: "{{ 'configuration-item-' + lookup('password', '/dev/null chars=ascii_letters,digit length=8') | lower }}"
+        name: "{{ 'configuration-item-' + unique_test_id }}"
         category: hardware
         environment: development
         install_status: on_order
@@ -170,7 +163,6 @@
           - result is changed
           - result.record.attachments | map(attribute="file_name") | sort | list == ["sample_file1.txt", "sample_file2.txt"]
 
-
     - name: Update the configuration item with same attachment, same name, add new
       servicenow.itsm.configuration_item: *ci-update
       register: result
@@ -181,7 +173,6 @@
           - result.record.attachments | map(attribute="file_name") | sort | list == ["sample_file1.txt", "sample_file2.txt"]
           - result.record.attachments[0].hash == "6f2b0dec698566114435a23f15dcac848a40e1fd3e0eda4afe24a663dda23f2e"
           - result.record.attachments[1].hash == "6f2b0dec698566114435a23f15dcac848a40e1fd3e0eda4afe24a663dda23f2e"
-
 
     - name: Update configuration item with different attachment, same name
       servicenow.itsm.configuration_item:
@@ -196,7 +187,6 @@
           - result.record.attachments | map(attribute="file_name") | sort | list == ["sample_file1.txt", "sample_file2.txt"]
           - result.record.attachments | map(attribute="hash") | sort | list == ["6f2b0dec698566114435a23f15dcac848a40e1fd3e0eda4afe24a663dda23f2e", "f52a678046a6f06e5fca54b4c535b210f29cbaf1134f2b75197cf47078621902"]
 
-
     - name: Read the configuration item with attachments
       servicenow.itsm.configuration_item_info:
         sys_id: "{{ test_result.record.sys_id }}"
@@ -207,7 +197,6 @@
           - result.records[0].attachments | length == 2
           - result.records[0].attachments | map(attribute="file_name") | sort | list == ["sample_file1.txt", "sample_file2.txt"]
           - result.records[0].attachments | map(attribute="hash") | sort | list == ["6f2b0dec698566114435a23f15dcac848a40e1fd3e0eda4afe24a663dda23f2e", "f52a678046a6f06e5fca54b4c535b210f29cbaf1134f2b75197cf47078621902"]
-
 
     - name: Delete configuration item with attachments - check mode
       servicenow.itsm.configuration_item: &delete-configuration_item-attachment
@@ -220,13 +209,11 @@
         that:
           - result is changed
 
-
     - name: Delete configuration item with attachments
       servicenow.itsm.configuration_item: *delete-configuration_item-attachment
       register: result
 
     - ansible.builtin.assert: *delete-configuration_item-attachment-result
-
 
     #######################################
     ###### Incident Attachment Tests ######
@@ -263,7 +250,6 @@
 
     - ansible.builtin.assert: *create-incident-attachment-result
 
-
     - name: Update the incident with same attachment, same name, add new (check mode)
       servicenow.itsm.incident: &incident-update
         number: "{{ test_result.record.number }}"
@@ -280,7 +266,6 @@
           - result is changed
           - result.record.attachments | map(attribute="file_name") | sort | list == ["sample_file1.txt", "sample_file2.txt"]
 
-
     - name: Update the incident with same attachment, same name, add new
       servicenow.itsm.incident: *incident-update
       register: result
@@ -291,7 +276,6 @@
           - result.record.attachments | map(attribute="file_name") | sort | list == ["sample_file1.txt", "sample_file2.txt"]
           - result.record.attachments[0].hash == "6f2b0dec698566114435a23f15dcac848a40e1fd3e0eda4afe24a663dda23f2e"
           - result.record.attachments[1].hash == "6f2b0dec698566114435a23f15dcac848a40e1fd3e0eda4afe24a663dda23f2e"
-
 
     - name: Update incident with different attachment, same name
       servicenow.itsm.incident:
@@ -306,7 +290,6 @@
           - result.record.attachments | map(attribute="file_name") | sort | list == ["sample_file1.txt", "sample_file2.txt"]
           - result.record.attachments | map(attribute="hash") | sort | list == ["6f2b0dec698566114435a23f15dcac848a40e1fd3e0eda4afe24a663dda23f2e", "f52a678046a6f06e5fca54b4c535b210f29cbaf1134f2b75197cf47078621902"]
 
-
     - name: Read the incident with attachments
       servicenow.itsm.incident_info:
         number: "{{ test_result.record.number }}"
@@ -318,7 +301,6 @@
           - result.records[0].attachments | map(attribute="file_name") | sort | list == ["sample_file1.txt", "sample_file2.txt"]
           - result.records[0].attachments | map(attribute="hash") | sort | list == ["6f2b0dec698566114435a23f15dcac848a40e1fd3e0eda4afe24a663dda23f2e", "f52a678046a6f06e5fca54b4c535b210f29cbaf1134f2b75197cf47078621902"]
 
-
     - name: Delete incident attachment - check mode
       servicenow.itsm.incident: &delete-incident-attachment
         number: "{{ test_result.record.number }}"
@@ -329,7 +311,6 @@
     - ansible.builtin.assert: &delete-incident-attachment-result
         that:
           - result is changed
-
 
     - name: Delete incident/attachments
       servicenow.itsm.incident: *delete-incident-attachment
@@ -358,13 +339,11 @@
           - first_problem.record.attachments | length == 1
           - first_problem.record.attachments[0].file_name == "sample_file1.txt"
 
-
     - name: Create the problem with attachment
       servicenow.itsm.problem: *problem-create-attachment
       register: first_problem
 
     - ansible.builtin.assert: *problem-create-assertions-attachment
-
 
     - name: Update the problem with same attachment, same name, add new (check mode)
       servicenow.itsm.problem: &problem-update
@@ -382,7 +361,6 @@
           - result is changed
           - result.record.attachments | map(attribute="file_name") | sort | list == ["sample_file1.txt", "sample_file2.txt"]
 
-
     - name: Update the problem with same attachment, same name, add new
       servicenow.itsm.problem: *problem-update
       register: result
@@ -393,7 +371,6 @@
           - result.record.attachments | map(attribute="file_name") | sort | list == ["sample_file1.txt", "sample_file2.txt"]
           - result.record.attachments[0].hash == "6f2b0dec698566114435a23f15dcac848a40e1fd3e0eda4afe24a663dda23f2e"
           - result.record.attachments[1].hash == "6f2b0dec698566114435a23f15dcac848a40e1fd3e0eda4afe24a663dda23f2e"
-
 
     - name: Update problem with different attachment, same name
       servicenow.itsm.problem:
@@ -408,7 +385,6 @@
           - result.record.attachments | map(attribute="file_name") | sort | list == ["sample_file1.txt", "sample_file2.txt"]
           - result.record.attachments | map(attribute="hash") | sort | list == ["6f2b0dec698566114435a23f15dcac848a40e1fd3e0eda4afe24a663dda23f2e", "f52a678046a6f06e5fca54b4c535b210f29cbaf1134f2b75197cf47078621902"]
 
-
     - name: Read the problem with attachments
       servicenow.itsm.problem_info:
         sys_id: "{{ first_problem.record.sys_id }}"
@@ -419,7 +395,6 @@
           - result.records[0].attachments | length == 2
           - result.records[0].attachments | map(attribute="file_name") | sort | list == ["sample_file1.txt", "sample_file2.txt"]
           - result.records[0].attachments | map(attribute="hash") | sort | list == ["6f2b0dec698566114435a23f15dcac848a40e1fd3e0eda4afe24a663dda23f2e", "f52a678046a6f06e5fca54b4c535b210f29cbaf1134f2b75197cf47078621902"]
-
 
     - name: Delete problem attachment - check mode
       servicenow.itsm.problem: &delete-problem-attachment
@@ -432,12 +407,10 @@
         that:
           - result is changed
 
-
     - name: Delete problem/attachments
       servicenow.itsm.problem: *delete-problem-attachment
 
     - ansible.builtin.assert: *delete-problem-attachment-result
-
 
     ################################################
     ############# Get Attachment Tests #############
@@ -446,7 +419,7 @@
     - name: Create a base configuration item with attachment
       servicenow.itsm.configuration_item: *ci-create
       register: ci_result
-    
+
     - name: Create temporary file
       ansible.builtin.tempfile:
         state: file
@@ -465,7 +438,7 @@
           - att_result.record.msg == "OK"
           - att_result.record.size != 0
           - att_result.record.status_code == 200
-    
+
     - name: Download attachment
       servicenow.itsm.attachment: *download-attachment
       register: att_result

--- a/tests/integration/targets/itsm_change_request_task/tasks/main.yml
+++ b/tests/integration/targets/itsm_change_request_task/tasks/main.yml
@@ -39,15 +39,12 @@
           - change_request_result.record.risk == "low"
           - change_request_result.record.impact == "low"
 
-    - ansible.builtin.set_fact:
-        prefix: "{{ lookup('password', '/dev/null chars=ascii_letters,digit length=8') | lower }}"
-
     - name: Create test change_request_task - check mode
       servicenow.itsm.change_request_task: &create-change_request_task
         change_request_number: "{{ change_request_result.record.number }}"
         type: planning
         state: pending
-        short_description: "{{ prefix }} Implement collision avoidance"
+        short_description: "{{ unique_test_id }} Implement collision avoidance"
         description: "Implement collision avoidance based on the newly installed TOF sensor arrays."
         other:
           approval: approved
@@ -60,7 +57,7 @@
           - result.record.change_request == change_request_result.record.sys_id
           - result.record.change_task_type == "planning"
           - result.record.state == "pending"
-          - prefix in result.record.short_description
+          - unique_test_id in result.record.short_description
           - result.record.description == "Implement collision avoidance based on the newly installed TOF sensor arrays."
           - result.record.approval == "approved"
 
@@ -84,7 +81,7 @@
           - result.records[0].change_request == change_request_result.record.sys_id
           - result.records[0].change_task_type == "planning"
           - result.records[0].state == "pending"
-          - prefix in result.records[0].short_description
+          - unique_test_id in result.records[0].short_description
           - result.records[0].description == "Implement collision avoidance based on the newly installed TOF sensor arrays."
           - result.records[0].approval == "approved"
 
@@ -136,7 +133,7 @@
     - ansible.builtin.assert: &update-change_request_task-result
         that:
           - result is changed
-          - prefix in result.record.short_description
+          - unique_test_id in result.record.short_description
           - result.record.state == "in_progress"
           - result.record.description == "Something changed"
           - result.record.change_task_type == "planning"
@@ -153,7 +150,7 @@
 
     - ansible.builtin.assert:
         that:
-          - prefix in result.records[0].short_description
+          - unique_test_id in result.records[0].short_description
           - result.records[0].state == "in_progress"
           - result.records[0].description == "Something changed"
           - result.records[0].change_task_type == "planning"
@@ -329,12 +326,12 @@
     - name: Get change_request_task info by sysparm query - short_description
       servicenow.itsm.change_request_task_info:
         query:
-          - short_description: "LIKE {{ prefix }}"
+          - short_description: "LIKE {{ unique_test_id }}"
       register: result
 
     - ansible.builtin.assert:
         that:
-          - prefix in result.records[0].short_description
+          - unique_test_id in result.records[0].short_description
 
     - name: Test bad parameter combinator (number + query)
       servicenow.itsm.change_request_task_info:
@@ -420,16 +417,13 @@
         impact: low
       register: change_request_result
 
-    - ansible.builtin.set_fact:
-        prefix: "{{ lookup('password', '/dev/null chars=ascii_letters,digit length=8') | lower }}"
-
     - name: Create test change_request_task
       servicenow.itsm.change_request_task:
         change_request_number: "{{ change_request_result.record.number }}"
         type: planning
         state: open
         assignment_group: "{{ assignment_groups[instance] | default('network') }}"
-        short_description: "{{ prefix }} Implement collision avoidance"
+        short_description: "{{ unique_test_id }} Changed Implement collision avoidance"
         description: "Implement collision avoidance based on the newly installed TOF sensor arrays."
         other:
           approval: approved

--- a/tests/integration/targets/itsm_configuration_item/tasks/main.yml
+++ b/tests/integration/targets/itsm_configuration_item/tasks/main.yml
@@ -7,7 +7,7 @@
   block:
     - name: Create a base configuration item (check mode)
       servicenow.itsm.configuration_item: &ci-create
-        name: "{{ 'configuration_item_' + lookup('password', '/dev/null chars=ascii_letters,digit length=8') | lower }}"
+        name: "{{ 'configuration_item_' + unique_test_id }}"
         category: hardware
         environment: development
         install_status: on_order
@@ -47,12 +47,12 @@
     - ansible.builtin.assert:
         that:
           - result.records | length == 1
-    
+
     - name: Update the configuration item (check mode)
       servicenow.itsm.configuration_item: &ci-update
         sys_id: "{{ base_ci.record.sys_id }}"
         sys_class_name: cmdb_ci_computer
-        name: "{{ 'my-configuration-item-' + lookup('password', '/dev/null chars=ascii_letters,digit length=8') | lower }}"
+        name: "{{ 'my-configuration-item-' + unique_test_id }}"
         short_description: short-description
         asset_tag: P22896
         install_status: installed
@@ -97,22 +97,22 @@
     - ansible.builtin.assert: *ci-update-assertions
 
     - name: Update the configuration item using only name (idempotence)
-      servicenow.itsm.configuration_item: 
+      servicenow.itsm.configuration_item:
         name: "{{ updated_ci.record.name }}"
       register: result
     - ansible.builtin.assert:
         that:
           - result is not changed
-    
+
     - name: Rename configuration item
       servicenow.itsm.configuration_item:
         sys_id: "{{ base_ci.record.sys_id }}"
-        name: "{{ 'my_computer_' + lookup('password', '/dev/null chars=ascii_letters,digit length=8') | lower }}"
+        name: "{{ 'my_computer_' + unique_test_id }}"
       register: base_ci
     - ansible.builtin.assert:
         that:
           - base_ci is changed
-    
+
     - name: Create configuration item without sys_id or name
       servicenow.itsm.configuration_item:
       ignore_errors: true
@@ -125,16 +125,16 @@
     - name: Get specific configuration item info by sysparm query
       servicenow.itsm.configuration_item_info:
         query:
-         - sys_id: = {{ base_ci.record.sys_id }}
-           sys_class_name: = cmdb_ci_computer
-           short_description: = short-description
-           asset_tag: = P22896
-           install_status: = installed
-           operational_status: = ready
-           serial_number: = abc123
-           ip_address: = 192.168.250.23
-           mac_address: = a1:b2:c3:d4:e5
-           assigned_to: = admin
+          - sys_id: = {{ base_ci.record.sys_id }}
+            sys_class_name: = cmdb_ci_computer
+            short_description: = short-description
+            asset_tag: = P22896
+            install_status: = installed
+            operational_status: = ready
+            serial_number: = abc123
+            ip_address: = 192.168.250.23
+            mac_address: = a1:b2:c3:d4:e5
+            assigned_to: = admin
       register: result
     - ansible.builtin.assert:
         that:
@@ -155,7 +155,7 @@
       servicenow.itsm.configuration_item:
         sys_id: "{{ base_ci.record.sys_id }}"
         other:
-          cpu_count: 4  # this field is present in cmdb_ci_computer, but not in cmdb_ci
+          cpu_count: 4 # this field is present in cmdb_ci_computer, but not in cmdb_ci
       register: result
     - ansible.builtin.assert:
         that:
@@ -164,21 +164,21 @@
 
     - name: Create a configuration item of an extended (non-base) type
       servicenow.itsm.configuration_item:
-        name: "{{ 'test-server-' + lookup('password', '/dev/null chars=ascii_letters,digit length=8') | lower }}"
+        name: "{{ 'test-server-' + unique_test_id }}"
         sys_class_name: cmdb_ci_server
         other:
-          classification: Development  # field specific to cmdb_ci_server
+          classification: Development # field specific to cmdb_ci_server
       register: server
     - ansible.builtin.assert:
         that:
           - server is changed
           - server.record.classification == "Development"
-    
+
     - name: Get configuration item info by sysparm query - sys_class_name and name
       servicenow.itsm.configuration_item_info:
         query:
-         - sys_class_name: = cmdb_ci_server
-           name: "= {{ server.record.name }}"
+          - sys_class_name: = cmdb_ci_server
+            name: "= {{ server.record.name }}"
       register: result
 
     - ansible.builtin.assert:
@@ -195,7 +195,7 @@
     - ansible.builtin.assert:
         that:
           - result is failed
-    
+
     - name: Delete a configuration item (check mode)
       servicenow.itsm.configuration_item: &ci-delete
         sys_id: "{{ base_ci.record.sys_id }}"
@@ -213,7 +213,7 @@
     - ansible.builtin.assert:
         that:
           - result.records | length == 1
-    
+
     - name: Delete configuration item using sys_id and wrong name
       servicenow.itsm.configuration_item:
         sys_id: "{{ base_ci.record.sys_id }}"
@@ -269,7 +269,7 @@
       servicenow.itsm.configuration_item_info:
         sys_id: "{{ base_ci.record.sys_id }}"
         query:
-         - name: = lnux101
+          - name: = lnux101
       ignore_errors: true
       register: result
     - ansible.builtin.assert:
@@ -280,7 +280,7 @@
     - name: Test invalid operator detection
       servicenow.itsm.configuration_item_info:
         query:
-         - name: == lnux101
+          - name: == lnux101
       ignore_errors: true
       register: result
     - ansible.builtin.assert:
@@ -291,7 +291,7 @@
     - name: Test unary operator with argument detection
       servicenow.itsm.configuration_item_info:
         query:
-         - short_description: ISEMPTY SAP
+          - short_description: ISEMPTY SAP
       ignore_errors: true
       register: result
     - ansible.builtin.assert:
@@ -302,19 +302,16 @@
     - name: Test sysparm query unary operator - short_description
       servicenow.itsm.configuration_item_info:
         query:
-         - short_description: ISNOTEMPTY
+          - short_description: ISNOTEMPTY
       register: result
     - ansible.builtin.assert:
         that:
           - result.records[0].short_description != ""
-    
-    # Tests for #208
-    - ansible.builtin.set_fact:
-        prefix: "{{ lookup('password', '/dev/null chars=ascii_letters,digit length=8') | lower }}"
 
+    # Tests for #208
     - name: Create a base configuration item
       servicenow.itsm.configuration_item:
-        name: "{{ prefix }}-my-configuration-item"
+        name: "{{ unique_test_id }}-my-configuration-item"
         category: hardware
         environment: development
         install_status: on_order

--- a/tests/integration/targets/itsm_configuration_item_batch/tasks/main.yml
+++ b/tests/integration/targets/itsm_configuration_item_batch/tasks/main.yml
@@ -7,7 +7,7 @@
   block:
     - name: Register instance in ServiceNow
       servicenow.itsm.configuration_item:
-        name: "{{ 'demo_ec2_' + lookup('password', '/dev/null chars=ascii_letters,digit length=8') | lower }}"
+        name: "{{ 'demo_ec2_' + unique_test_id }}"
         sys_class_name: cmdb_ci_ec2_instance
         ip_address: 1.1.1.1
         other:
@@ -20,13 +20,12 @@
           - ci.record.ip_address == "1.1.1.1"
           - ci.record.vm_inst_id == "10"
 
-
     - name: Update existing CMDB -- check mode --
       servicenow.itsm.configuration_item_batch: &update_cmdb
         sys_class_name: cmdb_ci_ec2_instance
         id_column_set: vm_inst_id
         dataset:
-          - instance_id: "{{ lookup('password', '/dev/null chars=ascii_letters,digit length=8') | lower }}"
+          - instance_id: "{{ unique_test_id }}"
             public_ip_address: 10.10.10.10
             tags:
               Name: instance_10
@@ -49,7 +48,6 @@
         that:
           - ci is changed
 
-
     - name: Configuration item info
       servicenow.itsm.configuration_item_info:
         sys_class_name: cmdb_ci_ec2_instance
@@ -62,7 +60,6 @@
           - ci.records[0].ip_address == "10.10.10.10"
           - ci.records[0].name == "instance_10"
 
-
     - name: Delete a configuration item
       servicenow.itsm.configuration_item:
         sys_id: "{{ ci.records[0].sys_id }}"
@@ -73,17 +70,16 @@
         that:
           - result is changed
 
-
     - name: Update CMDB with data from AWS
       servicenow.itsm.configuration_item_batch: &state_check_params
         sys_class_name: cmdb_ci_ec2_instance
         id_column_set: vm_inst_id
         dataset:
-          - instance_id: "{{ lookup('password', '/dev/null chars=ascii_letters,digit length=8') | lower }}"
+          - instance_id: "{{ unique_test_id }}"
             public_ip_address: 1.2.3.4
             tags:
               Name: my_name
-          - instance_id: "{{ lookup('password', '/dev/null chars=ascii_letters,digit length=8') | lower }}"
+          - instance_id: "{{ unique_test_id }}"
             public_ip_address: 4.3.2.1
             tags:
               Name: other_name
@@ -97,7 +93,6 @@
         that:
           - ci is changed
 
-
     - name: Configuration item info
       servicenow.itsm.configuration_item_info:
         sys_class_name: cmdb_ci_ec2_instance
@@ -108,8 +103,8 @@
     - ansible.builtin.assert:
         that:
           - result.records | length == 1
-          - result.records[0].ip_address in ('1.2.3.4','4.3.2.1') 
-    
+          - result.records[0].ip_address in ('1.2.3.4','4.3.2.1')
+
     - name: Configuration item info
       servicenow.itsm.configuration_item_info:
         sys_class_name: cmdb_ci_ec2_instance
@@ -120,8 +115,7 @@
     - ansible.builtin.assert:
         that:
           - result.records | length == 1
-          - result.records[0].ip_address in ('1.2.3.4','4.3.2.1') 
-
+          - result.records[0].ip_address in ('1.2.3.4','4.3.2.1')
 
     - name: Update CMDB with different data
       servicenow.itsm.configuration_item_batch:
@@ -146,7 +140,6 @@
         that:
           - ci is changed
 
-
     - name: Configuration item info
       servicenow.itsm.configuration_item_info:
         sys_class_name: cmdb_ci_ec2_instance
@@ -157,8 +150,7 @@
     - ansible.builtin.assert:
         that:
           - result.records | length == 1
-          - result.records[0].ip_address in ('1.1.1.1','2.2.2.2') 
-
+          - result.records[0].ip_address in ('1.1.1.1','2.2.2.2')
 
     - name: Delete a configuration item
       servicenow.itsm.configuration_item:
@@ -169,7 +161,7 @@
     - ansible.builtin.assert:
         that:
           - result is changed
-    
+
     - name: Configuration item info
       servicenow.itsm.configuration_item_info:
         sys_class_name: cmdb_ci_ec2_instance
@@ -180,8 +172,7 @@
     - ansible.builtin.assert:
         that:
           - result.records | length == 1
-          - result.records[0].ip_address in ('1.1.1.1','2.2.2.2') 
-
+          - result.records[0].ip_address in ('1.1.1.1','2.2.2.2')
 
     - name: Delete a configuration item
       servicenow.itsm.configuration_item:
@@ -192,7 +183,6 @@
     - ansible.builtin.assert:
         that:
           - result is changed
-
 
     - name: Configuration item info
       servicenow.itsm.configuration_item_info:

--- a/tests/integration/targets/itsm_configuration_item_relations/tasks/main.yml
+++ b/tests/integration/targets/itsm_configuration_item_relations/tasks/main.yml
@@ -10,12 +10,12 @@
         resource: cmdb_ci_linux_server
         action: post
         data:
-          name: "{{ 'linux_' + lookup('password', '/dev/null chars=ascii_letters,digit length=8') | lower }}"
+          name: "{{ 'linux_' + unique_test_id }}"
       loop: "{{ range(0,3,1)|list }}"
       register: servers
 
-    - ansible.builtin.assert: 
-        that: 
+    - ansible.builtin.assert:
+        that:
           - servers.results | length == 3
 
     - name: Add relation between the first server and the rest -- check mode --
@@ -50,13 +50,12 @@
       servicenow.itsm.configuration_item_relations: *create-relations-data
       register: relations
 
-    
     - name: Retrieve relations for the first server
       servicenow.itsm.configuration_item_relations_info:
         sys_id: "{{ servers.results[0].record.sys_id }}"
         classname: cmdb_ci_linux_server
       register: relations
-    
+
     - debug: var=relations
 
     - ansible.builtin.assert:
@@ -76,7 +75,7 @@
             sys_id: "{{ servers.results[2].record.sys_id }}"
       register: deleted_relation
       check_mode: true
-    
+
     - ansible.builtin.assert:
         that:
           - deleted_relation.record.outbound_relations | length == 0
@@ -86,21 +85,21 @@
         sys_id: "{{ servers.results[0].record.sys_id }}"
         classname: cmdb_ci_linux_server
       register: relations
-    
+
     - ansible.builtin.assert:
         that:
           - relations.record.outbound_relations | length == 2
           - relations.record.inbound_relations | length == 0
-    
+
     - name: Remove relation
       servicenow.itsm.configuration_item_relations: *delete-relations-data
-    
+
     - name: Retrieve relations for the first server
       servicenow.itsm.configuration_item_relations_info:
         sys_id: "{{ servers.results[0].record.sys_id }}"
         classname: cmdb_ci_linux_server
       register: relations
-    
+
     - ansible.builtin.assert:
         that:
           - relations.record.outbound_relations | length == 0
@@ -111,7 +110,7 @@
         resource: cmdb_ci_linux_server
         action: delete
         sys_id: "{{ item }}"
-      loop: 
+      loop:
         - "{{ servers.results[0].record.sys_id }}"
         - "{{ servers.results[1].record.sys_id }}"
         - "{{ servers.results[2].record.sys_id }}"

--- a/tests/integration/targets/itsm_service_catalog/tasks/main.yml
+++ b/tests/integration/targets/itsm_service_catalog/tasks/main.yml
@@ -16,7 +16,7 @@
         query_params:
           sysparm_input_display_value: true
         data:
-          user_name: "{{ 'demo_username_' + lookup('password', '/dev/null chars=ascii_letters,digit length=8') | lower }}"
+          user_name: "{{ 'demo_username_' + unique_test_id }}"
           user_password: "{{ password }}"
           first_name: "first_name"
           last_name: Demouser
@@ -47,14 +47,14 @@
         SN_USERNAME: "{{ user.record.user_name }}"
         SN_PASSWORD: "{{ password }}"
       register: result
-        
+
     - debug:
         var: result
 
     - ansible.builtin.assert:
         that:
           - result.records | length > 0
-        
+
     - name: Create new email account
       servicenow.itsm.service_catalog:
         action: order_now

--- a/tests/integration/targets/problem/tasks/main.yml
+++ b/tests/integration/targets/problem/tasks/main.yml
@@ -5,15 +5,9 @@
     SN_PASSWORD: "{{ sn_password }}"
 
   block:
-    - name: Generate random string for idempotency
-      ansible.builtin.set_fact:
-        suffix: "{{ lookup('password', '/dev/null chars=ascii_letters,digit length=8') | lower }}"
-
-    - debug: var=suffix
-
     - name: Create a problem (check mode)
       servicenow.itsm.problem: &problem-create
-        short_description: "my-problem_{{ suffix }}"
+        short_description: "my-problem_{{ unique_test_id }}"
         state: new
         attachments:
           - path: "{{ collection_base_dir }}/tests/integration/targets/problem/res/sample_file.txt"
@@ -29,7 +23,7 @@
     - name: Verify creation in check mode did not create a record
       servicenow.itsm.problem_info:
         query:
-          - short_description: "= my-problem_{{ suffix }}"
+          - short_description: "= my-problem_{{ unique_test_id }}"
       register: result
 
     - ansible.builtin.assert:
@@ -196,7 +190,7 @@
     - name: Create a bogus problem for cancellation
       servicenow.itsm.problem:
         state: assess
-        short_description: "cancel-me_{{ suffix }}"
+        short_description: "cancel-me_{{ unique_test_id }}"
         assigned_to: problem.manager
       register: bogus_problem
 
@@ -232,7 +226,7 @@
     - name: Create a new problem (initial state)
       servicenow.itsm.problem:
         state: "new"
-        short_description: "fixed-problem_{{ suffix }}"
+        short_description: "fixed-problem_{{ unique_test_id }}"
         assigned_to: "problem.manager"
       register: fixed_problem
 
@@ -271,7 +265,7 @@
     - name: Create an initial problem (new or assess)
       servicenow.itsm.problem:
         state: assess
-        short_description: "accepted-problem_{{ suffix }}"
+        short_description: "accepted-problem_{{ unique_test_id }}"
         assigned_to: problem.manager
       register: new_problem
 
@@ -306,7 +300,7 @@
         query:
           - number: = {{ risk_accepted_problem.record.number }}
             state: = resolved
-            short_description: "= accepted-problem_{{ suffix }}"
+            short_description: "= accepted-problem_{{ unique_test_id }}"
             assigned_to: = problem.manager
             resolution_code: = risk_accepted
             cause_notes: = cause
@@ -328,7 +322,7 @@
       servicenow.itsm.problem_info:
         query:
           - state: = resolved
-            short_description: "= accepted-problem_{{ suffix }}"
+            short_description: "= accepted-problem_{{ unique_test_id }}"
       register: result
 
     - ansible.builtin.assert:
@@ -340,7 +334,7 @@
       servicenow.itsm.problem:
         state: assess
         assigned_to: problem.manager
-        short_description: "a-duplicate_{{ suffix }}"
+        short_description: "a-duplicate_{{ unique_test_id }}"
       register: duplicated_problem
 
     - name: Advance problem to root cause analysis

--- a/tests/integration/targets/problem_task/tasks/main.yml
+++ b/tests/integration/targets/problem_task/tasks/main.yml
@@ -5,15 +5,9 @@
     SN_PASSWORD: "{{ sn_password }}"
 
   block:
-    - name: Generate random string for idempotency
-      ansible.builtin.set_fact:
-        suffix: "{{ lookup('password', '/dev/null chars=ascii_letters,digit length=8') | lower }}"
-
-    - debug: var=suffix
-
     - name: Create a problem
       servicenow.itsm.problem:
-        short_description: "my-problem_{{ suffix }}"
+        short_description: "my-problem_{{ unique_test_id }}"
         state: new
       register: problem
 
@@ -22,7 +16,6 @@
           - problem is changed
           - problem.record.state == "new"
           - "'my-problem' in problem.record.short_description"
-
 
     - name: Retrieve problem task records
       servicenow.itsm.problem_task_info:
@@ -33,7 +26,7 @@
         state: new
         type: general
         source_problem: "{{ problem.record.number }}"
-        short_description: "my-problem-task_{{ suffix }}"
+        short_description: "my-problem-task_{{ unique_test_id }}"
         priority: low
       check_mode: true
       register: problem_task
@@ -44,23 +37,20 @@
           - problem_task.record.state == "new"
           - "'my-problem-task' in problem_task.record.short_description"
 
-
     - name: Create a problem task
       servicenow.itsm.problem_task: *problem-task-create
       register: problem_task
-  
-    - ansible.builtin.assert: *problem-task-create-assertions
 
+    - ansible.builtin.assert: *problem-task-create-assertions
 
     - name: Verify that a new record was created
       servicenow.itsm.problem_task_info:
         sys_id: "{{ problem_task.record.sys_id }}"
       register: result
-  
+
     - ansible.builtin.assert:
         that:
           - "'my-problem-task' in result.records.0.short_description"
-
 
     - name: Change state of a problem task (check mode)
       servicenow.itsm.problem_task: &problem-task-change
@@ -69,7 +59,7 @@
         sys_id: "{{ problem_task.record.sys_id }}"
         assigned_to: problem.admin
         source_problem: "{{ problem.record.number }}"
-        short_description: "my-problem-task_{{ suffix }}"
+        short_description: "my-problem-task_{{ unique_test_id }}"
         priority: low
       check_mode: true
       register: problem_task
@@ -79,23 +69,20 @@
           - problem_task is changed
           - problem_task.record.state == "assess"
 
-
     - name: Change state of a problem task
       servicenow.itsm.problem_task: *problem-task-change
       register: problem_task
-  
-    - ansible.builtin.assert: *problem-task-change-assertions
 
+    - ansible.builtin.assert: *problem-task-change-assertions
 
     - name: Verify that state was changed
       servicenow.itsm.problem_task_info:
         sys_id: "{{ problem_task.record.sys_id }}"
       register: result
-  
+
     - ansible.builtin.assert:
         that:
           - result.records.0.state == "assess"
-
 
     - name: Delete a problem task (check mode)
       servicenow.itsm.problem_task: &problem-task-delete
@@ -108,19 +95,17 @@
         that:
           - result is changed
 
-
     - name: Delete a problem task
       servicenow.itsm.problem_task: *problem-task-delete
       register: result
-  
-    - ansible.builtin.assert: *problem-task-delete-assertions
 
+    - ansible.builtin.assert: *problem-task-delete-assertions
 
     - name: Verify that a record was deleted
       servicenow.itsm.problem_task_info:
         sys_id: "{{ problem_task.record.sys_id }}"
       register: result
-  
+
     - ansible.builtin.assert:
         that:
           - result.records | length == 0

--- a/tests/integration/targets/problem_with_mapping/tasks/main.yml
+++ b/tests/integration/targets/problem_with_mapping/tasks/main.yml
@@ -21,16 +21,10 @@
           "2": "normal"
           "3": "lowest"
   block:
-    - name: Generate random string for idempotency
-      ansible.builtin.set_fact:
-        suffix: "{{ lookup('password', '/dev/null chars=ascii_letters,digit length=8') | lower }}"
-
-    - debug: var=suffix
-
     - name: Create a problem (check mode)
       servicenow.itsm.problem: &problem-create
         problem_mapping: "{{ mapping.problem }}"
-        short_description: "my-problem_{{ suffix }}"
+        short_description: "my-problem_{{ unique_test_id }}"
         state: my_new
         attachments:
           - path: "{{ collection_base_dir }}/tests/integration/targets/problem_with_mapping/res/sample_file.txt"
@@ -47,7 +41,7 @@
     - name: Verify creation in check mode did not create a record
       servicenow.itsm.problem_info:
         query:
-          - short_description: "= my-problem_{{ suffix }}"
+          - short_description: "= my-problem_{{ unique_test_id }}"
       register: result
 
     - ansible.builtin.assert:
@@ -226,7 +220,7 @@
       servicenow.itsm.problem:
         problem_mapping: "{{ mapping.problem }}"
         state: assess
-        short_description: "cancel-me_{{ suffix }}"
+        short_description: "cancel-me_{{ unique_test_id }}"
         assigned_to: problem.manager
       register: bogus_problem
 
@@ -264,7 +258,7 @@
     - name: Create a new problem (initial state)
       servicenow.itsm.problem:
         state: "new"
-        short_description: "fixed-problem_{{ suffix }}"
+        short_description: "fixed-problem_{{ unique_test_id }}"
         assigned_to: "problem.manager"
       register: fixed_problem
 
@@ -303,7 +297,7 @@
     - name: Create an initial problem (new or assess)
       servicenow.itsm.problem:
         state: assess
-        short_description: "accepted-problem_{{ suffix }}"
+        short_description: "accepted-problem_{{ unique_test_id }}"
         assigned_to: problem.manager
       register: new_problem
 
@@ -338,7 +332,7 @@
         query:
           - number: = {{ risk_accepted_problem.record.number }}
             state: = resolved
-            short_description: "= accepted-problem_{{ suffix }}"
+            short_description: "= accepted-problem_{{ unique_test_id }}"
             assigned_to: = problem.manager
             resolution_code: = risk_accepted
             cause_notes: = cause
@@ -359,7 +353,7 @@
       servicenow.itsm.problem_info:
         query:
           - state: = resolved
-            short_description: "= accepted-problem_{{ suffix }}"
+            short_description: "= accepted-problem_{{ unique_test_id }}"
       register: result
 
     - ansible.builtin.assert:
@@ -370,7 +364,7 @@
       servicenow.itsm.problem:
         state: assess
         assigned_to: problem.manager
-        short_description: "a-duplicate_{{ suffix }}"
+        short_description: "a-duplicate_{{ unique_test_id }}"
       register: duplicated_problem
 
     - name: Advance problem to root cause analysis


### PR DESCRIPTION
##### SUMMARY
Needs https://github.com/ansible-collections/servicenow.itsm/pull/464

This change makes all tests use the unique_test_id variable instead of calling the password lookup all over the place

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
tests/integration
