### PR TITLE
add Australia release support and drop Xanadu

### DIFF
--- a/.agents/skills/update-snow-release/SKILL.md
+++ b/.agents/skills/update-snow-release/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: update-snow-release
+description: >-
+  Add or drop ServiceNow release support in servicenow.itsm (integration CI
+  matrix, README compatibility table, changelog fragment). Use when the user
+  asks to support a new SNOW release, drop an EOL release, update the test
+  matrix, or mentions release codenames (e.g. Australia, Xanadu, Zurich).
+---
+
+# Update ServiceNow release support
+
+This collection does **not** branch module code on SNOW release names. Support is expressed through CI, README, and changelogs. See also `AGENTS.md` → Integration CI.
+
+## Scope
+
+**In scope:** `.github/workflows/integration_source.yml`, `README.md` compatibility table, `changelogs/fragments/`, maintainer notes in `AGENTS.md` if conventions change.
+
+**Out of scope (unless integration tests fail):** `plugins/`, `tests/`, module doc URLs with old bundle names (`bundle/tokyo-...`), hand-editing `CHANGELOG.rst` or `changelogs/changelog.yaml` (generated at release).
+
+## Decision: upgrade in place vs new PDI
+
+| Scenario | Workflow change | GitHub secrets |
+|----------|-----------------|----------------|
+| **Upgrade existing newest PDI** (usual) | Change `servicenow-version` label only; keep `SN_*_<instance_id>` | Rename existing secrets to instance ID if still on codename; **do not** create new secrets |
+| **Add a new PDI** to the matrix | Add matrix entry + full `include` block | The user will need to create eight secrets in Github once: `SN_HOST_<id>`, `SN_USERNAME_<id>`, `SN_PASSWORD_<id>`, `SN_CLIENT_ID_<id>`, `SN_CLIENT_SECRET_<id>`, `SN_API_KEY_<id>`, `SN_CLIENT_CERTIFICATE_<id>`, `SN_CLIENT_KEY_<id>` |
+
+Instance ID = numeric suffix from the PDI hostname (e.g. `dev7056` → `7056`).
+
+## Workflow checklist
+
+Copy and track progress:
+
+```
+- [ ] Confirm new release codename and which PDI instance is upgraded
+- [ ] Update integration_source.yml matrix
+- [ ] Update README.md compatibility table
+- [ ] Add changelogs/fragments/<issue>-<topic>.yaml
+- [ ] Remind maintainer: GitHub secrets / instance upgrade (if not done)
+- [ ] Open PR using .github/pull_request_template.md
+```
+
+### 1. Integration CI — `.github/workflows/integration_source.yml`
+
+Only file with release-specific configuration. Matrix keeps **three** SNOW versions (newest + two older).
+
+**Upgrade in place (replace oldest / dropped release on newest instance):**
+
+```yaml
+servicenow-version:
+  - "<new_release>"   # was <old_release>
+  - "yokohama"
+  - "zurich"
+include:
+  - servicenow-version: "<new_release>"
+    sn_host_secret: SN_HOST_<instance_id>
+    sn_username_secret: SN_USERNAME_<instance_id>
+    # ... same pattern for all eight SN_*_<instance_id> secrets
+```
+
+**Do not** switch secrets back to `SN_*_<RELEASE_CODENAME>` — instances upgrade in place.
+
+Leave workflow comments above `servicenow-version` intact (they document the instance-ID convention).
+
+### 2. README — compatibility table
+
+In `README.md` (Supported ServiceNow versions):
+
+1. Add new release at the top: `| <NewRelease> | <next_collection_version>+ | TBA |`
+2. Retire dropped release: set EOL quarter and bound collection range (e.g. `2.7.0 - 2.14.0 | Q2 2026`), following Washington/Vancouver/Xanadu rows.
+3. Next collection version = bump after current `galaxy.yml` `version` (e.g. `2.14.0` → document `2.15.0+`).
+
+### 3. Changelog fragment — required
+
+Create `changelogs/fragments/<descriptive-name>.yaml`:
+
+```yaml
+---
+minor_changes:
+  - add support for SNOW <NEW_RELEASE> release
+  - tests - Drop testing of <OLD_RELEASE>, as it is no longer supported by the collection
+```
+
+Adjust wording if only adding (no drop) or only dropping. Per `AGENTS.md`, behavior/support changes need a fragment.
+
+### 4. Discover other references
+
+```bash
+rg -i '<old_release>|<new_release>' --glob '!CHANGELOG*' --glob '!changelogs/changelog.yaml'
+```
+
+Expect hits only in workflow, README, changelogs, and historical docs — not in `plugins/` or `tests/`.
+
+### 5. Pull request
+
+Use `.github/pull_request_template.md`:
+
+- **ISSUE TYPE:** Feature Pull Request (release support)
+- **COMPONENT NAME:** `integration CI / collection compatibility`
+- **ADDITIONAL INFORMATION:** List maintainer GitHub secret actions and which matrix leg uses which instance ID
+
+Prefer `ci:` commit prefix. Example: `ci: add Australia release support and drop Xanadu from test matrix`
+
+Draft PR against `ansible-collections/servicenow.itsm` `main` from the contributor fork.
+
+The user should be able to confirm the new version is valid via the CI running in their PR.
+
+## Reference: Australia / Xanadu (2026)
+
+| Item | Value |
+|------|-------|
+| Added | `australia` on instance `7056` (`SN_*_7056`) |
+| Dropped from CI | `xanadu` (same instance, upgraded in place) |
+| README | Australia `2.15.0+`; Xanadu `2.7.0 - 2.14.0`, EOL Q2 2026 |
+| Legacy secrets | Yokohama/Zurich rows may still use `SN_*_YOKOHAMA` / `SN_*_ZURICH` until migrated to instance IDs |
+
+Prior art: upstream PR adding Zurich (dropped Washington from matrix); commit adding Xanadu to matrix.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+##### SUMMARY
+<!--- Describe the change below, including rationale and design decisions -->
+
+<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
+
+##### ISSUE TYPE
+<!--- Pick one below and delete the rest -->
+- Bugfix Pull Request
+- Docs Pull Request
+- Feature Pull Request
+- New Module Pull Request
+
+##### COMPONENT NAME
+<!--- Write the short name of the module, plugin, task or feature below -->
+
+##### ADDITIONAL INFORMATION
+<!--- Include additional information to help people understand the change here -->
+<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
+
+<!--- Paste verbatim command output below, e.g. before and after your change -->
+```paste below
+
+```

