### PR TITLE
prepare 2.14.0 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,13 +4,34 @@ servicenow.itsm Release Notes
 
 .. contents:: Topics
 
+v2.14.0
+=======
+
+Release Summary
+---------------
+
+Add TinyURL fallback for long GET requests, OAuth token auto-refresh for EDA rulebook activations, and an HTTP retry mechanism to the client. The inventory plugin gains a ``lowercase_hostname`` option, ``api_key`` authentication support, and verbose debug logging.
+
+Minor Changes
+-------------
+
+- client - Automatically use ServiceNow TinyURL API (``api/now/tinyurl``) when a GET request URL exceeds 2048 characters. This allows modules like ``api_info`` to handle complex queries with many SysIDs without hitting ``414 URI Too Long`` errors. TinyURL support must be enabled on the ServiceNow instance (https://www.servicenow.com/docs/r/platform-user-interface/t_EnableTinyURLSupport.html).
+- now - Add ``display.vvv`` debug logging to the inventory plugin. When running with ``-vvv``, logs the request URL, API response latency, response parse time, and per-batch pagination progress to help diagnose slow inventory syncs.
+- now - Add ``lowercase_hostname`` option to the inventory plugin to convert hostnames to lowercase for consistent naming across mixed-case ServiceNow records.
+- now - return nothing in add_host when record is an empty data type or of NoneType
+
+Bugfixes
+--------
+
+- plugins/inventory/now - Add support for api_key authentication in the inventory plugin. Fixes https://github.com/ansible-collections/servicenow.itsm/issues/527
+
 v2.13.2
 =======
 
 Release Summary
 ---------------
 
-Allow ServiceNow timezone to be passed via parameter (remote_servicenow_timezone) to the plugin. Clarify error message to indicate that it must be set explicitly (either as a user setting or as the system default) in ServiceNow if not passed in via parameter.
+Allow ServiceNow timezone to be passed via parameter (remote_servicenow_timezone) to the plugin. Clarify error message to indicate that it must be set explicitly (that is, not to the system default) in the ServiceNow user record if not passed in via parameter.
 
 Bugfixes
 --------

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -408,6 +408,36 @@ releases:
     - 517-fix-timezone-lookup.yml
     - release_summary.yml
     release_date: '2025-11-11'
+  2.14.0:
+    changes:
+      bugfixes:
+      - plugins/inventory/now - Add support for api_key authentication in the inventory
+        plugin. Fixes https://github.com/ansible-collections/servicenow.itsm/issues/527
+      minor_changes:
+      - client - Automatically use ServiceNow TinyURL API (``api/now/tinyurl``) when
+        a GET request URL exceeds 2048 characters. This allows modules like ``api_info``
+        to handle complex queries with many SysIDs without hitting ``414 URI Too Long``
+        errors. TinyURL support must be enabled on the ServiceNow instance (https://www.servicenow.com/docs/r/platform-user-interface/t_EnableTinyURLSupport.html).
+      - now - Add ``display.vvv`` debug logging to the inventory plugin. When running
+        with ``-vvv``, logs the request URL, API response latency, response parse
+        time, and per-batch pagination progress to help diagnose slow inventory syncs.
+      - now - Add ``lowercase_hostname`` option to the inventory plugin to convert
+        hostnames to lowercase for consistent naming across mixed-case ServiceNow
+        records.
+      - now - return nothing in add_host when record is an empty data type or of NoneType
+      release_summary: Add TinyURL fallback for long GET requests, OAuth token auto-refresh
+        for EDA rulebook activations, and an HTTP retry mechanism to the client. The
+        inventory plugin gains a ``lowercase_hostname`` option, ``api_key`` authentication
+        support, and verbose debug logging.
+    fragments:
+    - 01182026-inven.yml
+    - 03222026-tinyurl-fallback.yml
+    - 03252026-inventory-debug-logging.yml
+    - 03252026-lowercase-hostname-inventory.yml
+    - 12022025-fix-depends-on-docs.yml
+    - 521_return_none_on_empty_record.yml
+    - release_summary.yml
+    release_date: '2026-04-13'
   2.2.0:
     changes:
       minor_changes:

--- a/changelogs/fragments/01182026-inven.yml
+++ b/changelogs/fragments/01182026-inven.yml
@@ -1,4 +1,0 @@
----
-bugfixes:
-  - plugins/inventory/now - Add support for api_key authentication in the inventory plugin.
-    Fixes https://github.com/ansible-collections/servicenow.itsm/issues/527

--- a/changelogs/fragments/03222026-tinyurl-fallback.yml
+++ b/changelogs/fragments/03222026-tinyurl-fallback.yml
@@ -1,8 +1,0 @@
----
-minor_changes:
-  - client - Automatically use ServiceNow TinyURL API (``api/now/tinyurl``) when
-    a GET request URL exceeds 2048 characters. This allows modules like
-    ``api_info`` to handle complex queries with many SysIDs without hitting
-    ``414 URI Too Long`` errors. TinyURL support must be enabled on the
-    ServiceNow instance
-    (https://www.servicenow.com/docs/r/platform-user-interface/t_EnableTinyURLSupport.html).

--- a/changelogs/fragments/03252026-inventory-debug-logging.yml
+++ b/changelogs/fragments/03252026-inventory-debug-logging.yml
@@ -1,6 +1,0 @@
----
-minor_changes:
-  - now - Add ``display.vvv`` debug logging to the inventory plugin. When
-    running with ``-vvv``, logs the request URL, API response latency, response
-    parse time, and per-batch pagination progress to help diagnose slow
-    inventory syncs.

--- a/changelogs/fragments/03252026-lowercase-hostname-inventory.yml
+++ b/changelogs/fragments/03252026-lowercase-hostname-inventory.yml
@@ -1,4 +1,0 @@
----
-minor_changes:
-  - now - Add ``lowercase_hostname`` option to the inventory plugin to convert
-    hostnames to lowercase for consistent naming across mixed-case ServiceNow records.

--- a/changelogs/fragments/12022025-fix-depends-on-docs.yml
+++ b/changelogs/fragments/12022025-fix-depends-on-docs.yml
@@ -1,4 +1,0 @@
----
-trivial:
-  - configuration_item_relations - Change 'Depends_On' in examples to 'Depends on::Used by'
-    Fixes https://github.com/ansible-collections/servicenow.itsm/issues/519

--- a/changelogs/fragments/521_return_none_on_empty_record.yml
+++ b/changelogs/fragments/521_return_none_on_empty_record.yml
@@ -1,4 +1,0 @@
----
-
-minor_changes:
-  - now - return nothing in add_host when record is an empty data type or of NoneType

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: servicenow
 name: itsm
-version: 2.13.2
+version: 2.14.0
 readme: README.md
 authors:
   - Cosmin Tupangiu <ctupangi@redhat.com>

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -17,8 +17,13 @@ repository: https://github.com/ansible-collections/servicenow.itsm
 homepage: https://github.com/ansible-collections/servicenow.itsm
 issues: https://github.com/ansible-collections/servicenow.itsm/issues
 build_ignore:
+  - .ansible
+  - .claude
+  - .cursor
   - .gitignore
+  - .vscode
   - changelogs/.plugin-cache.yaml
   - tests/integration/targets/*/test_session
   - tests/integration/targets/*/roles
   - tests/integration/integration_config.yml
+  - .pytest_cache


### PR DESCRIPTION
#### SUMMARY
- Prepare the 2.14.0 release: bump version in galaxy.yml, generate CHANGELOG.rst and changelogs/changelog.yaml via antsibull-changelog, and consume all pending changelog fragments.
- Key changes in this release: TinyURL fallback for long GET requests, OAuth token auto-refresh for EDA rulebook activations, HTTP retry mechanism, and inventory plugin improvements (lowercase_hostname option, api_key authentication, verbose debug logging).

#### ISSUE TYPE
- New Release Pull Request

#### COMPONENT NAME
- galaxy.yml
- CHANGELOG.rst
- changelogs/changelog.yaml
- changelogs/fragments/ (consumed)

#### ADDITIONAL INFORMATION
- Version bumped from 2.13.2 to 2.14.0 (minor release — new backward-compatible features, no breaking changes).
- All existing changelog fragments have been consumed and removed.