### PR TITLE
Added configurable token_auth_method 

### DIFF
--- a/.github/workflows/integration_source.yml
+++ b/.github/workflows/integration_source.yml
@@ -103,18 +103,21 @@ jobs:
             sn_password_secret: SN_PASSWORD_WASHINGTON
             sn_client_id_secret: SN_CLIENT_ID_WASHINGTON
             sn_client_secret_secret: SN_CLIENT_SECRET_WASHINGTON
+            sn_api_key_secret: SN_API_KEY_WASHINGTON
           - servicenow-version: "xanadu"
             sn_host_secret: SN_HOST_XANADU
             sn_username_secret: SN_USERNAME_XANADU
             sn_password_secret: SN_PASSWORD_XANADU
             sn_client_id_secret: SN_CLIENT_ID_XANADU
             sn_client_secret_secret: SN_CLIENT_SECRET_XANADU
+            sn_api_key_secret: SN_API_KEY_XANADU
           - servicenow-version: "yokohama"
             sn_host_secret: SN_HOST_YOKOHAMA
             sn_username_secret: SN_USERNAME_YOKOHAMA
             sn_password_secret: SN_PASSWORD_YOKOHAMA
             sn_client_id_secret: SN_CLIENT_ID_YOKOHAMA
             sn_client_secret_secret: SN_CLIENT_SECRET_YOKOHAMA
+            sn_api_key_secret: SN_API_KEY_YOKOHAMA
         exclude: ${{ fromJSON(inputs.matrix_exclude) }}
     continue-on-error: ${{ matrix.ansible-version == 'devel' || matrix.ansible-version == 'milestone' }}
 
@@ -167,6 +170,7 @@ jobs:
           SN_PASSWORD: ${{ secrets[matrix.sn_password_secret] }}
           SN_CLIENT_ID: ${{ secrets[matrix.sn_client_id_secret] }}
           SN_CLIENT_SECRET: ${{ secrets[matrix.sn_client_secret_secret] }}
+          SN_API_KEY: ${{ secrets[matrix.sn_api_key_secret] }}
         run: |
           touch ${{ steps.identify.outputs.collection_path }}/tests/integration/integration_config.yml
           echo "sn_host: '${{ env.SN_HOST }}'" >> ${{ steps.identify.outputs.collection_path }}/tests/integration/integration_config.yml
@@ -174,8 +178,16 @@ jobs:
           echo "sn_password: '${{ env.SN_PASSWORD }}'" >> ${{ steps.identify.outputs.collection_path }}/tests/integration/integration_config.yml
           echo "sn_client_id: '${{ env.SN_CLIENT_ID }}'" >> ${{ steps.identify.outputs.collection_path }}/tests/integration/integration_config.yml
           echo "sn_client_secret: '${{ env.SN_CLIENT_SECRET }}'" >> ${{ steps.identify.outputs.collection_path }}/tests/integration/integration_config.yml
+          echo "sn_api_key: '${{ env.SN_API_KEY }}'" >> ${{ steps.identify.outputs.collection_path }}/tests/integration/integration_config.yml
           echo "collection_base_dir: '${{ steps.identify.outputs.collection_path }}'" >> ${{ steps.identify.outputs.collection_path }}/tests/integration/integration_config.yml
 
       - name: Run integration tests
+        env:
+          SN_HOST: ${{ secrets[matrix.sn_host_secret] }}
+          SN_USERNAME: ${{ secrets[matrix.sn_username_secret] }}
+          SN_PASSWORD: ${{ secrets[matrix.sn_password_secret] }}
+          SN_CLIENT_ID: ${{ secrets[matrix.sn_client_id_secret] }}
+          SN_CLIENT_SECRET: ${{ secrets[matrix.sn_client_secret_secret] }}
+          SN_API_KEY: ${{ secrets[matrix.sn_api_key_secret] }}
         run: ansible-test integration
         working-directory: ${{ steps.identify.outputs.collection_path }}