--- a/.github/workflows/integration_source.yml
+++ b/.github/workflows/integration_source.yml
@@ -227,6 +227,5 @@ jobs:
           SN_CLIENT_ID: ${{ secrets[matrix.sn_client_id_secret] }}
           SN_CLIENT_SECRET: ${{ secrets[matrix.sn_client_secret_secret] }}
           SN_API_KEY: ${{ secrets[matrix.sn_api_key_secret] }}
-          SN_TIMEOUT: 30
         run: ansible-test integration
         working-directory: ${{ steps.identify.outputs.collection_path }}

--- a/.github/workflows/integration_source.yml
+++ b/.github/workflows/integration_source.yml
@@ -227,5 +227,6 @@ jobs:
           SN_CLIENT_ID: ${{ secrets[matrix.sn_client_id_secret] }}
           SN_CLIENT_SECRET: ${{ secrets[matrix.sn_client_secret_secret] }}
           SN_API_KEY: ${{ secrets[matrix.sn_api_key_secret] }}
+          SN_TIMEOUT: 30
         run: ansible-test integration
         working-directory: ${{ steps.identify.outputs.collection_path }}

--- a/.github/workflows/integration_source.yml
+++ b/.github/workflows/integration_source.yml
@@ -115,20 +115,23 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+        # servicenow-version is the SNOW release label (job names / matrix only).
+        # GitHub secrets use PDI instance IDs (SN_*_<id>) because instances upgrade
+        # in place; when a new release ships, update the label here—not new secrets.
         servicenow-version:
-          - "xanadu"
+          - "australia"
           - "yokohama"
           - "zurich"
         include:
