### PR TITLE
Allow relationship filtering when using enhanced in inven plugin

### DIFF
--- a/changelogs/fragments/483-inven-enhanced-params.yml
+++ b/changelogs/fragments/483-inven-enhanced-params.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - plugins/inventory/now - Added additional parameters to allow the user to configure the enhanced query and additional columns

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -939,9 +939,12 @@ class InventoryModule(BaseInventoryPlugin, ConstructableWithLookup, Cacheable):
             )
 
         rel_records = fetch_records(
-            table_client, REL_TABLE,
+            table_client,
+            REL_TABLE,
             query=(enhanced_query or enhanced_sysparm_query or REL_QUERY),
-            fields=REL_FIELDS.union(set(self.get_option('enhanced_additional_columns'))),
+            fields=REL_FIELDS.union(
+                set(self.get_option("enhanced_additional_columns"))
+            ),
             is_encoded_query=bool(enhanced_sysparm_query),
         )
         enhance_records_with_rel_groups(records, rel_records)

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -138,9 +138,40 @@ options:
   enhanced:
     description:
       - Enable enhanced inventory which provides relationship information from CMDB.
+      - This produces groups that reflect the relationships defined in CMDB. For example,
+        myhost_Depends_On would contain all hosts with a dependent relationship on myhost.
     type: bool
     default: false
     version_added: 1.3.0
+  enhanced_additional_columns:
+    description:
+      - Define a list of additional CMDB relationship columns to use when querying the relationship
+        table and creating groups using I(enhanced).
+      - If your relationship table has additional columns that you would like to use to in your
+        I(enhanced_query) or I(enhanced_sysparm_query) option, you should specify the column names here.
+      - By default, only the columns sys_id, type.name, parent.sys_id, parent.name,
+        parent.sys_class_name, child.sys_id, child.name, and child.sys_class_name are collected.
+    type: list
+    default: []
+    version_added: 2.10.0
+  enhanced_query:
+    description:
+      - Define a query to limit the relationships queried and eventually turned into groups when using
+        I(enhanced).
+      - The default is to include all relationship types.
+      - This option is mutually exclusive with I(enhanced_sysparm_query).
+      - This query should follow the same format at the I(query) option.
+    type: str
+    version_added: 2.10.0
+  enhanced_sysparm_query:
+    description:
+      - Define a query to limit the relationships queried and eventually turned into groups when using
+        I(enhanced).
+      - The default is to include all relationship types.
+      - This option is mutually exclusive with I(enhanced_query).
+      - This query should follow the same format at the I(sysparm_query) option.
+    type: str
+    version_added: 2.10.0
   aggregation:
     description:
       - Enable multiple variable values aggregations.
@@ -893,12 +924,27 @@ class InventoryModule(BaseInventoryPlugin, ConstructableWithLookup, Cacheable):
             )
 
         if enhanced:
-            rel_records = fetch_records(
-                table_client, REL_TABLE, REL_QUERY, fields=REL_FIELDS
-            )
-            enhance_records_with_rel_groups(records, rel_records)
+            self.__populate_enhanced_records_from_remote(table_client, records)
 
         self._cache[self.cache_key] = {self._cache_sub_key: records}
+
+    def __populate_enhanced_records_from_remote(self, table_client, records):
+        enhanced_query = self.get_option("enhanced_query")
+        enhanced_sysparm_query = self.get_option("enhanced_sysparm_query")
+
+        if enhanced_query and enhanced_sysparm_query:
+            raise AnsibleParserError(
+                "Invalid configuration: 'enhanced_query' and 'enhanced_sysparm_query' are mutually "
+                "exclusive."
+            )
+
+        rel_records = fetch_records(
+            table_client, REL_TABLE,
+            query=(enhanced_query or enhanced_sysparm_query or REL_QUERY),
+            fields=REL_FIELDS.union(set(self.get_option('enhanced_additional_columns'))),
+            is_encoded_query=bool(enhanced_sysparm_query),
+        )
+        enhance_records_with_rel_groups(records, rel_records)
 
     def __create_table_client(self):
         try:
@@ -923,8 +969,13 @@ class InventoryModule(BaseInventoryPlugin, ConstructableWithLookup, Cacheable):
         # has examples that depend on this, and certainly deployed code does this and to do otherwise
         # would break existing inventories. query_columns == None implies retrieving every column from
         # the desired table, which can take a very long time to parse for large tables with many columns.
