### PR TITLE
Fix documented return key

### DIFF
--- a/plugins/modules/api_info.py
+++ b/plugins/modules/api_info.py
@@ -121,7 +121,7 @@ EXAMPLES = """
 """
 
 RETURN = r"""
-records:
+record:
   description:
     - A list of records from the specified table.
   returned: success

--- a/plugins/modules/configuration_item_info.py
+++ b/plugins/modules/configuration_item_info.py
@@ -116,7 +116,7 @@ EXAMPLES = r"""
 """
 
 RETURN = r"""
-record:
+records:
   description:
     - A list of configuration item records.
     - Note that the fields of the returned records depend on the configuration


### PR DESCRIPTION
##### SUMMARY

Correct documented return values for `api_info` and `configuration_item_info`.

Two modules had return documentation that did not match their actual runtime output:

- `servicenow.itsm.api_info` documents `records`, but the module returns `record`.
- `servicenow.itsm.configuration_item_info` documents `record`, but the module returns `records`.

This change updates the module return documentation to match the existing code behavior.

No runtime behavior is changed. This keeps compatibility with existing playbooks and aligns the docs with the keys already used by the integration tests.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

api_info
configuration_item_info

##### ADDITIONAL INFORMATION

Current runtime behavior:

```yaml
servicenow.itsm.api_info:
  resource: incident
register: api_result

# actual key:
api_result.record
```

```yaml
servicenow.itsm.configuration_item_info:
  sys_class_name: cmdb_ci_server
register: ci_result

# actual key:
ci_result.records
```

Before this change, the docs described the opposite keys for both modules:

```yaml
# api_info docs
records:
  description:
    - A list of records from the specified table.

# configuration_item_info docs
record:
  description:
    - A list of configuration item records.
```

After this change, the documented return values match the module output:

```yaml
# api_info
record:
  description:
    - A list of records from the specified table.

# configuration_item_info
records:
  description:
    - A list of configuration item records.
```

The existing integration tests also reflect this behavior:
- `api_info` assertions use `result.record`
- `configuration_item_info` assertions use `result.records`