-          - servicenow-version: "xanadu"
-            sn_host_secret: SN_HOST_XANADU
-            sn_username_secret: SN_USERNAME_XANADU
-            sn_password_secret: SN_PASSWORD_XANADU
-            sn_client_id_secret: SN_CLIENT_ID_XANADU
-            sn_client_secret_secret: SN_CLIENT_SECRET_XANADU
-            sn_api_key_secret: SN_API_KEY_XANADU
-            sn_client_certificate_secret: SN_CLIENT_CERTIFICATE_XANADU
-            sn_client_key_secret: SN_CLIENT_KEY_XANADU
+          - servicenow-version: "australia"
+            sn_host_secret: SN_HOST_7056
+            sn_username_secret: SN_USERNAME_7056
+            sn_password_secret: SN_PASSWORD_7056
+            sn_client_id_secret: SN_CLIENT_ID_7056
+            sn_client_secret_secret: SN_CLIENT_SECRET_7056
+            sn_api_key_secret: SN_API_KEY_7056
+            sn_client_certificate_secret: SN_CLIENT_CERTIFICATE_7056
+            sn_client_key_secret: SN_CLIENT_KEY_7056
           - servicenow-version: "yokohama"
             sn_host_secret: SN_HOST_YOKOHAMA
             sn_username_secret: SN_USERNAME_YOKOHAMA

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,6 @@ tests/integration/targets/*/roles
 .opencode
 .lola
 .pytest_cache
-skills/
+/skills/
 CLAUDE.md
 GEMINI.md

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,14 @@ venv/
 .venv/
 tests/integration/targets/*/test_session
 tests/integration/targets/*/roles
+
+# AI and lola stuff
+.claude
+.cursor
+.gemini
+.opencode
+.lola
+.pytest_cache
+skills/
+CLAUDE.md
+GEMINI.md

--- a/.lola-req
+++ b/.lola-req
@@ -1,0 +1,6 @@
+# .lola-req - AI context modules for this project
+
+https://github.com/ansible-community/ai-forge.git#subdirectory=ansible-collection-sdlc
+https://github.com/ansible-community/ai-forge.git#subdirectory=ansible-collection-standards
+
+https://github.com/RedHatProductSecurity/prodsec-skills.git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,67 @@
+# AGENTS.md
+
+This file is intended for AI coding agents. It is kept human-readable so contributors can also use it as a quick-reference guide.
+
+## What This Project Is
+
+An Ansible collection (`servicenow.itsm`) providing modules for managing ServiceNow resources via the REST api. No roles exist — only modules and shared utilities. This qualifies as a "Certified" collection.
+
+The collection namespace, name, and version number can all be found in the `galaxy.yml` file.
+
+## Development Environment
+
+The collection must reside at `ansible_collections/NAMESPACE/NAME/` (relative to a directory on `ANSIBLE_COLLECTIONS_PATHS`) for imports to resolve correctly.
+
+All required packages are listed in `requirements.txt`.
+
+## Coding Guidelines
+
+- Follow these software development principles: KISS (Keep It Simple, Stupid), DRY (Don't Repeat Yourself), YAGNI (You Aren't Gonna Need It), Separation of Concerns, Composition over Inheritance, and Convention Over Configuration.
+- Prioritize code simplicity and readability over flexibility.
+- Favor simple, short, and easily testable functions with no side effects over classes. Use classes only when they naturally fit the problem and help avoid boilerplate code while grouping tightly related functionality.
+- Use `snake_case` for all variable and parameter names.
+- Shared code used by multiple modules belongs in `plugins/module_utils/` (DRY principle). Do not duplicate connection or utility logic in individual modules.
+- Do not add connection parameters to individual modules. Extend the doc fragment in `plugins/doc_fragments/` instead.
+- All modules must pass sanity and integration tests before merging.
+- Keep each piece of work focused on solving a single, specific issue or task. Do not mix unrelated changes (e.g., a bugfix and an unrelated refactoring) in the same branch or PR.
+- Use conventional commit message prefixes: `feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`, `ci:`. Example: `fix: handle empty database list in mysql_info`.
+
+## Development Conventions
+
+- Every PR that changes module behavior needs a changelog fragment in `changelogs/fragments/<something>.yaml`. Docs/tests/refactoring PRs are exempt. Valid fragment sections: `major_changes`, `minor_changes`, `bugfixes`, `breaking_changes`, `deprecated_features`, `removed_features`, `security_fixes`, `known_issues`. Fragments are consumed (deleted) at release time (`keep_fragments: false` in `changelogs/config.yaml`).
+
+## Integration CI (ServiceNow instances)
+
+Integration tests run in `.github/workflows/integration_source.yml` against three ServiceNow PDIs in the `protected-snow` GitHub environment.
+
+- **Matrix label** (`servicenow-version`): the SNOW release codename under test (e.g. `australia`). Used for job names only.
+- **GitHub secrets**: named by **PDI instance ID**, not release codename — `SN_HOST_<id>`, `SN_USERNAME_<id>`, etc. (e.g. `SN_HOST_7056` for instance `dev7056`). Instances are upgraded in place; credentials stay the same.
+
+When supporting a new SNOW release on an existing instance:
+
+1. Upgrade the instance in ServiceNow.
+2. Change the `servicenow-version` string in the workflow matrix (and update `README.md` compatibility table + changelog fragment).
+3. Do **not** create new GitHub secrets.
+
+When adding a **new** PDI to the matrix, create the eight `SN_*_<instance_id>` secrets once, then add a new `include` block with that instance ID.
+
+Legacy rows may still reference `SN_*_YOKOHAMA` / `SN_*_ZURICH` until those secrets are renamed in GitHub to instance IDs and the workflow is updated to match.
+
+## Subagents
+
+Subagent definitions live in `.agents/subagents/`. When a task matches a subagent's trigger conditions, delegate to it.
+
+## Project Skills
+
+Skills live in `.agents/skills/*/SKILL.md` (YAML frontmatter + instructions). At session start, scan and register all skills. When a request matches a skill's trigger, load and apply it.
+
+## Lola Skills
+
+These skills are installed by Lola and provide specialized capabilities.
+When a task matches a skill's description, read the skill's SKILL.md file
+to learn the detailed instructions and workflows.
+
+**How to use skills:**
+1. Check if your task matches any skill description below
+2. Use `read_file` to read the skill's SKILL.md for detailed instructions
+3. Follow the instructions in the SKILL.md file

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,8 @@ Subagent definitions live in `.agents/subagents/`. When a task matches a subagen
 
 Skills live in `.agents/skills/*/SKILL.md` (YAML frontmatter + instructions). At session start, scan and register all skills. When a request matches a skill's trigger, load and apply it.
 
+- **update-snow-release** — add/drop ServiceNow release support (CI matrix, README, changelog).
+
 ## Lola Skills
 
 These skills are installed by Lola and provide specialized capabilities.

--- a/README.md
+++ b/README.md
@@ -157,10 +157,11 @@ Known exceptions or compatibility issues will be tracked via the GitHub Issues p
 
 | ServiceNow Release | Collection Release |   EOL   |
 | ------------------ | ------------------ | ------- |
+| Australia          | 2.15.0+            |   TBA   |
 | Zurich             | 2.13.0+            |   TBA   |
 | Yokohama           | 2.9.0+             |   TBA   |
-| Xanadu             | 2.7.0+             |   TBA   |
-| Washington DC      | 2.5.0+             | Q4 2025 |
+| Xanadu             | 2.7.0 - 2.14.0     | Q2 2026 |
+| Washington DC      | 2.5.0 - 2.13.0     | Q4 2025 |
 | Vancouver          | 2.5.0 - 2.8.0      | Q2 2025 |
 | Utah               | 2.1.0 - 2.8.0      | Q2 2025 |
 | Tokyo              | 2.1.0 - 2.6.1      | Q2 2024 |

--- a/changelogs/fragments/add-support-for-australia.yml
+++ b/changelogs/fragments/add-support-for-australia.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - add support for SNOW AUSTRALIA release
+  - tests - Drop testing of Xanadu, as it is no longer supported by the collection

--- a/coderabbit.yml
+++ b/coderabbit.yml
@@ -1,0 +1,393 @@
+# CodeRabbit configuration for prodsec-skills
+# Enforces Red Hat Product Security concerns during code review.
+# Skills source: module/skills/*/SKILL.md (129 skills, 4 categories)
+#
+# Schema: https://coderabbit.ai/integrations/schema.v2.json
+# Validate: comment "@coderabbitai configuration" on any PR
+#
+#
+language: "en-US"
+tone_instructions: "Security-focused. State risk severity and impact."
+
+reviews:
+  profile: "assertive"
+  request_changes_workflow: true
+  high_level_summary: true
+  collapse_walkthrough: false
+  sequence_diagrams: true
+
+  path_filters:
+    - "!vendor/**"
+    - "!node_modules/**"
+    - "!dist/**"
+    - "!*.min.js"
+    # yarn.lock excluded: high churn, low signal — package.json changes are
+    # reviewed by the supply-chain block. Other dependency locks (go.sum,
+    # package-lock.json, Cargo.lock) are deliberately kept so the supply-chain
+    # path_instructions block fires on them.
+    - "!yarn.lock"
+
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    drafts: false
+    base_branches:
+      - "main"
+      - "release/.*"
+
+  path_instructions:
+    # ── Injection & input validation ─────────────────────────────
+    # Skills: input-validation-injection, web-application-security
+    - path: "**/*.{py,js,ts,go,rs,java,rb,php,kt,swift,cs}"
+      instructions: |
+        Injection prevention (prodsec-skills):
+        - SQL: parameterized queries only; no string concatenation
+        - Command: no shell=True, os.system, or backtick exec with user input
+        - LDAP/XPath: escape special characters in filters
+        - Path traversal: canonicalize paths, reject ../
+        - Deserialization: no pickle/yaml.load()/eval on untrusted data
+        - Prototype pollution: no recursive merge of untrusted objects
+        - Validate at trust boundaries with allow-lists, not deny-lists
+        - Normalize Unicode and anchor regexes (^$); watch for ReDoS
+
+    # ── Web & frontend security ──────────────────────────────────
+    # Skills: react-security, client-side-security, http-security-headers,
+    #         graphql-security, session-management-cookies, file-handling-uploads,
+    #         xml-serialization-security
+    - path: "**/*.{html,jsx,tsx,vue,svelte}"
+      instructions: |
+        Web security (prodsec-skills):
+        - No dangerouslySetInnerHTML or v-html with user data
+        - CSP: no unsafe-inline, no unsafe-eval
+        - CSRF tokens on state-changing requests
+        - Cookies: Secure, HttpOnly, SameSite=Strict
+        - No document.write, eval, new Function with user input
+        - GraphQL: depth/complexity limits, disable introspection in prod
+        - File uploads: validate by content magic, cap size, server-generate names
+        - XML: disable external entities (XXE), reject DTDs from untrusted sources
+
+    # ── Cryptography ─────────────────────────────────────────────
+    # Skills: algorithm-selection, constant-time-analysis, zeroize-audit,
+    #         wycheproof, crypto-protocol-diagram, mermaid-to-proverif,
+    #         constant-time-testing
+    - path: "**/*{crypt,cipher,sign,hash,tls,ssl,cert,key,token}*"
+      instructions: |
+        Cryptographic security (prodsec-skills):
+        - Banned: MD5, SHA1, DES, RC4, 3DES, Blowfish, ECB mode
+        - Symmetric: AES-256-GCM or ChaCha20-Poly1305
+        - Passwords: Argon2id (not bcrypt/scrypt for new code)
+        - Signing: Ed25519 or ECDSA P-256+
+        - Key exchange: X25519 or ECDH P-256+
+        - Constant-time comparison for all secret/token data
+        - Zeroize key material after use (no garbage-collector reliance)
+        - No custom crypto; use vetted libraries only
+        - Post-quantum: flag if protecting long-lived secrets
+
+    # ── Container & image hardening ──────────────────────────────
+    # Skills: container-hardening, isolation-sandboxing
+    - path: "**/{Dockerfile,Containerfile}*"
+      instructions: |
+        Container security (prodsec-skills):
+        - Base image: UBI minimal or distroless from catalog.redhat.com
+        - Red Hat images: use floating tags (Red Hat manages updates);
+          non-RH images: pin by digest
+        - Multi-stage builds; no build tools in final image
+        - USER non-root; never run as root
+        - COPY specific files, not entire context
+        - No secrets in ENV, ARG, or COPY
+        - Read-only rootfs where possible
+        - No package manager cache in final layer
+        - HEALTHCHECK defined
+
+    # ── Kubernetes & OpenShift ───────────────────────────────────
+    # Skills: scc-security, operator-security, helm-chart-security,
+    #         container-hardening, health-probes
+    - path: "**/*.{yaml,yml}"
+      instructions: |
+        If this is a Kubernetes/OpenShift manifest or Helm template:
+        - securityContext: runAsNonRoot, readOnlyRootFilesystem,
+          allowPrivilegeEscalation: false
+        - Drop ALL capabilities, add only what is required
+        - Resource limits (cpu, memory) on every container
+        - No hostPID, hostNetwork, hostIPC, privileged: true
+        - NetworkPolicy defined for the namespace
+        - OpenShift: SCC must be restricted or custom-scoped
+        - Liveness + readiness probes defined
+        - automountServiceAccountToken: false unless needed
+        - RBAC: least privilege; no cluster-admin for workloads
+        - Helm: no .Values interpolation in shell commands
+
+    # ── MCP server security ──────────────────────────────────────
+    # Skills: hardening-local, hardening-remote, oauth21-resource-server,
+    #         rbac, input-output-sanitization, secure-token-handling,
+    #         containerization, tool-server-injection-prevention,
+    #         no-credential-forwarding, roots-support, sampling-controls,
+    #         logging-and-observability, runtime-restrictions, os-tool-security,
+    #         reject-api-keys, token-exchange-for-tools
+    - path: "**/{mcp,tool_server,toolserver}/**/*"
+      instructions: |
+        MCP server review (prodsec-skills):
+        - OAuth 2.1 resource server: validate tokens per RFC 9068
+        - Enforce scope-based access per tool; no default-allow
+        - RBAC: per-tool permissions mapped to token scopes/roles
+        - Sanitize all tool inputs against declared schemas
+        - Reject path traversal in file-accessing tools
+        - No credential forwarding to downstream services
+        - Tool injection: validate registry integrity, reject dynamic
+          tool loading from untrusted sources
+        - Container isolation: unprivileged, read-only rootfs
+        - Audit log all tool invocations with caller identity
+        - Rate limiting per client/scope
+        - Reject API keys; require IdP-issued tokens
+
+    # ── MCP client ───────────────────────────────────────────────
+    # Skills: mcp-client-client-metadata-support,
+    #         mcp-client-dynamic-client-registration,
+    #         mcp-client-protected-resource-metadata,
+    #         consent-and-scoping, discovery-mechanisms
+    - path: "**/{mcp_client,mcp-client}/**/*"
+      instructions: |
+        MCP client review (prodsec-skills):
+        - OAuth client metadata: register with minimal scopes
+        - Dynamic registration: validate server response, store
+          client_id/secret securely
+        - Protected resource metadata: discover before token request
+        - Consent: prompt user before granting tool access
+        - Discovery: validate .well-known endpoints over HTTPS only
+
+    # ── Inference engine & model serving ─────────────────────────
+    # Skills: isolation-sandboxing, jwt-token-enforcement,
+    #         model-security-scanning, model-signature-verification,
+    #         oidc-integration, token-lifecycle, external-idp-integration
+    - path: "**/{inference,model,serving,predict}/**/*"
+      instructions: |
+        Inference engine review (prodsec-skills):
+        - Process isolation: container or microVM per model
+        - JWT/OIDC on all inference endpoints; no unauthenticated access
+        - Model provenance: verify signatures before loading
+        - Scan models for embedded payloads (pickle, arbitrary code)
+        - Token lifecycle: short-lived, secure storage, revocation
+        - No direct filesystem access from inference process
+        - Resource limits to prevent DoS via large inputs
+
+    # ── Agent security ───────────────────────────────────────────
+    # Skills: agent-identity, agent-to-agent-auth, agent-to-mcp-server-auth
+    - path: "**/{agent,agents,agentic}/**/*"
+      instructions: |
+        Agent security (prodsec-skills):
+        - Unique, verifiable identity per agent instance
+        - Agent-to-agent auth: SPIFFE/mTLS, not shared secrets
+        - Agent-to-MCP auth: OAuth 2.1 client credentials flow
+        - No ambient authority; agents present credentials per call
+        - Audit trail for all inter-agent communication
+
+    # ── LLM interaction ──────────────────────────────────────────
+    # Skills: prompt-injection-mitigation, file-protection,
+    #         third-party-model-security, bidirectional-filtering,
+    #         output-validation-sandbox
+    - path: "**/{llm,prompt,chat,completion}**/*"
+      instructions: |
+        LLM security (prodsec-skills):
+        - Prompt injection: separate system/user content; never
+          interpolate untrusted input into system prompts
+        - Output filtering: validate LLM output before execution
+        - File protection: restrict file access to declared paths
+        - Third-party models: evaluate trust, scan artifacts
+        - Guardrails: bidirectional filtering on prompts and responses
+
+    # ── Supply chain & dependencies ──────────────────────────────
+    # Skills: supply-chain-risk-auditor, sbom-provenance,
+    #         software-signing, secure-pipeline, vulnerability-management
+    - path: "**/{requirements*.txt,Pipfile*,pyproject.toml,package*.json,go.mod,go.sum,Cargo.toml,Gemfile*,pom.xml,build.gradle*}"
+      instructions: |
+        Supply chain security (prodsec-skills):
+        - New deps: justify need, check license compatibility
+        - Pin exact versions; verify hashes where supported
+        - Flag known CVEs (cross-ref osv.dev)
+        - No pre-release or yanked versions in production
+        - SBOM: ensure build produces provenance attestations
+        - Signing: artifacts signed with Sigstore/cosign
+
+    # ── CI/CD & GitHub Actions ───────────────────────────────────
+    # Skills: secure-pipeline, build-yaml-misconfiguration,
+    #         agentic-actions-auditor
+    - path: ".github/workflows/**/*"
+      instructions: |
+        CI/CD security (prodsec-skills):
+        - Pin actions by full SHA, not tag
+        - No secrets in logs; mask sensitive outputs
+        - Least privilege: minimize GITHUB_TOKEN permissions
+        - No pull_request_target with checkout of PR head
+        - SAST/SCA steps in pipeline
+        - Sign artifacts with Sigstore/cosign
+        - Agentic CI actions: audit for prompt injection via
+          issue/PR title/body flowing into LLM prompts
+
+    # ── Authentication & OAuth ───────────────────────────────────
+    # Skills: oauth21-implementation, authentication, authorization,
+    #         session-management-cookies, avoid-api-keys,
+    #         service-to-service-mtls
+    - path: "**/{auth,oauth,oidc,login,session,saml}/**/*"
+      instructions: |
+        Authentication review (prodsec-skills):
+        - OAuth 2.1: PKCE required; no implicit grant
+        - JWT: verify signature, issuer, audience, expiry, nbf
+        - Sessions: secure cookie flags, regenerate ID on login
+        - Passwords: Argon2id; never plaintext or weak hashes
+        - Rate limit login attempts; account lockout policy
+        - MFA: support and encourage; never bypass silently
+        - Service-to-service: SPIFFE/mTLS, not shared secrets
+        - Avoid API keys; prefer IdP-issued short-lived tokens
+
+    # ── API gateway & rate limiting ──────────────────────────────
+    # Skills: authentication-enforcement, internal-application-routing,
+    #         rate-limiting, request-validation
+    - path: "**/{gateway,proxy,ingress,route}/**/*"
+      instructions: |
+        API gateway review (prodsec-skills):
+        - Auth enforcement at gateway, not just downstream
+        - Rate limiting per client/endpoint; fail closed
+        - Request validation: size limits, content-type checks
+        - No internal-only routes exposed externally
+        - TLS termination with strong cipher suites
+
+    # ── Go ───────────────────────────────────────────────────────
+    # Skills: go-security
+    - path: "**/*.go"
+      instructions: |
+        Go security (prodsec-skills):
+        - Never ignore error returns
+        - database/sql with placeholders; no fmt.Sprintf in queries
+        - Use stdlib crypto/* and golang.org/x/crypto (Go team maintained);
+          avoid third-party crypto libraries
+        - Integer overflow: bounds-check user-supplied sizes
+        - context.Context for cancellation and timeouts
+
+    # ── C/C++ ────────────────────────────────────────────────────
+    # Skills: safe-c-functions, compiler-hardening
+    - path: "**/*.{c,cpp,cc,h,hpp}"
+      instructions: |
+        C/C++ security (prodsec-skills):
+        - Banned: gets, sprintf, strcpy, strcat, strtok
+        - Use strlcpy, snprintf, bounded APIs
+        - Compile: -fstack-protector-strong -fPIE -pie
+          -D_FORTIFY_SOURCE=2 -Wformat-security
+        - Nullify pointers after free; no use-after-free
+        - Integer overflow: check arithmetic on untrusted sizes
+
+    # ── Database & external data ─────────────────────────────────
+    # Skills: database-security, authentication (external-data-source),
+    #         encrypted-communication, redis-elasticache-security
+    - path: "**/{db,database,redis,cache,storage}/**/*"
+      instructions: |
+        Data store security (prodsec-skills):
+        - Auth: no default credentials; use IAM or IdP tokens
+        - Encryption: TLS in transit, encryption at rest
+        - Least privilege: app user has minimal grants
+        - Redis/ElastiCache: AUTH required, no KEYS in prod,
+          rename dangerous commands (FLUSHALL, CONFIG)
+        - Connection strings: no embedded credentials
+
+    # ── Messaging ────────────────────────────────────────────────
+    # Skills: kafka-amq-security, mqtt-security
+    - path: "**/{kafka,amq,mqtt,messaging,broker}/**/*"
+      instructions: |
+        Messaging security (prodsec-skills):
+        - Kafka/AMQ: TLS, SASL auth, per-topic ACLs
+        - MQTT: auth required, topic ACLs, payload encryption
+        - No anonymous access in production
+
+    # ── Model registry ───────────────────────────────────────────
+    # Skills: model-registry-*, admin-interface-security,
+    #         model-registry-secure-storage
+    - path: "**/{model_registry,model-registry,registry}/**/*"
+      instructions: |
+        Model registry review (prodsec-skills):
+        - Admin interface: auth + RBAC, no public exposure
+        - Model scanning: check for malicious payloads before publish
+        - Model signing: verify signatures on pull
+        - Audit logging: who uploaded/downloaded/deleted what
+        - Secure storage: encrypted at rest, access-controlled
+
+  # ── Security scanners ────────────────────────────────────────
+  tools:
+    gitleaks:
+      enabled: true
+    semgrep:
+      enabled: true
+    checkov:
+      enabled: true
+    hadolint:
+      enabled: true
+    trivy:
+      enabled: true
+    osvScanner:
+      enabled: true
+    actionlint:
+      enabled: true
+    ast-grep:
+      essential_rules: true
+
+  # ── Pre-merge checks (hard gates) ───────────────────────────
+  pre_merge_checks:
+    description:
+      mode: "warning"
+    custom_checks:
+      - name: "no-hardcoded-secrets"
+        instructions: |
+          Flag hardcoded secrets: API keys, tokens, passwords, private
+          keys, credentials. Also flag base64 strings >32 chars in config,
+          URLs with embedded credentials, variables named api_key/secret/
+          token/password assigned string literals.
+        mode: "error"
+
+      - name: "no-weak-crypto"
+        instructions: |
+          Flag MD5, SHA1, DES, RC4, 3DES, Blowfish, ECB mode usage.
+          Flag custom crypto implementations. Flag non-constant-time
+          comparison of secrets or tokens.
+        mode: "error"
+
+      - name: "no-injection-vectors"
+        instructions: |
+          Flag SQL string concatenation, shell=True with user input,
+          eval/exec on untrusted data, pickle.loads on untrusted input,
+          yaml.load without SafeLoader, os.system with variables,
+          dangerouslySetInnerHTML with user data.
+        mode: "error"
+
+      - name: "container-privileges"
+        instructions: |
+          Flag privileged: true, hostPID, hostNetwork, hostIPC,
+          SYS_ADMIN capability, running as root without justification,
+          allowPrivilegeEscalation: true in container/K8s manifests.
+        mode: "error"
+
+      - name: "no-sensitive-data-in-logs"
+        instructions: |
+          Flag logging that may expose passwords, tokens, API keys,
+          PII (email, SSN, credit card), session IDs, internal
+          hostnames, or customer data.
+        mode: "error"
+
+      - name: "ai-attribution"
+        instructions: |
+          If AI tools were used (mentioned in PR or commits), verify
+          Red Hat attribution: Assisted-by or Generated-by trailers.
+          Flag use of Co-Authored-By for AI tools.
+        mode: "warning"
+
+# ── Knowledge base ───────────────────────────────────────────
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "**/AGENTS.md"
+      - "**/REDHAT.md"
+      - "**/CLAUDE.md"
+      - "**/CONTRIBUTING.md"
+
+  issues:
+    scope: "auto"
+  pull_requests:
+    scope: "auto"