+        # When using enhanced, the sys_id property is required to determine in what relationship groups things
+        # should go.
         if query_limit_columns:
-            return list(set(query_additional_columns + columns))
+            _cols = set(query_additional_columns + columns)
+            if self.get_option("enhanced"):
+                _cols = _cols.union(REL_FIELDS)
+            return list(_cols)
         else:
             return None
 

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -152,6 +152,7 @@ options:
       - By default, only the columns sys_id, type.name, parent.sys_id, parent.name,
         parent.sys_class_name, child.sys_id, child.name, and child.sys_class_name are collected.
     type: list
+    elements: str
     default: []
     version_added: 2.10.0
   enhanced_query:

--- a/tests/integration/targets/inventory/templates/enhanced.now.yml
+++ b/tests/integration/targets/inventory/templates/enhanced.now.yml
@@ -1,0 +1,19 @@
+---
+plugin: servicenow.itsm.now
+table: cmdb_ci_ec2_instance
+columns:
+  - state
+  - environment
+  - fqdn
+  - ip_address
+  - name
+
+strict: true
+sysparm_query: nameSTARTSWITH{{ unique_test_id }}
+instance:
+  host: "{{ sn_host }}"
+  username: "{{ sn_username }}"
+  password: "{{ sn_password }}"
+
+enhanced: true
+enhanced_sysparm_query: type.nameSTARTSWITHContains

--- a/tests/integration/targets/inventory/tests/enhanced.yml
+++ b/tests/integration/targets/inventory/tests/enhanced.yml
@@ -1,0 +1,57 @@
+---
+- name: Test enhanced
+  block:
+    - name: Create imaginary VMs
+      servicenow.itsm.configuration_item:
+        name: "{{ resource_prefix }}-{{ item }}"
+        sys_class_name: cmdb_ci_ec2_instance
+        ip_address: 10.1.0.{{ item }}
+        environment: "{{ (item % 2 == 0) | ansible.builtin.ternary('development', 'production') }}"
+        other:
+          fqdn: f{{ item }}.example.com
+          guest_os_fullname: "{{ (item < 106) | ansible.builtin.ternary('OS0', 'OS1') }}"
+          vm_inst_id: i{{ item }}
+      loop: "{{ range(101, 109) | list }}"
+      register: vms
+
+    - name: Add cools relationship
+      servicenow.itsm.configuration_item_relations:
+        parent_sys_id: "{{ vms.results[0].record.sys_id }}"
+        parent_classname: cmdb_ci_ec2_instance
+        state: present
+        name: Cools::Cooled By
+        targets:
+          - name: "{{ vms.results[item].record.name }}"
+            sys_id: "{{ vms.results[item].record.sys_id }}"
+      loop: "{{ range(1, 3) | list }}"
+
+    - name: Add contains relationship
+      servicenow.itsm.configuration_item_relations:
+        parent_sys_id: "{{ vms.results[4].record.sys_id }}"
+        parent_classname: cmdb_ci_ec2_instance
+        state: present
+        name: Contains::Contained By
+        targets:
+          - name: "{{ vms.results[item].record.name }}"
+            sys_id: "{{ vms.results[item].record.sys_id }}"
+      loop: "{{ range(5, 7) | list }}"
+      register: contains_relations
+
+    - name: Reload inventory
+      ansible.builtin.include_tasks: ../tasks/refresh_inventory.yml
+
+    - name: Make sure only the expected relationship groups were created
+      ansible.builtin.assert:
+        that:
+          - groups.all | length == 8
+          - groups.ungrouped | length == 5
+          - groups | length == 5
+
+  always:
+    - name: Delete VMs
+      servicenow.itsm.configuration_item:
+        state: absent
+        sys_id: "{{ item.record.sys_id }}"
+      loop: "{{ vms.results }}"
+      loop_control:
+        label: "{{ item.record.name }}"

--- a/tests/unit/plugins/inventory/test_now.py
+++ b/tests/unit/plugins/inventory/test_now.py
@@ -15,7 +15,11 @@ from ansible.inventory.data import InventoryData
 from ansible.module_utils.common.text.converters import to_text
 from ansible.template import Templar
 from ansible_collections.servicenow.itsm.plugins.inventory import now
