### PR TITLE
Fix - table path ignores instance.api_path parameter

### DIFF
--- a/changelogs/fragments/fix_table_path_ignores_instance_api_path.yaml
+++ b/changelogs/fragments/fix_table_path_ignores_instance_api_path.yaml
@@ -1,6 +1,6 @@
 bugfixes:
   - table - ``TableClient.path()`` was hardcoding ``api/now/table`` as the base path,
-    silently ignoring the ``instance.api_path`` parameter introduced in 2.5.0. This
+    silently ignoring the ``instance.api_path`` parameter introduced in 2.4.0. This
     caused all Table API modules (incident, change_request, problem, etc.) to fail when
     routing through an API gateway that uses a custom base path (e.g.
     ``servicenow/v1/now``). The fix aligns ``TableClient.path()`` with the existing

--- a/changelogs/fragments/fix_table_path_ignores_instance_api_path.yaml
+++ b/changelogs/fragments/fix_table_path_ignores_instance_api_path.yaml
@@ -4,4 +4,4 @@ bugfixes:
     caused all Table API modules (incident, change_request, problem, etc.) to fail when
     routing through an API gateway that uses a custom base path (e.g.
     ``servicenow/v1/now``). The fix aligns ``TableClient.path()`` with the existing
-    correct pattern already used in ``attachment.py`` (github.com/ansible-collections/servicenow.itsm/issues/TODO).
+    correct pattern already used in ``attachment.py``

--- a/changelogs/fragments/fix_table_path_ignores_instance_api_path.yaml
+++ b/changelogs/fragments/fix_table_path_ignores_instance_api_path.yaml
@@ -1,0 +1,7 @@
+bugfixes:
+  - table - ``TableClient.path()`` was hardcoding ``api/now/table`` as the base path,
+    silently ignoring the ``instance.api_path`` parameter introduced in 2.5.0. This
+    caused all Table API modules (incident, change_request, problem, etc.) to fail when
+    routing through an API gateway that uses a custom base path (e.g.
+    ``servicenow/v1/now``). The fix aligns ``TableClient.path()`` with the existing
+    correct pattern already used in ``attachment.py`` (github.com/ansible-collections/servicenow.itsm/issues/TODO).

--- a/plugins/module_utils/table.py
+++ b/plugins/module_utils/table.py
@@ -59,7 +59,11 @@ class TableClient(snow.SNowClient):
             self.delete(self.path(table), record["sys_id"])
 
     def path(self, table, *subpaths):
-        return "/".join(list(self.client.api_path) + ["table", table] + list(itertools.chain(subpaths)))
+        return "/".join(
+            list(self.client.api_path)
+            + ["table", table]
+            + list(itertools.chain(subpaths))
+        )
 
 
 def find_user(table_client, user_id):

--- a/plugins/module_utils/table.py
+++ b/plugins/module_utils/table.py
@@ -59,7 +59,7 @@ class TableClient(snow.SNowClient):
             self.delete(self.path(table), record["sys_id"])
 
     def path(self, table, *subpaths):
-        return "/".join(["api/now/table", table] + list(itertools.chain(subpaths)))
+        return "/".join(list(self.client.api_path) + ["table", table] + list(itertools.chain(subpaths)))
 
 
 def find_user(table_client, user_id):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The instance.api_path configuration parameter is not taken into account in plugins/module_utils/table.py
This was introduced during the release of 2.5.0
Strangely it is correctly handled in plugins/module_utils/atthacment.py

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
I haven't opened the issue since I thought I should fix it.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
table.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

### instance config:
```
instance:
  host: "https://our_api_gw.example.com"
  username: "our_username"
  password: "our_password"
  custom_headers: { OUR_API_GW_TOKEN: "our_api_gw_token" }
  api_path: "servicenow/v1/now"
```

### before:
```
$ ansible-playbook -v test_business_unit.yml
No config file found; using defaults
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [localhost] ************************************************************************************************************************************************************************************************

TASK [Query business unit] **************************************************************************************************************************************************************************************
[ERROR]: Task failed: Module failed: 'result'
Origin: /mnt/c/Users/osuskya/Work/SNOW-TEST/test_business_unit.yml:7:7

5     - env_setup.yml
6   tasks:
7     - name: Query business unit
        ^ column 7

fatal: [localhost]: FAILED! => {"changed": false, "msg": "Task failed: Module failed: 'result'"}

PLAY RECAP ******************************************************************************************************************************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```
### after:
```
$ ansible-playbook -v test_business_unit.yml
No config file found; using defaults
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [localhost] ************************************************************************************************************************************************************************************************

TASK [Query business unit] **************************************************************************************************************************************************************************************
ok: ...
...
...
TASK [debug] ****************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": [
        {
            "name": "Name1",
            "sys_id": "065ba32f8793f8103e49b95f8bbb3536"
        },
        {
            "name": "Name2",
            "sys_id": "128d90351b15a910c0b8986cbc4bcb53"
        },
        ...
        }
    ]
}

```