--- a/plugins/modules/service_catalog_info.py
+++ b/plugins/modules/service_catalog_info.py
@@ -22,6 +22,13 @@ description:
   - For more information, refer to ServiceNow service catalog documentation at
     U(https://developer.servicenow.com/dev.do#!/reference/api/utah/rest/c_ServiceCatalogAPI)
 
+notes:
+  - In the AUSTRALIA release, SNOW exposed a 'Admin Home' service catalog. When attempting to gather
+    full information about this catalog, the module will fail with a 500 error. This is due to a null
+    pointer bug in a SNOW owned script included by the catalog, UIPolicyBuilder. If you need to
+    gather full information about all catalogs in your instance, you should consider contacting
+    SNOW support to discuss the best way to proceed in your environment.
+
 version_added: 2.6.0
 
 extends_documentation_fragment:

--- a/tests/integration/generate_integration_config.sh
+++ b/tests/integration/generate_integration_config.sh
@@ -1,12 +1,34 @@
 #!/bin/sh
 SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 
+if [ -z "$SN_CLIENT_CERTIFICATE_FILE" ]; then
+    SN_CLIENT_CERTIFICATE_FILE="/tmp/SN_CLIENT_CERTIFICATE_FILE"
+fi
+
+if [ -z "$SN_CLIENT_KEY_FILE" ]; then
+    SN_CLIENT_KEY_FILE="/tmp/SN_CLIENT_KEY_FILE"
+fi
+
+yaml_literal_block() {
+    key=$1
+    value=$2
+    printf '%s: |\n' "$key"
+    printf '%s\n' "$value" | sed 's/^/  /'
+}
+
 {
     echo "sn_host: '$SN_HOST'"
     echo "sn_username: '$SN_USERNAME'"
     echo "sn_password: '$SN_PASSWORD'"
     echo "sn_client_id: '$SN_CLIENT_ID'"
     echo "sn_client_secret: '$SN_CLIENT_SECRET'"
+    echo "sn_api_key: '$SN_API_KEY'"
+    if [ -n "$SN_CLIENT_CERTIFICATE" ]; then
+        yaml_literal_block sn_client_certificate "$SN_CLIENT_CERTIFICATE"
+    fi
+    if [ -n "$SN_CLIENT_KEY" ]; then
+        yaml_literal_block sn_client_key "$SN_CLIENT_KEY"
+    fi
     echo "sn_client_certificate_file: '$SN_CLIENT_CERTIFICATE_FILE'"
     echo "sn_client_key_file: '$SN_CLIENT_KEY_FILE'"
     echo "collection_base_dir: '$SCRIPT_DIR/../..'"

--- a/tests/integration/targets/api_authentication/tasks/main.yml
+++ b/tests/integration/targets/api_authentication/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 - environment:
     SN_HOST: "{{ sn_host }}"
+    SN_TIMEOUT: "{{ sn_timeout }}"
 
   block:
     # We dont care if this incident actually exists, we have other tests for that. But

--- a/tests/integration/targets/api_authentication/tasks/main.yml
+++ b/tests/integration/targets/api_authentication/tasks/main.yml
@@ -202,6 +202,28 @@
         that:
           - bearer_result is success
 
+    - name: Verify client cert files exist
+      ansible.builtin.stat:
+        path: "{{ sn_client_certificate_file }}"
+      register: client_certificate_stat
+
+    # Needed when using ansible-test and --docker, since ansible-test doesnt actually copy the files to the container
+    - name: Setup client cert files
+      when: not client_certificate_stat.stat.exists and sn_client_certificate is defined
+      no_log: true
+      diff: false
+      block:
+        - name: Write client cert file
+          ansible.builtin.copy:
+            content: "{{ sn_client_certificate }}"
+            dest: "{{ sn_client_certificate_file }}"
+            mode: "0600"
+        - name: Write client key file
+          ansible.builtin.copy:
+            content: "{{ sn_client_key }}"
+            dest: "{{ sn_client_key_file }}"
+            mode: "0600"
+
     - name: Client cert authentication success
       servicenow.itsm.incident_info:
         number: "{{ incident_number }}"

--- a/tests/integration/targets/inventory/setup.yml
+++ b/tests/integration/targets/inventory/setup.yml
@@ -19,6 +19,7 @@
           sn_username: '{{ sn_username }}'
           sn_password: '{{ sn_password }}'
           sn_client_id: '{{ sn_client_id }}'
+          sn_timeout: '{{ sn_timeout }}'
           sn_client_secret: '{{ sn_client_secret }}'
           sn_client_certificate_file: '{{ sn_client_certificate_file }}'
           sn_client_key_file: '{{ sn_client_key_file }}'

--- a/tests/integration/targets/inventory/test.yml
+++ b/tests/integration/targets/inventory/test.yml
@@ -9,6 +9,7 @@
     SN_HOST: "{{ sn_host }}"
     SN_USERNAME: "{{ sn_username }}"
     SN_PASSWORD: "{{ sn_password }}"
+    SN_TIMEOUT: "{{ sn_timeout }}"
 
   vars:
     resource_prefix: "{{ unique_test_id }}-inven-{{ test_name }}"

--- a/tests/integration/targets/itsm_api/tasks/main.yml
+++ b/tests/integration/targets/itsm_api/tasks/main.yml
@@ -3,6 +3,7 @@
     SN_HOST: "{{ sn_host }}"
     SN_USERNAME: "{{ sn_username }}"
     SN_PASSWORD: "{{ sn_password }}"
+    SN_TIMEOUT: "{{ sn_timeout }}"
 
   block:
     - name: create user (object with encrypted fields)

--- a/tests/integration/targets/itsm_api_generic/tasks/main.yml
+++ b/tests/integration/targets/itsm_api_generic/tasks/main.yml
@@ -3,6 +3,7 @@
     SN_HOST: "{{ sn_host }}"
     SN_USERNAME: "{{ sn_username }}"
     SN_PASSWORD: "{{ sn_password }}"
+    SN_TIMEOUT: "{{ sn_timeout }}"
 
   block:
     - name: Retrieve all ci linux server cmdb

--- a/tests/integration/targets/itsm_attachment/tasks/main.yml
+++ b/tests/integration/targets/itsm_attachment/tasks/main.yml
@@ -2,6 +2,7 @@
     SN_HOST: "{{ sn_host }}"
     SN_USERNAME: "{{ sn_username }}"
     SN_PASSWORD: "{{ sn_password }}"
+    SN_TIMEOUT: "{{ sn_timeout }}"
 
   block:
     #############################################

--- a/tests/integration/targets/itsm_attachment_info/tasks/main.yml
+++ b/tests/integration/targets/itsm_attachment_info/tasks/main.yml
@@ -2,6 +2,7 @@
     SN_HOST: "{{ sn_host }}"
     SN_USERNAME: "{{ sn_username }}"
     SN_PASSWORD: "{{ sn_password }}"
+    SN_TIMEOUT: "{{ sn_timeout }}"
 
   block:
     ###################################################################

--- a/tests/integration/targets/itsm_attachment_upload/tasks/main.yml
+++ b/tests/integration/targets/itsm_attachment_upload/tasks/main.yml
@@ -2,6 +2,7 @@
     SN_HOST: "{{ sn_host }}"
     SN_USERNAME: "{{ sn_username }}"
     SN_PASSWORD: "{{ sn_password }}"
+    SN_TIMEOUT: "{{ sn_timeout }}"
 
   block:
     #############################################

--- a/tests/integration/targets/itsm_catalog_request/tasks/main.yml
+++ b/tests/integration/targets/itsm_catalog_request/tasks/main.yml
@@ -2,6 +2,7 @@
     SN_HOST: "{{ sn_host }}"
     SN_USERNAME: "{{ sn_username }}"
     SN_PASSWORD: "{{ sn_password }}"
+    SN_TIMEOUT: "{{ sn_timeout }}"
 
   block:
     - name: Create test catalog_request - check mode

--- a/tests/integration/targets/itsm_catalog_request_task/tasks/main.yml
+++ b/tests/integration/targets/itsm_catalog_request_task/tasks/main.yml
@@ -3,6 +3,7 @@
     SN_HOST: "{{ sn_host }}"
     SN_USERNAME: "{{ sn_username }}"
     SN_PASSWORD: "{{ sn_password }}"
+    SN_TIMEOUT: "{{ sn_timeout }}"
 
   block:
     # Setup: Create a parent catalog request first

--- a/tests/integration/targets/itsm_change_request/tasks/main.yml
+++ b/tests/integration/targets/itsm_change_request/tasks/main.yml
@@ -2,6 +2,7 @@
     SN_HOST: "{{ sn_host }}"
     SN_USERNAME: "{{ sn_username }}"
     SN_PASSWORD: "{{ sn_password }}"
+    SN_TIMEOUT: "{{ sn_timeout }}"
 
   vars:
     assignment_groups:

--- a/tests/integration/targets/itsm_change_request_task/tasks/main.yml
+++ b/tests/integration/targets/itsm_change_request_task/tasks/main.yml
@@ -2,6 +2,7 @@
     SN_HOST: "{{ sn_host }}"
     SN_USERNAME: "{{ sn_username }}"
     SN_PASSWORD: "{{ sn_password }}"
+    SN_TIMEOUT: "{{ sn_timeout }}"
 
   vars:
     assignment_groups:

--- a/tests/integration/targets/itsm_change_request_with_mapping/tasks/main.yml
+++ b/tests/integration/targets/itsm_change_request_with_mapping/tasks/main.yml
@@ -2,6 +2,7 @@
     SN_HOST: "{{ sn_host }}"
     SN_USERNAME: "{{ sn_username }}"
     SN_PASSWORD: "{{ sn_password }}"
+    SN_TIMEOUT: "{{ sn_timeout }}"
 
   vars:
     mapping:

--- a/tests/integration/targets/itsm_configuration_item/tasks/main.yml
+++ b/tests/integration/targets/itsm_configuration_item/tasks/main.yml
@@ -3,6 +3,7 @@
     SN_HOST: "{{ sn_host }}"
     SN_USERNAME: "{{ sn_username }}"
     SN_PASSWORD: "{{ sn_password }}"
+    SN_TIMEOUT: "{{ sn_timeout }}"
 
   block:
     - name: Create a base configuration item (check mode)

--- a/tests/integration/targets/itsm_configuration_item_batch/tasks/main.yml
+++ b/tests/integration/targets/itsm_configuration_item_batch/tasks/main.yml
@@ -3,6 +3,7 @@
     SN_HOST: "{{ sn_host }}"
     SN_USERNAME: "{{ sn_username }}"
     SN_PASSWORD: "{{ sn_password }}"
+    SN_TIMEOUT: "{{ sn_timeout }}"
 
   block:
     - name: Register instance in ServiceNow

--- a/tests/integration/targets/itsm_configuration_item_relations/tasks/main.yml
+++ b/tests/integration/targets/itsm_configuration_item_relations/tasks/main.yml
@@ -3,6 +3,7 @@
     SN_HOST: "{{ sn_host }}"
     SN_USERNAME: "{{ sn_username }}"
     SN_PASSWORD: "{{ sn_password }}"
+    SN_TIMEOUT: "{{ sn_timeout }}"
 
   block:
     - name: Create 3 servers

--- a/tests/integration/targets/itsm_incident/tasks/main.yml
+++ b/tests/integration/targets/itsm_incident/tasks/main.yml
@@ -2,6 +2,7 @@
     SN_HOST: "{{ sn_host }}"
     SN_USERNAME: "{{ sn_username }}"
     SN_PASSWORD: "{{ sn_password }}"
+    SN_TIMEOUT: "{{ sn_timeout }}"
 
   block:
     - name: Create test incident - check mode

--- a/tests/integration/targets/itsm_incident_with_mapping/tasks/main.yml
+++ b/tests/integration/targets/itsm_incident_with_mapping/tasks/main.yml
@@ -2,6 +2,7 @@
     SN_HOST: "{{ sn_host }}"
     SN_USERNAME: "{{ sn_username }}"
     SN_PASSWORD: "{{ sn_password }}"
+    SN_TIMEOUT: "{{ sn_timeout }}"
 
   vars:
     mapping:

--- a/tests/integration/targets/itsm_misc/tasks/main.yml
+++ b/tests/integration/targets/itsm_misc/tasks/main.yml
@@ -3,6 +3,7 @@
     SN_HOST: "{{ sn_host }}"
     SN_USERNAME: "{{ sn_username }}"
     SN_PASSWORD: "{{ sn_password }}"
+    SN_TIMEOUT: "{{ sn_timeout }}"
 
   block:
     - name: Make sure timeout setting is enforced

--- a/tests/integration/targets/itsm_service_catalog/tasks/main.yml
+++ b/tests/integration/targets/itsm_service_catalog/tasks/main.yml
@@ -3,6 +3,7 @@
     SN_HOST: "{{ sn_host }}"
     SN_USERNAME: "{{ sn_username }}"
     SN_PASSWORD: "{{ sn_password }}"
+    SN_TIMEOUT: "{{ sn_timeout }}"
 
   block:
     - name: Set fact user passowrd

--- a/tests/integration/targets/itsm_service_catalog_info/tasks/main.yml
+++ b/tests/integration/targets/itsm_service_catalog_info/tasks/main.yml
@@ -12,12 +12,25 @@
     - debug: var=catalogs
     - ansible.builtin.assert:
         that:
-          - catalogs | length > 1
-    
+          - catalogs.records | length > 0
+
+    # Pin a stable OOTB catalog. Do not use records[0]: on Australia, Admin Home
+    # is listed first and items_info: full can hit platform bugs on admin items.
+    - name: Select Technical Catalog for single-catalog tests
+      ansible.builtin.set_fact:
+        test_catalog: "{{ item }}"
+      when: item.title == "Technical Catalog"
+      loop: "{{ catalogs.records }}"
+
+    - ansible.builtin.assert:
+        that:
+          - test_catalog is defined
+          - test_catalog.title != "Admin Home"
+
     - name: Get one catalog only
       servicenow.itsm.service_catalog_info:
         categories: true
-        sys_id: "{{ catalogs.records[0].sys_id }}"
+        sys_id: "{{ test_catalog.sys_id }}"
       register: catalog
 
     - ansible.builtin.assert:
@@ -30,7 +43,7 @@
       servicenow.itsm.service_catalog_info:
         categories: true
         items_info: brief
-        sys_id: "{{ catalogs.records[0].sys_id }}"
+        sys_id: "{{ test_catalog.sys_id }}"
       register: catalog
 
     - ansible.builtin.assert:
@@ -39,13 +52,13 @@
           - catalog.records[0].categories | length > 0
           - catalog.records[0].sn_items is defined
           - catalog.records[0].sn_items | length > 0
-    
+
     - name: Get one catalog with item filtered -- should return none --
       servicenow.itsm.service_catalog_info:
         categories: false
         items_info: brief
         items_query: some_not_existent_field
-        sys_id: "{{ catalogs.records[0].sys_id }}"
+        sys_id: "{{ test_catalog.sys_id }}"
       register: catalog
 
     - ansible.builtin.assert:
@@ -59,7 +72,7 @@
       servicenow.itsm.service_catalog_info:
         categories: true
         items_info: full
-        sys_id: "{{ catalogs.records[0].sys_id }}"
+        sys_id: "{{ test_catalog.sys_id }}"
       register: catalog
 
     - ansible.builtin.assert:

--- a/tests/integration/targets/itsm_service_catalog_info/tasks/main.yml
+++ b/tests/integration/targets/itsm_service_catalog_info/tasks/main.yml
@@ -3,6 +3,7 @@
     SN_HOST: "{{ sn_host }}"
     SN_USERNAME: "{{ sn_username }}"
     SN_PASSWORD: "{{ sn_password }}"
+    SN_TIMEOUT: "{{ sn_timeout }}"
 
   block:
     - name: Get all catalogs

--- a/tests/integration/targets/prepare_test_vars/tasks/main.yml
+++ b/tests/integration/targets/prepare_test_vars/tasks/main.yml
@@ -13,3 +13,9 @@
 - name: Generate unique test ID
   ansible.builtin.set_fact:
     unique_test_id: "test-{{ lookup('password', '/dev/null chars=ascii_letters,digit length=6') | lower }}"
+
+# A higher timeout is needed for CI integration tests, since so many are running in parallel.
+- name: Set timeout
+  ansible.builtin.set_fact:
+    sn_timeout: 30
+  when: sn_timeout is not defined

--- a/tests/integration/targets/problem/tasks/main.yml
+++ b/tests/integration/targets/problem/tasks/main.yml
@@ -3,6 +3,7 @@
     SN_HOST: "{{ sn_host }}"
     SN_USERNAME: "{{ sn_username }}"
     SN_PASSWORD: "{{ sn_password }}"
+    SN_TIMEOUT: "{{ sn_timeout }}"
 
   block:
     - name: Create a problem (check mode)

--- a/tests/integration/targets/problem_task/tasks/main.yml
+++ b/tests/integration/targets/problem_task/tasks/main.yml
@@ -3,6 +3,7 @@
     SN_HOST: "{{ sn_host }}"
     SN_USERNAME: "{{ sn_username }}"
     SN_PASSWORD: "{{ sn_password }}"
+    SN_TIMEOUT: "{{ sn_timeout }}"
 
   block:
     - name: Create a problem

--- a/tests/integration/targets/problem_with_mapping/tasks/main.yml
+++ b/tests/integration/targets/problem_with_mapping/tasks/main.yml
@@ -3,6 +3,7 @@
     SN_HOST: "{{ sn_host }}"
     SN_USERNAME: "{{ sn_username }}"
     SN_PASSWORD: "{{ sn_password }}"
+    SN_TIMEOUT: "{{ sn_timeout }}"
 
   vars:
     mapping:


### PR DESCRIPTION
##### SUMMARY
Add support for ServiceNow **Australia** and drop **Xanadu**

There are a few other related but inconsequential changes:
- Added AI support files and related skills
- Had to increase timeouts to all tests on AUSTRALIA. There are SNOW support cases indicating this is a common issue, but no official statement. It could also be due to this instance being recently upgraded
- Added a note to service_catalog_info about an edge case issue that seems to be on SNOWs side in AUSTRALIA
- Updates the CI secret names to be tied to the instance ID and not the SNOW version, which will simplify changes in the future. I updated Xanadu/Australia in this PR for testing purposes, ill update the others in a different PR with other CI improvements

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
integration CI / collection compatibility