-from ansible_collections.servicenow.itsm.plugins.module_utils.relations import REL_FIELDS, REL_TABLE, REL_QUERY
+from ansible_collections.servicenow.itsm.plugins.module_utils.relations import (
+    REL_FIELDS,
+    REL_TABLE,
+    REL_QUERY,
+)
 
 
 try:
@@ -995,36 +999,51 @@ class TestInventoryModuleEnhancedQueryFeatures:
             if option_name == "enhanced":
                 return options.get("enhanced", True)
             return options.get(option_name, None)
+
         return get_option
 
     def setup_mocks(self, mocker):
-        self.mock_fetch_records = mocker.patch('ansible_collections.servicenow.itsm.plugins.inventory.now.fetch_records')
+        self.mock_fetch_records = mocker.patch(
+            "ansible_collections.servicenow.itsm.plugins.inventory.now.fetch_records"
+        )
         self.mock_fetch_records.return_value = []
 
-        self.mock_enhance_records_with_rel_groups = mocker.patch('ansible_collections.servicenow.itsm.plugins.inventory.now.enhance_records_with_rel_groups')
+        self.mock_enhance_records_with_rel_groups = mocker.patch(
+            "ansible_collections.servicenow.itsm.plugins.inventory.now.enhance_records_with_rel_groups"
+        )
 
         self.mock_table_client = mocker.Mock()
         self.mock_records = []
 
-    def assert_fetch_records_called_with(self, query, expected_fields, is_encoded_query):
+    def assert_fetch_records_called_with(
+        self, query, expected_fields, is_encoded_query
+    ):
         self.mock_fetch_records.assert_called_once_with(
             self.mock_table_client,
             REL_TABLE,
             query=query,
             fields=expected_fields,
-            is_encoded_query=is_encoded_query
+            is_encoded_query=is_encoded_query,
         )
 
-    def test_populate_enhanced_records_with_enhanced_query(self, inventory_plugin, mocker):
+    def test_populate_enhanced_records_with_enhanced_query(
+        self, inventory_plugin, mocker
+    ):
         """Test __populate_enhanced_records_from_remote with enhanced_query option"""
-        mocker.patch.object(inventory_plugin, "get_option", side_effect=self.setup_get_option_side_effect(
-            enhanced_query=[{"type.name": "Contains:Contained By"}],
-            enhanced_additional_columns=["extra_col1", "extra_col2"],
-        ))
+        mocker.patch.object(
+            inventory_plugin,
+            "get_option",
+            side_effect=self.setup_get_option_side_effect(
+                enhanced_query=[{"type.name": "Contains:Contained By"}],
+                enhanced_additional_columns=["extra_col1", "extra_col2"],
+            ),
+        )
         self.setup_mocks(mocker)
 
         # Test the method
-        inventory_plugin._InventoryModule__populate_enhanced_records_from_remote(self.mock_table_client, self.mock_records)
+        inventory_plugin._InventoryModule__populate_enhanced_records_from_remote(
+            self.mock_table_client, self.mock_records
+        )
         expected_fields = REL_FIELDS.union({"extra_col1", "extra_col2"})
 
         self.assert_fetch_records_called_with(
@@ -1034,19 +1053,29 @@ class TestInventoryModuleEnhancedQueryFeatures:
         )
 
         # Verify enhance_records_with_rel_groups was called
-        self.mock_enhance_records_with_rel_groups.assert_called_once_with(self.mock_records, [])
+        self.mock_enhance_records_with_rel_groups.assert_called_once_with(
+            self.mock_records, []
+        )
 
-    def test_populate_enhanced_records_with_enhanced_sysparm_query(self, inventory_plugin, mocker):
+    def test_populate_enhanced_records_with_enhanced_sysparm_query(
+        self, inventory_plugin, mocker
+    ):
         """Test __populate_enhanced_records_from_remote with enhanced_sysparm_query option"""
 
