### PR TITLE
Issue #502 fix. Prevent missed events

### DIFF
--- a/changelogs/fragments/eda-records-fix.yml
+++ b/changelogs/fragments/eda-records-fix.yml
@@ -1,5 +1,5 @@
 ---
 bugfixes:
-  - records - Prevent missed events between polls by avoiding future 'since' timestamps; advance the 'since' timestamp (cursor) to the latest seen value at second precision (monotonic). (issue #<issue_number>)
+  - records - Prevent missed events between polls by avoiding future 'since' timestamps; advance the 'since' timestamp (cursor) to the latest seen value at second precision (monotonic). (issue #502)
 
 

--- a/changelogs/fragments/eda-records-fix.yml
+++ b/changelogs/fragments/eda-records-fix.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - records - Prevent missed events between polls by avoiding future 'since' timestamps; advance the 'since' timestamp (cursor) to the latest seen value at second precision (monotonic). (issue #<issue_number>)
+
+

--- a/extensions/eda/plugins/event_source/records.py
+++ b/extensions/eda/plugins/event_source/records.py
@@ -2,7 +2,6 @@
 #
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-
 DOCUMENTATION = r"""
 module: records
 short_description: Event Driven Ansible source for ServiceNow records.
@@ -95,7 +94,7 @@ class RecordsSource:
 
         self.snow_client = client.Client(**self.instance_config)
         self.table_client = table.TableClient(self.snow_client)
-        self.previously_reported_records = dict()
+        self.previously_reported_records: Dict[str, str] = dict()
 
     def format_list_query(self, args):
         if args.get("sysparm_query"):
@@ -118,31 +117,60 @@ class RecordsSource:
             await asyncio.sleep(self.interval)
 
     async def _poll_for_records(self):
-        next_polling_time = datetime.datetime.now() + datetime.timedelta(
-            seconds=self.interval
-        )
-        reported_records = dict()
+        # Mark the start of this poll. We'll advance the since timestamp (cursor)
+        # at the end to a safe value: max(poll_start_floor, newest_seen_this_poll).
+        poll_start = datetime.datetime.now()
+        poll_start_floor = poll_start.replace(microsecond=0)
+
+        reported_records: Dict[str, str] = dict()
+        newest_seen = self.updated_since  # start from current since timestamp (cursor)
+
         logger.info(
             "Polling for new records in %s since %s",
             self.table_name,
             self.updated_since,
         )
+
         for record in self.table_client.list_records(self.table_name, self.list_query):
             await self.process_record(record, reported_records)
+            # Track the newest timestamp actually observed this cycle
+            try:
+                ts = self.parse_string_to_datetime(record["sys_updated_on"])
+                if ts > newest_seen:
+                    newest_seen = ts
+            except Exception:
+                # If a record has an unexpected timestamp format, ignore it for advancing the since timestamp
+                pass
 
         self.previously_reported_records = reported_records
-        self.updated_since = next_polling_time
+
+        # Compute next 'since' timestamp (lower bound/cursor for next poll):
+        # - never in the future
+        # - aligned to seconds
+        # - monotonically non-decreasing
+        next_since = max(newest_seen, poll_start_floor)
+        if next_since > self.updated_since:
+            logger.debug(
+                "Advancing since timestamp: %s -> %s", self.updated_since, next_since
+            )
+            self.updated_since = next_since
+        else:
+            logger.debug(
+                "Since timestamp unchanged (next_since=%s <= updated_since=%s)",
+                next_since,
+                self.updated_since,
+            )
 
     async def process_record(self, record, reported_records):
+        # Ignore anything strictly older than our since timestamp.
         if self.parse_string_to_datetime(record["sys_updated_on"]) < self.updated_since:
             return
 
         if self.has_record_been_reported(record):
-            # We already reported this record during the last polling interval, so we can skip it.
+            # Already reported in the immediately previous cycle.
             return
         else:
-            # We havent reported this record yet, so we need to store it in the reported_records dict
-            # and send it to the queue.
+            # Not reported yet: remember it for this cycle and emit.
             reported_records[record["sys_id"]] = record["sys_updated_on"]
             await self.queue.put(record)
 
@@ -158,9 +186,11 @@ class RecordsSource:
     def parse_string_to_datetime(self, date_string: str = None):
         format_string = "%Y-%m-%d %H:%M:%S"
         if date_string is None:
-            return datetime.datetime.now()
+            # Truncate to whole seconds to match ServiceNow precision
+            return datetime.datetime.now().replace(microsecond=0)
 
         try:
+            # ServiceNow returns second-precision strings (no microseconds)
             return datetime.datetime.strptime(date_string, format_string)
         except ValueError:
             raise ValueError("Invalid date string: %s" % date_string)


### PR DESCRIPTION
##### SUMMARY
Prevent missed events by changing how the source advances its **since** timestamp between polls.

**What changed**
- Stop setting the next **since** to a future time (`now + interval`) at the end of a poll.
- Instead, set it to the **start time of the poll**, truncated to whole seconds, and never move it beyond the **newest `sys_updated_on`** observed during that poll:
  - `poll_start_floor = poll_start.replace(microsecond=0)`
  - `next_since = max(poll_start_floor, newest_seen_this_poll)`
- When `updated_since` is not provided, initialize it at **second precision** (`datetime.now().replace(microsecond=0)`).

**Why**
- ServiceNow timestamps are **second-precision**. Comparing them to microsecond-precision host times can drop boundary rows.
- Advancing **since** into the future creates a blind spot: records created after the last fetch but before that future time are skipped.
- Using the poll start (second precision) and clamping by the newest record seen keeps **since** monotonic, never in the future, and aligned with ServiceNow’s precision.

Fixes #502

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`servicenow.itsm.records` (EDA event source) — `extensions/eda/plugins/event_source/records.py`

##### ADDITIONAL INFORMATION
**Design notes**
- **since** is updated at the end of each poll to `max(poll_start_floor, newest_seen_this_poll)`.
- Per-poll de-duplication remains unchanged.
- No new configuration parameters.

**Before (problem)**
- **since** set to `now + interval` at poll end means blind spot between fetch and that future time.
- First run used microsecond precision, which can miss rows that share the same second as startup.

**After (this change)**
- **since** set to poll start (second precision), never beyond the newest record seen.
- No future **since** values; comparison happens at second precision end-to-end.

**Evidence (event captured after change)**
```text
2025-09-10 10:15:28,637 - ansible_rulebook.rule_generator - DEBUG - callback calling Output ServiceNow Information
2025-09-10 10:15:28,637 - ansible_rulebook.rule_set_runner - DEBUG - None
2025-09-10 10:15:28,637 - ansible_rulebook.rule_set_runner - DEBUG - Creating action task action::debug::Respond to ServiceNow catalog request items::Output ServiceNow Information
2025-09-10 10:15:28,638 - ansible_rulebook.rule_set_runner - DEBUG - call_action debug

** 2025-09-10 10:15:28.638548 [debug] ******************************************
event: {'number': 'REQ0010033', 'sys_created_on': '2025-09-10 10:15:19', 'sys_updated_on': '2025-09-10 10:15:19', 'sys_id': '88ff80d7533fa210a33138f0a0490e0c', ...}
********************************************************************************
2025-09-10 10:15:38,584 - <run_path> - INFO - Polling for new records in sc_request since 2025-09-10 10:15:27
2025-09-10 10:15:39,512 - <run_path> - DEBUG - Advancing since timestamp: 2025-09-10 10:15:27 -> 2025-09-10 10:15:38
2025-09-10 10:15:39,512 - <run_path> - INFO - Sleeping for 10 seconds
```

```paste below
# BEFORE (illustrative)
INFO - Polling for new records in sc_request since 2025-09-10 09:43:17
INFO - Sleeping for 10 seconds
INFO - Polling for new records in sc_request since 2025-09-10 09:43:28
# A record created at 09:43:19 was never emitted.

# AFTER (this PR)
INFO  - Polling for new records in sc_request since 2025-09-10 10:15:27
DEBUG - Advancing since timestamp: 2025-09-10 10:15:27 -> 2025-09-10 10:15:38
# Record created during previous sleep window emitted on the next poll.
```