### PR TITLE
add stable-2.20 and stable-2.21 to CI workflows

### DIFF
--- a/.github/workflows/integration_source.yml
+++ b/.github/workflows/integration_source.yml
@@ -13,7 +13,9 @@ on:
         # 2.17 supports Python 3.10-3.12
         # 2.18 supports Python 3.11-3.13
         # 2.19 supports Python 3.11-3.13
-        # devel will be 2.20
+        # 2.20 supports Python 3.12-3.14
+        # 2.21 supports Python 3.12-3.14
+        # devel will be 2.22
         default: >-
           [
             {
@@ -49,6 +51,30 @@ on:
               "python-version": "3.10"
             },
             {
+              "ansible-version": "stable-2.20",
+              "python-version": "3.9"
+            },
+            {
+              "ansible-version": "stable-2.20",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "stable-2.20",
+              "python-version": "3.11"
+            },
+            {
+              "ansible-version": "stable-2.21",
+              "python-version": "3.9"
+            },
+            {
+              "ansible-version": "stable-2.21",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "stable-2.21",
+              "python-version": "3.11"
+            },
+            {
               "ansible-version": "devel",
               "python-version": "3.9"
             },
@@ -80,6 +106,8 @@ jobs:
           - stable-2.16
           - stable-2.18
           - stable-2.19
+          - stable-2.20
+          - stable-2.21
           - devel
         python-version:
           - "3.9"

--- a/.github/workflows/unit_source.yml
+++ b/.github/workflows/unit_source.yml
@@ -13,7 +13,9 @@ on:
         # 2.17 supports Python 3.10-3.12
         # 2.18 supports Python 3.11-3.13
         # 2.19 supports Python 3.11-3.13
-        # This structure assumes milestone and devel are 2.19 to-be
+        # 2.20 supports Python 3.12-3.14
+        # 2.21 supports Python 3.12-3.14
+        # This structure assumes milestone and devel are 2.22 to-be
         default: >-
           [
             {
@@ -47,6 +49,30 @@ on:
             {
               "ansible-version": "stable-2.19",
               "python-version": "3.10"
+            },
+            {
+              "ansible-version": "stable-2.20",
+              "python-version": "3.9"
+            },
+            {
+              "ansible-version": "stable-2.20",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "stable-2.20",
+              "python-version": "3.11"
+            },
+            {
+              "ansible-version": "stable-2.21",
+              "python-version": "3.9"
+            },
+            {
+              "ansible-version": "stable-2.21",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "stable-2.21",
+              "python-version": "3.11"
             },
             {
               "ansible-version": "milestone",
@@ -91,6 +117,8 @@ jobs:
           - stable-2.16
           - stable-2.18
           - stable-2.19
+          - stable-2.20
+          - stable-2.21
           - milestone
           - devel
         python-version:

--- a/changelogs/fragments/add-stable-2.20-2.21-ci.yml
+++ b/changelogs/fragments/add-stable-2.20-2.21-ci.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - CI - Add ansible-core stable-2.20 and stable-2.21 to integration and unit test matrices.


### PR DESCRIPTION
#### SUMMARY
- Add ansible-core stable-2.20 and stable-2.21 to the CI test matrices for both integration and unit tests.
- Update devel comments to reference the upcoming 2.22 release.

#### ISSUE TYPE
- Feature Pull Request

#### COMPONENT NAME
- .github/workflows/integration_source.yml
- .github/workflows/unit_source.yml

#### ADDITIONAL INFORMATION
- ansible-core 2.20 (GA Nov 2025) and 2.21 (GA May 2026) both support Python 3.12-3.14 on the control node.
- Python 3.14 is not yet in the CI matrix; adding it is out of scope for this PR.
- No functional test or module changes; CI-only update.