-        mocker.patch.object(inventory_plugin, "get_option", side_effect=self.setup_get_option_side_effect(
-            enhanced_sysparm_query="type.nameSTARTSWITHContains",
-            enhanced_additional_columns=[],
-        ))
+        mocker.patch.object(
+            inventory_plugin,
+            "get_option",
+            side_effect=self.setup_get_option_side_effect(
+                enhanced_sysparm_query="type.nameSTARTSWITHContains",
+                enhanced_additional_columns=[],
+            ),
+        )
         self.setup_mocks(mocker)
 
         # Call the method
-        inventory_plugin._InventoryModule__populate_enhanced_records_from_remote(self.mock_table_client, self.mock_records)
+        inventory_plugin._InventoryModule__populate_enhanced_records_from_remote(
+            self.mock_table_client, self.mock_records
+        )
 
         # Verify fetch_records was called with correct parameters
         self.assert_fetch_records_called_with(
@@ -1056,17 +1085,27 @@ class TestInventoryModuleEnhancedQueryFeatures:
         )
 
         # Verify enhance_records_with_rel_groups was called
-        self.mock_enhance_records_with_rel_groups.assert_called_once_with(self.mock_records, [])
+        self.mock_enhance_records_with_rel_groups.assert_called_once_with(
+            self.mock_records, []
+        )
 
-    def test_populate_enhanced_records_with_default_query(self, inventory_plugin, mocker):
+    def test_populate_enhanced_records_with_default_query(
+        self, inventory_plugin, mocker
+    ):
         """Test __populate_enhanced_records_from_remote with no custom query (default REL_QUERY)"""
-        mocker.patch.object(inventory_plugin, "get_option", side_effect=self.setup_get_option_side_effect(
-            enhanced_additional_columns=["custom_col"],
-        ))
+        mocker.patch.object(
+            inventory_plugin,
+            "get_option",
+            side_effect=self.setup_get_option_side_effect(
+                enhanced_additional_columns=["custom_col"],
+            ),
+        )
         self.setup_mocks(mocker)
 
         # Call the method
-        inventory_plugin._InventoryModule__populate_enhanced_records_from_remote(self.mock_table_client, self.mock_records)
+        inventory_plugin._InventoryModule__populate_enhanced_records_from_remote(
+            self.mock_table_client, self.mock_records
+        )
 
         # Verify fetch_records was called with correct parameters
         expected_fields = REL_FIELDS.union({"custom_col"})
@@ -1077,24 +1116,39 @@ class TestInventoryModuleEnhancedQueryFeatures:
             is_encoded_query=False,
         )
 
-    def test_populate_enhanced_records_mutual_exclusivity_error(self, inventory_plugin, mocker):
+    def test_populate_enhanced_records_mutual_exclusivity_error(
+        self, inventory_plugin, mocker
+    ):
         """Test that enhanced_query and enhanced_sysparm_query are mutually exclusive"""
-        mocker.patch.object(inventory_plugin, "get_option", side_effect=self.setup_get_option_side_effect(
-            enhanced_query=[{"type.name": "STARTSWITH Contains"}],
-            enhanced_sysparm_query="type.nameSTARTSWITHContains",
-            enhanced_additional_columns=[],
-        ))
+        mocker.patch.object(
+            inventory_plugin,
+            "get_option",
+            side_effect=self.setup_get_option_side_effect(
+                enhanced_query=[{"type.name": "STARTSWITH Contains"}],
+                enhanced_sysparm_query="type.nameSTARTSWITHContains",
+                enhanced_additional_columns=[],
+            ),
+        )
         self.setup_mocks(mocker)
         # Verify that AnsibleParserError is raised
-        with pytest.raises(AnsibleParserError, match="Invalid configuration: 'enhanced_query' and 'enhanced_sysparm_query' are mutually exclusive"):
-            inventory_plugin._InventoryModule__populate_enhanced_records_from_remote(self.mock_table_client, self.mock_records)
+        with pytest.raises(
+            AnsibleParserError,
+            match="Invalid configuration: 'enhanced_query' and 'enhanced_sysparm_query' are mutually exclusive",
+        ):
+            inventory_plugin._InventoryModule__populate_enhanced_records_from_remote(
+                self.mock_table_client, self.mock_records
+            )
 
     def test_get_query_columns_with_enhanced(self, inventory_plugin, mocker):
         """Test __get_query_columns includes REL_FIELDS when enhanced is enabled"""
