### PR TITLE
fix unit test CI: update collection_base_dir to match upstream actions

### DIFF
--- a/.github/workflows/unit_source.yml
+++ b/.github/workflows/unit_source.yml
@@ -81,7 +81,7 @@ jobs:
     env:
       PY_COLORS: "1"
       source_directory: "./source"
-      collection_base_dir: "/home/runner/collections"
+      collection_base_dir: "/home/runner/.ansible/collections"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
#### SUMMARY
- The upstream `ansible-network/github_actions` shared actions changed the collection install path from `/home/runner/collections` to `/home/runner/.ansible/collections` in [ansible-network/github_actions#190](https://github.com/ansible-network/github_actions/commit/446d4586bcde8bf6e1a9c085983bf172b59bd7b2).
- This broke all unit test CI runs because `PYTHONPATH` still pointed to the old path, causing `ModuleNotFoundError: No module named 'ansible_collections'` during test collection.
- Updates `collection_base_dir` in `unit_source.yml` to match the new install location.

#### ISSUE TYPE
- Bug Fix Pull Request

#### COMPONENT NAME
- .github/workflows/unit_source.yml

#### ADDITIONAL INFORMATION
- This is a one-line change: `/home/runner/collections` -> `/home/runner/.ansible/collections`.
- Affects all branches and all Python/Ansible version matrix combinations.
- Nightly and PR CI runs are broken until this is merged.