### PR TITLE
add option to tune relationship batches in inven

### DIFF
--- a/changelogs/fragments/489-add-enhanced-query-limit.yml
+++ b/changelogs/fragments/489-add-enhanced-query-limit.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - now - added enhanced_sysparm_limit option to now inventory plugin, allowing control of the maximum number of relationship
+    records returned in a single query when using enhanced.

--- a/tests/integration/targets/inventory/templates/enhanced.now.yml
+++ b/tests/integration/targets/inventory/templates/enhanced.now.yml
@@ -17,3 +17,4 @@ instance:
 
 enhanced: true
 enhanced_sysparm_query: type.nameSTARTSWITHContains
+enhanced_sysparm_limit: 5


### PR DESCRIPTION
##### SUMMARY
Adding an option to control the batch size of relationship queries, separate from other queries. This allows users to fine tune the relationship query performance without impacting the other inventory queries. 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
now