-        mocker.patch.object(inventory_plugin, "get_option", side_effect=self.setup_get_option_side_effect(
-            query_limit_columns=True,
-            query_additional_columns=["extra_col"],
-        ))
+        mocker.patch.object(
+            inventory_plugin,
+            "get_option",
+            side_effect=self.setup_get_option_side_effect(
+                query_limit_columns=True,
+                query_additional_columns=["extra_col"],
+            ),
+        )
 
         columns = ["name", "ip_address"]
         result = inventory_plugin._InventoryModule__get_query_columns(columns)
@@ -1105,9 +1159,13 @@ class TestInventoryModuleEnhancedQueryFeatures:
 
     def test_get_query_columns_no_limit(self, inventory_plugin, mocker):
         """Test __get_query_columns returns None when query_limit_columns is False"""
-        mocker.patch.object(inventory_plugin, "get_option", side_effect=self.setup_get_option_side_effect(
-            query_limit_columns=False,
-        ))
+        mocker.patch.object(
+            inventory_plugin,
+            "get_option",
+            side_effect=self.setup_get_option_side_effect(
+                query_limit_columns=False,
+            ),
+        )
 
         columns = ["name", "ip_address"]
         result = inventory_plugin._InventoryModule__get_query_columns(columns)

--- a/tests/unit/plugins/inventory/test_now.py
+++ b/tests/unit/plugins/inventory/test_now.py
@@ -15,6 +15,8 @@ from ansible.inventory.data import InventoryData
 from ansible.module_utils.common.text.converters import to_text
 from ansible.template import Templar
 from ansible_collections.servicenow.itsm.plugins.inventory import now
+from ansible_collections.servicenow.itsm.plugins.module_utils.relations import REL_FIELDS, REL_TABLE, REL_QUERY
+
 
 try:
     # post 2.19 is strict about jinja template safety. This means test inputs
@@ -985,3 +987,129 @@ class TestConstructCacheSuffix:
         suffix = inventory_plugin._construct_cache_suffix()
 
         assert suffix == ""