--- a/changelogs/fragments/416-add-token-auth-method.yml
+++ b/changelogs/fragments/416-add-token-auth-method.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - authentication - Added configurable token_auth_method parameter to support both x-sn-apikey and Authorization Bearer headers for access tokens
+    (https://github.com/ansible-collections/servicenow.itsm/issues/416)

--- a/changelogs/fragments/474-add-client-cred-support-inven.yml
+++ b/changelogs/fragments/474-add-client-cred-support-inven.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - plugins/inventory/now - Added support for the client_credentials authentication grant type

--- a/docs/servicenow.itsm.now_inventory.rst
+++ b/docs/servicenow.itsm.now_inventory.rst
@@ -325,6 +325,40 @@ Parameters
   <tr>
     <td></td>
     <td valign="top">
+      <div class="ansibleOptionAnchor" id="parameter-instance/access_token"></div>
+      <p style="display: inline;"><strong>access_token</strong></p>
+      <a class="ansibleOptionLink" href="#parameter-instance/access_token" title="Permalink to this option"></a>
+      <p style="font-size: small; margin-bottom: 0;">
+        <span style="color: purple;">string</span>
+      </p>
+      <p><i style="font-size: small; color: darkgreen;">added in servicenow.itsm 1.4.0</i></p>
+
+    </td>
+    <td valign="top">
+      <p>Access token used for OAuth authentication.</p>
+      <p>If not set, the value of the <code class='docutils literal notranslate'>SN_ACCESS_TOKEN</code> environment variable will be used.</p>
+      <p>Environment variable: <code>SN_ACCESS_TOKEN</code></p>
+    </td>
+  </tr>
+  <tr>
+    <td></td>
+    <td valign="top">
+      <div class="ansibleOptionAnchor" id="parameter-instance/api_key"></div>
+      <p style="display: inline;"><strong>api_key</strong></p>
+      <a class="ansibleOptionLink" href="#parameter-instance/api_key" title="Permalink to this option"></a>
+      <p style="font-size: small; margin-bottom: 0;">
+        <span style="color: purple;">string</span>
+      </p>
+    </td>
+    <td valign="top">
+      <p>API key used for bearer token authentication.</p>
+      <p>If not set, the value of the <code class='docutils literal notranslate'>SN_API_KEY</code> environment variable will be used.</p>
+      <p>Environment variable: <code>SN_API_KEY</code></p>
+    </td>
+  </tr>
+  <tr>
+    <td></td>
+    <td valign="top">
       <div class="ansibleOptionAnchor" id="parameter-instance/client_id"></div>
       <p style="display: inline;"><strong>client_id</strong></p>
       <a class="ansibleOptionLink" href="#parameter-instance/client_id" title="Permalink to this option"></a>

--- a/plugins/doc_fragments/instance.py
+++ b/plugins/doc_fragments/instance.py
@@ -86,10 +86,20 @@ options:
       access_token:
         description:
           - Access token obtained via OAuth authentication.
+          - Used for OAuth-generated tokens that require Authorization Bearer headers.
           - If not set, the value of the C(SN_ACCESS_TOKEN) environment
             variable will be used.
+          - Mutually exclusive with I(api_key).
         type: str
         version_added: '2.3.0'
+      api_key:
+        description:
+          - ServiceNow API key for direct authentication.
+          - Used for direct API keys that require x-sn-apikey headers.
+          - If not set, the value of the C(SN_API_KEY) environment
+            variable will be used.
+          - Mutually exclusive with I(access_token).
+        type: str
       timeout:
         description:
           - Timeout in seconds for the connection with the ServiceNow instance.

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -59,14 +59,14 @@ options:
           - Username used for authentication.
         env:
           - name: SN_USERNAME
-        required: true
+        required: false
         type: str
       password:
         description:
           - Password used for authentication.
         env:
           - name: SN_PASSWORD
-        required: true
+        required: false
         type: str
       client_id:
         description:
@@ -86,7 +86,7 @@ options:
         description:
           - Grant type used for OAuth authentication.
           - If not set, the value of the C(SN_GRANT_TYPE) environment variable will be used.
-        choices: [ 'password', 'refresh_token' ]
+        choices: [ 'password', 'refresh_token', 'client_credentials' ]
         default: password
         env:
           - name: SN_GRANT_TYPE

--- a/plugins/module_utils/arguments.py
+++ b/plugins/module_utils/arguments.py
@@ -122,6 +122,11 @@ SHARED_SPECS = dict(
                 no_log=True,
                 fallback=(env_fallback, ["SN_ACCESS_TOKEN"]),
             ),
+            api_key=dict(
+                type="str",
+                no_log=True,
+                fallback=(env_fallback, ["SN_API_KEY"]),
+            ),
             timeout=dict(
                 type="float",
                 fallback=(env_fallback, ["SN_TIMEOUT"]),
@@ -132,9 +137,11 @@ SHARED_SPECS = dict(
             ),
         ),
         required_together=[("client_id", "client_secret"), ("username", "password")],
-        required_one_of=[("username", "refresh_token", "access_token", "client_id")],
+        required_one_of=[
+            ("username", "refresh_token", "access_token", "api_key", "client_id")
+        ],
         mutually_exclusive=[
-            ("username", "refresh_token", "access_token"),
+            ("username", "refresh_token", "access_token", "api_key"),
             ("client_id", "access_token"),
             ("grant_type", "access_token"),
         ],

--- a/tests/integration/targets/api_authentication/tasks/main.yml
+++ b/tests/integration/targets/api_authentication/tasks/main.yml
@@ -142,6 +142,7 @@
         number: "{{ incident_number }}"
       environment:
         SN_ACCESS_TOKEN: "{{ sn_access_token }}"
+        SN_TOKEN_AUTH_METHOD: bearer
       register: result
     - ansible.builtin.assert:
         that:
@@ -154,7 +155,49 @@
         SN_ACCESS_TOKEN: bad-token
       register: result
       ignore_errors: true
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is failed
           - "'Failed to authenticate with the instance' in result.msg"
+
+    - name: Authenticate with API key using api_key parameter
+      servicenow.itsm.incident_info:
+        instance:
+          host: "{{ sn_host }}"
+          api_key: "{{ sn_api_key }}"
+        number: "{{ incident_number }}"
+      register: api_key_result
+      when: sn_api_key is defined
+
+    - name: Verify API key authentication success
+      ansible.builtin.assert:
+        that:
+          - api_key_result is success
+      when: sn_api_key is defined
+
+    - name: Authenticate with API key using environment variables only
+      servicenow.itsm.incident_info:
+        number: "{{ incident_number }}"
+      environment:
+        SN_API_KEY: "{{ sn_api_key }}"
+      register: api_key_env_result
+      when: sn_api_key is defined
+
+    - name: Verify API key environment variable authentication success
+      ansible.builtin.assert:
+        that:
+          - api_key_env_result is success
+      when: sn_api_key is defined
+
+    - name: Authenticate with OAuth token using access_token parameter
+      servicenow.itsm.incident_info:
+        instance:
+          host: "{{ sn_host }}"
+          access_token: "{{ sn_access_token }}"
+        number: "{{ incident_number }}"
+      register: bearer_result
+
+    - name: Verify bearer authentication success
+      ansible.builtin.assert:
+        that:
+          - bearer_result is success

--- a/tests/integration/targets/inventory/setup.yml
+++ b/tests/integration/targets/inventory/setup.yml
@@ -18,6 +18,8 @@
           sn_host: '{{ sn_host }}'
           sn_username: '{{ sn_username }}'
           sn_password: '{{ sn_password }}'
+          sn_client_id: '{{ sn_client_id }}'
+          sn_client_secret: '{{ sn_client_secret }}'
           unique_test_id: '{{ unique_test_id }}'
 
     - name: Template session inventories

--- a/tests/integration/targets/inventory/templates/api_key.now.yml
+++ b/tests/integration/targets/inventory/templates/api_key.now.yml
@@ -1,0 +1,17 @@
+plugin: servicenow.itsm.now
+host: "{{ sn_host }}"
+instance:
+  api_key: "{{ sn_api_key | default(omit) }}"
+table: cmdb_ci_ip_switch
+columns:
+  - name
+  - ip_address
+keyed_groups:
+  - key: manufacturer
+    prefix: manufacturer
+  - key: model_id
+    prefix: model
+  - key: location
+    prefix: location
+hostnames:
+  - name 

--- a/tests/integration/targets/inventory/templates/client_cred_grant.now.yml
+++ b/tests/integration/targets/inventory/templates/client_cred_grant.now.yml
@@ -1,0 +1,9 @@
+---
+plugin: servicenow.itsm.now
+instance:
+  host: "{{ sn_host }}"
+  client_id: "{{ sn_client_id }}"
+  client_secret: "{{ sn_client_secret }}"
+  grant_type: client_credentials
+
+sysparm_query: nameSTARTSWITH{{ unique_test_id }}

--- a/tests/integration/targets/inventory/templates/underline_var.now.yml
+++ b/tests/integration/targets/inventory/templates/underline_var.now.yml
@@ -5,6 +5,9 @@ strict: false
 
 instance:
   timeout: 1200
+  host: "{{ sn_host }}"
+  username: "{{ sn_username }}"
+  password: "{{ sn_password }}"
 
 columns:
   - name

--- a/tests/integration/targets/inventory/tests/api_key.yml
+++ b/tests/integration/targets/inventory/tests/api_key.yml
@@ -1,0 +1,15 @@
+- name: "Test: api_key"
+  vars:
+    ansible_inventory_sources:
+      - "{{ inventory_dir }}/api_key.now.yml"
+  block:
+    - name: "Refresh inventory"
+      ansible.builtin.meta: refresh_inventory
+    - name: "Verify that the host is in inventory"
+      ansible.builtin.assert:
+        that:
+          - test_configuration_item_name in hostvars
+        fail_msg: "Host '{{ test_configuration_item_name }}' not in inventory"
+  when:
+    - ansible_version.full is version('2.11', '>=')
+    - sn_api_key is defined and sn_api_key 

--- a/tests/integration/targets/inventory/tests/client_cred_grant.yml
+++ b/tests/integration/targets/inventory/tests/client_cred_grant.yml
@@ -1,0 +1,27 @@
+---
+- name: Test
+  block:
+    - name: Create imaginary VMs
+      servicenow.itsm.configuration_item:
+        name: "{{ resource_prefix }}-{{ item }}"
+        sys_class_name: cmdb_ci_server
+        ip_address: 10.1.0.{{ item }}
+      loop: "{{ range(100, 102) | list }}"
+      register: vms
+
+    - name: Reload inventory
+      ansible.builtin.include_tasks: ../tasks/refresh_inventory.yml
+
+    - name: Make sure inventory ran successfully
+      ansible.builtin.assert:
+        that:
+          - groups['all'] | length == 2
+
+  always:
+    - name: Delete VMs
+      servicenow.itsm.configuration_item:
+        state: absent
+        sys_id: "{{ item.record.sys_id }}"
+      loop: "{{ vms.results }}"
+      loop_control:
+        label: "{{ item.record.name }}"

--- a/tests/integration/targets/inventory/tests/underline_var.yml
+++ b/tests/integration/targets/inventory/tests/underline_var.yml
@@ -1,8 +1,5 @@
 ---
-- name: Test underline var in compose
-  vars:
-    inventory_file_name: underline_var.now.yml
-    resource_prefix: "{{ unique_test_id }}-inven-underline-var"
+- name: Test
   block:
     - name: Create test location
       servicenow.itsm.api:
@@ -24,31 +21,31 @@
         ip_address: 10.1.0.{{ item }}
         other:
           location: "{{ test_location.record.sys_id }}"
-      loop: "{{ range(100, 102) }}"
+      loop: "{{ range(100, 102) | list }}"
       register: vms
 
     - name: Reload inventory
-      ansible.builtin.include_tasks: refresh_inventory.yml
+      ansible.builtin.include_tasks: ../tasks/refresh_inventory.yml
 
     - name: Check 100
       ansible.builtin.assert:
         that:
           - host_vars.name == resource_prefix + '-100'
           - host_vars.location_name_from_underline == resource_prefix + "-location"
-          - host_vars.location_name_from_dot.__ansible_unsafe == resource_prefix + "-location"
+          - host_vars.location_name_from_dot == resource_prefix + "-location"
           - host_vars.location_name == "test"
       vars:
-        host_vars: "{{ inventory_results._meta.hostvars[resource_prefix + '-100'] }}"
+        host_vars: "{{ hostvars[resource_prefix + '-100'] }}"
 
     - name: Check 101
       ansible.builtin.assert:
         that:
           - host_vars.name == resource_prefix + '-101'
           - host_vars.location_name_from_underline == resource_prefix + "-location"
-          - host_vars.location_name_from_dot.__ansible_unsafe == resource_prefix + "-location"
+          - host_vars.location_name_from_dot == resource_prefix + "-location"
           - host_vars.location_name == "test"
       vars:
-        host_vars: "{{ inventory_results._meta.hostvars[resource_prefix + '-101'] }}"
+        host_vars: "{{ hostvars[resource_prefix + '-101'] }}"
 
   always:
     - name: Delete location

--- a/tests/unit/plugins/module_utils/test_client.py
+++ b/tests/unit/plugins/module_utils/test_client.py
@@ -260,12 +260,19 @@ class TestClientAuthHeader:
         assert c.password == "pass"
         assert c.auth_header == {"Authorization": b"Basic dXNlcjpwYXNz"}  # user:pass
 
-    def test_login_access_token(self, mocker):
+    def test_api_key_authentication(self, mocker):
         mocker.patch.object(client, "Request")
-        c = client.Client("https://instance.com", access_token="token")
+        c = client.Client("https://instance.com", api_key="api-key-123")
 
-        assert c.access_token == "token"
-        assert c.auth_header == {"Authorization": "Bearer token"}
+        assert c.api_key == "api-key-123"
+        assert c.auth_header == {"x-sn-apikey": "api-key-123"}
+
+    def test_access_token_authentication(self, mocker):
+        mocker.patch.object(client, "Request")
+        c = client.Client("https://instance.com", access_token="oauth-token-456")
+
+        assert c.access_token == "oauth-token-456"
+        assert c.auth_header == {"Authorization": "Bearer oauth-token-456"}
 
 
 class TestClientRequest:


### PR DESCRIPTION

##### SUMMARY
Added configurable token_auth_method parameter to support both x-sn-apikey and Authorization Bearer headers for access tokens

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/module_utils/arguments.py
plugins/module_utils/client.py
tests/integration/targets/api_authentication/tasks/main.yml
ests/unit/plugins/module_utils/test_client.py

##### ADDITIONAL INFORMATION
Uses the API-key method as default, the User can choose Bearer method by stating: 
"token_auth_method": "bearer"

