### PR TITLE
Fix(modules): column name formatting in run function

### DIFF
--- a/changelogs/fragments/537-add-option-to-preserve-column-names.yml
+++ b/changelogs/fragments/537-add-option-to-preserve-column-names.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - api_info - Added option to preserve column names in the response.
+    - This is a legacy behavior. If your column names are not lowercase, set this to false to
+    preserve the original case in the response.

--- a/plugins/modules/api_info.py
+++ b/plugins/modules/api_info.py
@@ -231,7 +231,7 @@ from ..module_utils.api import (
 
 def run(module, client):
     search_dict = dict(module.params)
-    columns = ",".join([field.lower() for field in module.params[FIELD_COLUMNS_NAME]])
+    columns = ",".join(module.params[FIELD_COLUMNS_NAME])
     search_dict.update(columns=columns)
     query = utils.filter_dict(search_dict, *POSSIBLE_FILTER_PARAMETERS)
     servicenow_query = transform_query_to_servicenow_query(query)

--- a/plugins/modules/api_info.py
+++ b/plugins/modules/api_info.py
@@ -239,9 +239,11 @@ from ..module_utils.api import (
 def run(module, client):
     search_dict = dict(module.params)
     if module.params["normalize_column_names"]:
-        columns = ','.join([field.lower() for field in module.params[FIELD_COLUMNS_NAME]])
+        columns = ",".join(
+            [field.lower() for field in module.params[FIELD_COLUMNS_NAME]]
+        )
     else:
-        columns = ','.join(module.params[FIELD_COLUMNS_NAME])
+        columns = ",".join(module.params[FIELD_COLUMNS_NAME])
     search_dict.update(columns=columns)
     query = utils.filter_dict(search_dict, *POSSIBLE_FILTER_PARAMETERS)
     servicenow_query = transform_query_to_servicenow_query(query)

--- a/plugins/modules/api_info.py
+++ b/plugins/modules/api_info.py
@@ -239,9 +239,9 @@ from ..module_utils.api import (
 def run(module, client):
     search_dict = dict(module.params)
     if module.params["normalize_column_names"]:
-        columns = [field.lower() for field in module.params[FIELD_COLUMNS_NAME]]
+        columns = ','.join([field.lower() for field in module.params[FIELD_COLUMNS_NAME]])
     else:
-        columns = module.params[FIELD_COLUMNS_NAME]
+        columns = ','.join(module.params[FIELD_COLUMNS_NAME])
     search_dict.update(columns=columns)
     query = utils.filter_dict(search_dict, *POSSIBLE_FILTER_PARAMETERS)
     servicenow_query = transform_query_to_servicenow_query(query)

--- a/plugins/modules/api_info.py
+++ b/plugins/modules/api_info.py
@@ -65,6 +65,13 @@ options:
     type: list
     elements: str
     default: []
+  normalize_column_names:
+    description:
+      - If true, the column names in O(columns) will be normalized to lowercase.
+      - This is a legacy behavior. If your column names are not lowercase, set this to false to
+        preserve the original case in the response.
+    type: bool
+    default: True
   query_category:
     description:
       - Name of the query category to use for queries.
@@ -231,7 +238,10 @@ from ..module_utils.api import (
 
 def run(module, client):
     search_dict = dict(module.params)
-    columns = ",".join(module.params[FIELD_COLUMNS_NAME])
+    if module.params["normalize_column_names"]:
+        columns = [field.lower() for field in module.params[FIELD_COLUMNS_NAME]]
+    else:
+        columns = module.params[FIELD_COLUMNS_NAME]
     search_dict.update(columns=columns)
     query = utils.filter_dict(search_dict, *POSSIBLE_FILTER_PARAMETERS)
     servicenow_query = transform_query_to_servicenow_query(query)
@@ -257,6 +267,10 @@ def main():
         columns=dict(
             type="list", default=[], elements="str"
         ),  # A comma-separated list of fields to return in the response
+        normalize_column_names=dict(
+            type="bool",
+            default=True,
+        ),  # If true, the column names in O(columns) will be normalized to lowercase.
         query_category=dict(
             type="str"
         ),  # Name of the query category (read replica category) to use for queries

--- a/tests/unit/plugins/modules/test_api_info.py
+++ b/tests/unit/plugins/modules/test_api_info.py
@@ -44,6 +44,7 @@ class TestMain:
             display_value="false",
             exclude_reference_link="false",
             columns=["parent", "watch_list"],
+            normalize_column_names="true",
             query_category="cat",
             query_no_domain="true",
             no_count="true",
@@ -69,6 +70,7 @@ class TestRun:
             ),
             resource="sys_user",
             columns=["upon_reject", "state", "cmdb_ci"],
+            normalize_column_names="true",
         )
 
         module = create_module(params=params)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Column names passed to sysparm_fields were forced to lowercase, breaking case-sensitive catalog variables (e.g. variables.AwsEnv). Standard SNOW field names are already lowercase so this has no impact.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`api_info`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This fixes a bug where when you wanted to fetch catalog variables containing uppercase characters, the api_info module would not return the field. This was working when the variables were gathered through a GET request to the api.
<!--- Paste verbatim command output below, e.g. before and after your change -->