+
+
+class TestInventoryModuleEnhancedQueryFeatures:
+    def setup_get_option_side_effect(self, **options):
+        def get_option(option_name):
+            if option_name == "enhanced":
+                return options.get("enhanced", True)
+            return options.get(option_name, None)
+        return get_option
+
+    def setup_mocks(self, mocker):
+        self.mock_fetch_records = mocker.patch('ansible_collections.servicenow.itsm.plugins.inventory.now.fetch_records')
+        self.mock_fetch_records.return_value = []
+
+        self.mock_enhance_records_with_rel_groups = mocker.patch('ansible_collections.servicenow.itsm.plugins.inventory.now.enhance_records_with_rel_groups')
+
+        self.mock_table_client = mocker.Mock()
+        self.mock_records = []
+
+    def assert_fetch_records_called_with(self, query, expected_fields, is_encoded_query):
+        self.mock_fetch_records.assert_called_once_with(
+            self.mock_table_client,
+            REL_TABLE,
+            query=query,
+            fields=expected_fields,
+            is_encoded_query=is_encoded_query
+        )
+
+    def test_populate_enhanced_records_with_enhanced_query(self, inventory_plugin, mocker):
+        """Test __populate_enhanced_records_from_remote with enhanced_query option"""
+        mocker.patch.object(inventory_plugin, "get_option", side_effect=self.setup_get_option_side_effect(
+            enhanced_query=[{"type.name": "Contains:Contained By"}],
+            enhanced_additional_columns=["extra_col1", "extra_col2"],
+        ))
+        self.setup_mocks(mocker)
+
+        # Test the method
+        inventory_plugin._InventoryModule__populate_enhanced_records_from_remote(self.mock_table_client, self.mock_records)
+        expected_fields = REL_FIELDS.union({"extra_col1", "extra_col2"})
+
+        self.assert_fetch_records_called_with(
+            query=[{"type.name": "Contains:Contained By"}],
+            expected_fields=expected_fields,
+            is_encoded_query=False,
+        )
+
+        # Verify enhance_records_with_rel_groups was called
+        self.mock_enhance_records_with_rel_groups.assert_called_once_with(self.mock_records, [])
+
+    def test_populate_enhanced_records_with_enhanced_sysparm_query(self, inventory_plugin, mocker):
+        """Test __populate_enhanced_records_from_remote with enhanced_sysparm_query option"""
+
+        mocker.patch.object(inventory_plugin, "get_option", side_effect=self.setup_get_option_side_effect(
+            enhanced_sysparm_query="type.nameSTARTSWITHContains",
+            enhanced_additional_columns=[],
+        ))
+        self.setup_mocks(mocker)
+
+        # Call the method
+        inventory_plugin._InventoryModule__populate_enhanced_records_from_remote(self.mock_table_client, self.mock_records)
+
+        # Verify fetch_records was called with correct parameters
+        self.assert_fetch_records_called_with(
+            query="type.nameSTARTSWITHContains",
+            expected_fields=REL_FIELDS,
+            is_encoded_query=True,
+        )
+
+        # Verify enhance_records_with_rel_groups was called
+        self.mock_enhance_records_with_rel_groups.assert_called_once_with(self.mock_records, [])
+
+    def test_populate_enhanced_records_with_default_query(self, inventory_plugin, mocker):
+        """Test __populate_enhanced_records_from_remote with no custom query (default REL_QUERY)"""
+        mocker.patch.object(inventory_plugin, "get_option", side_effect=self.setup_get_option_side_effect(
+            enhanced_additional_columns=["custom_col"],
+        ))
+        self.setup_mocks(mocker)
+
+        # Call the method
+        inventory_plugin._InventoryModule__populate_enhanced_records_from_remote(self.mock_table_client, self.mock_records)
+
+        # Verify fetch_records was called with correct parameters
+        expected_fields = REL_FIELDS.union({"custom_col"})
+
+        self.assert_fetch_records_called_with(
+            query=REL_QUERY,
+            expected_fields=expected_fields,
+            is_encoded_query=False,
+        )
+
+    def test_populate_enhanced_records_mutual_exclusivity_error(self, inventory_plugin, mocker):
+        """Test that enhanced_query and enhanced_sysparm_query are mutually exclusive"""
+        mocker.patch.object(inventory_plugin, "get_option", side_effect=self.setup_get_option_side_effect(
+            enhanced_query=[{"type.name": "STARTSWITH Contains"}],
+            enhanced_sysparm_query="type.nameSTARTSWITHContains",
+            enhanced_additional_columns=[],
+        ))
+        self.setup_mocks(mocker)
+        # Verify that AnsibleParserError is raised
+        with pytest.raises(AnsibleParserError, match="Invalid configuration: 'enhanced_query' and 'enhanced_sysparm_query' are mutually exclusive"):
+            inventory_plugin._InventoryModule__populate_enhanced_records_from_remote(self.mock_table_client, self.mock_records)
+
+    def test_get_query_columns_with_enhanced(self, inventory_plugin, mocker):
+        """Test __get_query_columns includes REL_FIELDS when enhanced is enabled"""
+        mocker.patch.object(inventory_plugin, "get_option", side_effect=self.setup_get_option_side_effect(
+            query_limit_columns=True,
+            query_additional_columns=["extra_col"],
+        ))
+
+        columns = ["name", "ip_address"]
+        result = inventory_plugin._InventoryModule__get_query_columns(columns)
+
+        expected_columns = set(["name", "ip_address", "extra_col"]).union(REL_FIELDS)
+
+        assert set(result) == expected_columns
+
+    def test_get_query_columns_no_limit(self, inventory_plugin, mocker):
+        """Test __get_query_columns returns None when query_limit_columns is False"""
+        mocker.patch.object(inventory_plugin, "get_option", side_effect=self.setup_get_option_side_effect(
+            query_limit_columns=False,
+        ))
+
+        columns = ["name", "ip_address"]
+        result = inventory_plugin._InventoryModule__get_query_columns(columns)
+
+        assert result is None


### PR DESCRIPTION
##### SUMMARY
This change allows users to modify how the `enhanced` option impacts the inventory plugin. It adds three new options:

`enhanced_additional_columns` - Include additional columns/attributes when querying the relationship table
`enhanced_query` - Specify a query that can be used to limit the relationships returned when `enhanced` is true
`enhanced_sysparm_query` - Same as `enhanced_query` but different format

Fixes https://github.com/ansible-collections/servicenow.itsm/issues/436

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/inventory/now
