### PR TITLE
add oauth client credentials grant type to modules

### DIFF
--- a/changelogs/fragments/472-add-client_cred-grant-type.yml
+++ b/changelogs/fragments/472-add-client_cred-grant-type.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - authentication - Adds support for the OAUTH client_credentials grant type

--- a/plugins/doc_fragments/instance.py
+++ b/plugins/doc_fragments/instance.py
@@ -45,7 +45,7 @@ options:
             specifications.
           - If not set by any means, the default value (that is, I(password)) will be set
             internally to preserve backwards compatibility.
-        choices: [ 'password', 'refresh_token' ]
+        choices: [ 'password', 'refresh_token', 'client_credentials' ]
         type: str
         version_added: '1.1.0'
       api_path:
@@ -60,6 +60,7 @@ options:
           - If not set, the value of the C(SN_CLIENT_ID) environment
             variable will be used.
           - If provided, it requires I(client_secret).
+          - Required when I(grant_type=client_credentials).
         type: str
       client_secret:
         description:
@@ -67,6 +68,7 @@ options:
           - If not set, the value of the C(SN_CLIENT_SECRET) environment
             variable will be used.
           - If provided, it requires I(client_id).
+          - Required when I(grant_type=client_credentials).
         type: str
       custom_headers:
         description:

--- a/plugins/module_utils/arguments.py
+++ b/plugins/module_utils/arguments.py
@@ -95,7 +95,7 @@ SHARED_SPECS = dict(
             ),
             grant_type=dict(
                 type="str",
-                choices=["password", "refresh_token"],
+                choices=["password", "refresh_token", "client_credentials"],
                 fallback=(env_fallback, ["SN_GRANT_TYPE"]),
             ),
             api_path=dict(

--- a/tests/integration/targets/api_authentication/tasks/main.yml
+++ b/tests/integration/targets/api_authentication/tasks/main.yml
@@ -46,6 +46,18 @@
         that:
           - result is success
 
+    - name: OAuth authentication success with client_credentials grant type
+      servicenow.itsm.incident_info:
+        number: "{{ incident_number }}"
+      environment:
+        SN_GRANT_TYPE: client_credentials
+        SN_CLIENT_ID: "{{ sn_client_id }}"
+        SN_CLIENT_SECRET: "{{ sn_client_secret }}"
+      register: result
+    - ansible.builtin.assert:
+        that:
+          - result is success
+
     - name: OAuth authentication failure with bad client secret
       servicenow.itsm.incident_info:
         number: "{{ incident_number }}"


### PR DESCRIPTION
##### SUMMARY
Adds support for the OAUTH client credentials grant type. This grant type allows users to specify an OAUTH application's client ID and secret without a username and password.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/module_utils/client

##### ADDITIONAL INFORMATION
Im going to add this for the inventory plugin in a different PR