### PR TITLE
Set default HTTP timeout to 60s and update docs

### DIFF
--- a/changelogs/fragments/20240624-default-timeout.yml
+++ b/changelogs/fragments/20240624-default-timeout.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - The default timeout for HTTP requests is now 60 seconds unless overridden by the module parameter or the SN_TIMEOUT environment variable. 

--- a/docs/general_usage_patterns.md
+++ b/docs/general_usage_patterns.md
@@ -212,3 +212,7 @@ an exercise for the reader.
 
 Do note that we can use the same credential type for running playbooks and
 fetching inventory.
+
+## Default Timeout for HTTP Requests
+
+By default, all HTTP requests made by the collection have a 60 second timeout. This can be overridden by setting the `timeout` parameter in your playbook or by setting the `SN_TIMEOUT` environment variable.

--- a/docs/servicenow.itsm.now_inventory.rst
+++ b/docs/servicenow.itsm.now_inventory.rst
@@ -1016,7 +1016,6 @@ Examples
       - name
       - classification
       - cpu_type
-      - cost
     compose:
         cost: cost ~ " " ~ cost_cc
         ansible_host: fqdn

--- a/plugins/module_utils/arguments.py
+++ b/plugins/module_utils/arguments.py
@@ -130,6 +130,7 @@ SHARED_SPECS = dict(
             timeout=dict(
                 type="float",
                 fallback=(env_fallback, ["SN_TIMEOUT"]),
+                default=60.0,
             ),
             validate_certs=dict(
                 type="bool",

--- a/plugins/modules/api.py
+++ b/plugins/modules/api.py
@@ -80,6 +80,11 @@ options:
         you have specified relative path to the file.
       - Template file needs to be present on the Ansible Controller's system. Otherwise, an error is raised.
     type: str
+  timeout:
+    description:
+      - Timeout in seconds for HTTP requests.
+    type: float
+    default: 60.0
 """
 
 
@@ -363,6 +368,10 @@ def main():
         data=dict(type="dict", default=dict()),
         template=dict(
             type="str",
+        ),
+        timeout=dict(
+            type="float",
+            default=60.0
         ),
     )
 

--- a/plugins/modules/api_info.py
+++ b/plugins/modules/api_info.py
@@ -81,6 +81,11 @@ options:
       - Default is set to C(false).
     type: bool
     default: False
+  timeout:
+    description:
+      - Timeout in seconds for HTTP requests.
+    type: float
+    default: 60.0
 """
 
 EXAMPLES = """
@@ -268,6 +273,10 @@ def main():
             type="bool",
             default=False,  # to enforce False when this parameter is omitted from a playbook
         ),  # Do not execute a select count(*) on table (default: false)
+        timeout=dict(
+            type="float",
+            default=60.0,  # to enforce 60.0 when this parameter is omitted from a playbook
+        ),  # Timeout in seconds for HTTP requests (default: 60.0)
     )
 
     module = AnsibleModule(

--- a/plugins/modules/attachment_info.py
+++ b/plugins/modules/attachment_info.py
@@ -37,6 +37,11 @@ options:
       - Attachment's sys_id.
     type: str
     required: true
+  timeout:
+    description:
+      - Timeout in seconds for HTTP requests.
+    type: float
+    default: 60.0
 
 notes:
   - Supports check_mode.
@@ -132,6 +137,10 @@ def main():
         dest=dict(
             type="path",
             required=True,
+        ),
+        timeout=dict(
+            type="float",
+            default=60.0,
         ),
     )
 

--- a/plugins/modules/attachment_upload.py
+++ b/plugins/modules/attachment_upload.py
@@ -38,6 +38,11 @@ options:
       - Record to attach the file to.
     type: str
     required: true
+  timeout:
+    description:
+      - Timeout in seconds for HTTP requests.
+    type: float
+    default: 60.0
 notes:
   - Supports check_mode.
 """
@@ -136,6 +141,10 @@ def main():
         table_name=dict(
             type="str",
             required=True,
+        ),
+        timeout=dict(
+            type="float",
+            default=60.0,
         ),
     )
 

--- a/plugins/modules/change_request.py
+++ b/plugins/modules/change_request.py
@@ -150,6 +150,11 @@ options:
         change request documentation at
         U(https://docs.servicenow.com/bundle/tokyo-it-service-management/page/product/change-management/task/t_CreateAChange.html).
     type: dict
+  timeout:
+    description:
+      - Timeout in seconds for HTTP requests.
+    type: float
+    default: 60.0
 """
 
 EXAMPLES = """
@@ -445,6 +450,10 @@ def main():
         ),
         other=dict(
             type="dict",
+        ),
+        timeout=dict(
+            type="float",
+            default=60.0,
         ),
     )
 

--- a/plugins/modules/change_request_info.py
+++ b/plugins/modules/change_request_info.py
@@ -33,6 +33,11 @@ extends_documentation_fragment:
   - servicenow.itsm.sysparm_display_value
 seealso:
   - module: servicenow.itsm.change_request
+  timeout:
+    description:
+      - Timeout in seconds for HTTP requests.
+    type: float
+    default: 60.0
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/change_request_task.py
+++ b/plugins/modules/change_request_task.py
@@ -137,6 +137,11 @@ options:
         change task documentation at
         U(https://docs.servicenow.com/bundle/tokyo-it-service-management/page/product/change-management/task/create-a-change-task.html).
     type: dict
+  timeout:
+    description:
+      - Timeout in seconds for HTTP requests.
+    type: float
+    default: 60.0
 """
 
 EXAMPLES = """
@@ -403,6 +408,10 @@ def main():
         ),
         other=dict(
             type="dict",
+        ),
+        timeout=dict(
+            type="float",
+            default=60.0,
         ),
     )
 

--- a/plugins/modules/change_request_task_info.py
+++ b/plugins/modules/change_request_task_info.py
@@ -31,6 +31,11 @@ extends_documentation_fragment:
   - servicenow.itsm.sysparm_display_value
 seealso:
   - module: servicenow.itsm.change_request_task
+  timeout:
+    description:
+      - Timeout in seconds for HTTP requests.
+    type: float
+    default: 60.0
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/configuration_item.py
+++ b/plugins/modules/configuration_item.py
@@ -119,6 +119,11 @@ options:
       - For the attributes of configuration items specific to I(sys_class_name),
         please consult the relevant ServiceNow documentation.
     type: dict
+  timeout:
+    description:
+      - Timeout in seconds for HTTP requests.
+    type: float
+    default: 60.0
 """
 
 EXAMPLES = r"""
@@ -466,6 +471,10 @@ def main():
         ),
         other=dict(
             type="dict",
+        ),
+        timeout=dict(
+            type="float",
+            default=60.0,
         ),
     )
 

--- a/plugins/modules/configuration_item_batch.py
+++ b/plugins/modules/configuration_item_batch.py
@@ -58,6 +58,11 @@ options:
       - Data is returned as string because ServiceNow API expect this
     required: true
     type: dict
+  timeout:
+    description:
+      - Timeout in seconds for HTTP requests.
+    type: float
+    default: 60.0
 """
 
 EXAMPLES = r"""
@@ -228,6 +233,10 @@ def main():
         map=dict(
             type="dict",
             required=True,
+        ),
+        timeout=dict(
+            type="float",
+            default=60.0,
         ),
     )
 


### PR DESCRIPTION


##### SUMMARY
Default timeout for HTTP requests is now 60 seconds unless overridden by the module parameter or SN_TIMEOUT environment variable.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
docs/general_usage_patterns.md
docs/servicenow.itsm.now_inventory.rst
plugins/module_utils/arguments.py



```
