### PR TITLE
Update testing matrix to add 2.19 and remove milestone

### DIFF
--- a/.github/workflows/integration_source.yml
+++ b/.github/workflows/integration_source.yml
@@ -12,9 +12,8 @@ on:
         # 2.16 supports Python 3.10-3.12
         # 2.17 supports Python 3.10-3.12
         # 2.18 supports Python 3.11-3.13
-        # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_17.html
-        # milestone is 2.17 until after 2.17 branches from devel
-        # devel is 2.17 until 2024-04-01
+        # 2.19 supports Python 3.11-3.13
+        # devel will be 2.20
         default: >-
           [
             {
@@ -50,11 +49,11 @@ on:
               "python-version": "3.10"
             },
             {
-              "ansible-version": "milestone",
+              "ansible-version": "stable-2.19",
               "python-version": "3.9"
             },
             {
-              "ansible-version": "milestone",
+              "ansible-version": "stable-2.19",
               "python-version": "3.10"
             },
             {
@@ -84,7 +83,7 @@ jobs:
           - stable-2.16
           - stable-2.17
           - stable-2.18
-          - milestone
+          - stable-2.19
           - devel
         python-version:
           - "3.9"

--- a/changelogs/fragments/20250728-milestone.yml
+++ b/changelogs/fragments/20250728-milestone.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - workflows - Removed milestone, added stable-2.19 to testing matrix. Milestone and devel are close anyway


### PR DESCRIPTION
##### SUMMARY
Trivial change to swap out milestone in integration tests and add stable-2.19 in its place

##### ISSUE TYPE
- Trivial test changes
- 
##### COMPONENT NAME
Github Workflows