### PR TITLE
add extensions meta for eda docs

### DIFF
--- a/changelogs/fragments/504-add-extensions-meta.yml
+++ b/changelogs/fragments/504-add-extensions-meta.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - eda/plugins/event_source/records - Add meta file so EDA plugin docs will be parsed by Galaxy
+    (fixes https://github.com/ansible-collections/servicenow.itsm/issues/498)

--- a/meta/extensions.yml
+++ b/meta/extensions.yml
@@ -1,0 +1,4 @@
+---
+extensions:
+  - args:
+      ext_dir: eda/plugins/event_source


### PR DESCRIPTION
##### SUMMARY
Adds a file in meta/ so eda plugins will be parsed and show up in Galaxy

Fixes https://github.com/ansible-collections/servicenow.itsm/issues/498

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
EDA

##### ADDITIONAL INFORMATION
Reference: https://github.com/ansible/event-driven-ansible/blob/main/meta/extensions.yml