### PR TITLE
fix ci id issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,8 @@ sanity: install-collection linters
 units: install-collection
 	cd ~/.ansible/collections/ansible_collections/servicenow/itsm; \
 	ansible-test units --docker --coverage --python "$(PYTHON_VERSION)" $(TARGET); \
-	ansible-test coverage combine --export tests/output/coverage/; \
-	ansible-test coverage report --docker --omit 'tests/*' --show-missing
+	ansible-test coverage combine --requirements --export tests/output/coverage/; \
+	ansible-test coverage report --requirements --docker --omit 'tests/*' --show-missing
 
 ## Run integration tests
 .PHONY: integration

--- a/changelogs/fragments/507-configuration-item-id-column-set.yaml
+++ b/changelogs/fragments/507-configuration-item-id-column-set.yaml
@@ -1,0 +1,5 @@
+bugfixes:
+  - configuration_item - Added ``id_column_set`` parameter to specify which columns
+    identify an existing record, fixing failures when using tables like ``cmdb_rel_ci``
+    where ``name`` is not a unique identifier
+    (https://github.com/ansible-collections/servicenow.itsm/issues/507).

--- a/plugins/modules/configuration_item.py
+++ b/plugins/modules/configuration_item.py
@@ -113,6 +113,17 @@ options:
       - Expected value for I(assigned_to) is user id (usually in the form of
         C(first_name.last_name)).
     type: str
+  id_column_set:
+    description:
+      - Columns that should be used to identify an existing record.
+      - When not specified, records are identified by C(sys_id) or C(name).
+      - Use this for CMDB tables where C(name) is not a unique identifier, such as C(cmdb_rel_ci),
+        where records are identified by a combination of columns like C(parent), C(child), and
+        C(type).
+      - The column values are sourced from the I(other) parameter or from top-level module parameters.
+    type: list
+    elements: str
+    version_added: "2.7.0"
   other:
     description:
       - Any of the remaining configuration parameters.
@@ -153,6 +164,18 @@ EXAMPLES = r"""
   servicenow.itsm.configuration_item:
     sys_id: "{{ server.record.sys_id }}"
     state: absent
+
+- name: Create a CI relationship using id_column_set
+  servicenow.itsm.configuration_item:
+    sys_class_name: cmdb_rel_ci
+    id_column_set:
+      - parent
+      - child
+      - type
+    other:
+      parent: "{{ parent_ci_sys_id }}"
+      child: "{{ child_ci_sys_id }}"
+      type: "{{ relationship_type_sys_id }}"
 """
 
 RETURN = r"""
@@ -288,9 +311,31 @@ DIRECT_PAYLOAD_FIELDS = (
 )
 
 
+def build_identity_query(module):
+    id_column_set = module.params.get("id_column_set")
+    if not id_column_set:
+        return None
+
+    query = {}
+    other = module.params.get("other") or {}
+    for col in id_column_set:
+        if col in module.params and module.params[col] is not None:
+            query[col] = module.params[col]
+        elif col in other:
+            query[col] = other[col]
+        else:
+            raise errors.ServiceNowError(
+                "id_column_set column '{0}' is not provided in module "
+                "parameters or 'other'.".format(col)
+            )
+    return query
+
+
 def ensure_absent(module, table_client, attachment_client):
     mapper = get_mapper(module, "configuration_item_mapping", PAYLOAD_FIELDS_MAPPING)
-    query = utils.filter_dict(module.params, "sys_id", "name")
+    query = build_identity_query(module)
+    if query is None:
+        query = utils.filter_dict(module.params, "sys_id", "name")
     cmdb_table = module.params["sys_class_name"]
     configuration_item = table_client.get_record(cmdb_table, query)
 
@@ -327,13 +372,16 @@ def ensure_present(module, table_client, attachment_client):
     mapper = get_mapper(module, "configuration_item_mapping", PAYLOAD_FIELDS_MAPPING)
     query_sys_id = utils.filter_dict(module.params, "sys_id")
     query_name = utils.filter_dict(module.params, "name")
+    identity_query = build_identity_query(module)
     payload = build_payload(module, table_client)
     attachments = attachment.transform_metadata_list(
         module.params["attachments"], module.sha256
     )
 
+    lookup_query = identity_query or query_name
+
     if not query_sys_id:
-        configuration_item = table_client.get_record(cmdb_table, query_name)
+        configuration_item = table_client.get_record(cmdb_table, lookup_query)
         # User did not specify existing CI, so we need to create a new one.
         if not configuration_item:
             new = mapper.to_ansible(
@@ -353,7 +401,7 @@ def ensure_present(module, table_client, attachment_client):
             return True, new, dict(before=None, after=new)
 
         else:
-            # Get existing record using provided name
+            # Get existing record using provided name or identity query
             old = mapper.to_ansible(configuration_item)
 
     else:
@@ -361,8 +409,8 @@ def ensure_present(module, table_client, attachment_client):
         old = mapper.to_ansible(
             table_client.get_record(cmdb_table, query_sys_id, must_exist=True)
         )
-        # Check if provided name already exists
-        if query_name:
+        # Check if provided name already exists (skip when using id_column_set)
+        if query_name and not identity_query:
             configuration_item = table_client.get_record(
                 old["sys_class_name"], query_name
             )
@@ -381,7 +429,7 @@ def ensure_present(module, table_client, attachment_client):
     if cmdb_table != "cmdb_ci":
         old = mapper.to_ansible(
             table_client.get_record(
-                cmdb_table, query_sys_id or query_name, must_exist=True
+                cmdb_table, query_sys_id or lookup_query, must_exist=True
             )
         )
 
@@ -467,6 +515,10 @@ def main():
         assigned_to=dict(
             type="str",
         ),
+        id_column_set=dict(
+            type="list",
+            elements="str",
+        ),
         other=dict(
             type="dict",
         ),
@@ -479,6 +531,7 @@ def main():
             (
                 "sys_id",
                 "name",
+                "id_column_set",
             ),
         ],
     )

--- a/tests/integration/targets/itsm_service_catalog/tasks/main.yml
+++ b/tests/integration/targets/itsm_service_catalog/tasks/main.yml
@@ -26,6 +26,24 @@
           title: Demo user
       register: user
 
+    - name: Get snc_basic_auth_api_access role
+      servicenow.itsm.api:
+        resource: sys_user_role
+        action: get
+        query_params:
+          sysparm_query: "name=snc_basic_auth_api_access"
+          sysparm_fields: "sys_id"
+          sysparm_limit: "1"
+      register: basic_auth_role
+
+    - name: Assign snc_basic_auth_api_access role to user
+      servicenow.itsm.api:
+        resource: sys_user_has_role
+        action: post
+        data:
+          user: "{{ user.record.sys_id }}"
+          role: "{{ basic_auth_role.record[0].sys_id }}"
+
     - name: Get all catalogs
       servicenow.itsm.service_catalog_info:
       environment:

--- a/tests/unit/plugins/modules/test_configuration_item.py
+++ b/tests/unit/plugins/modules/test_configuration_item.py
@@ -197,6 +197,49 @@ class TestEnsureAbsent:
         table_client.delete_record.assert_not_called()
         assert result == (False, None, dict(before=None, after=None))
 
+    def test_delete_configuration_item_using_id_column_set(
+        self, create_module, table_client, attachment_client
+    ):
+        module = create_module(
+            params=dict(
+                instance=dict(
+                    host="https://my.host.name", username="user", password="pass"
+                ),
+                state="absent",
+                name=None,
+                sys_id=None,
+                sys_class_name="cmdb_rel_ci",
+                id_column_set=["parent", "child", "type"],
+                other=dict(
+                    parent="parent_sys_id",
+                    child="child_sys_id",
+                    type="rel_type_sys_id",
+                ),
+            )
+        )
+        table_client.get_record.return_value = dict(
+            sys_class_name="cmdb_rel_ci",
+            sys_id="rel_record_sys_id",
+            parent="parent_sys_id",
+            child="child_sys_id",
+            type="rel_type_sys_id",
+        )
+
+        result = configuration_item.ensure_absent(
+            module, table_client, attachment_client
+        )
+
+        table_client.get_record.assert_called_once_with(
+            "cmdb_rel_ci",
+            {
+                "parent": "parent_sys_id",
+                "child": "child_sys_id",
+                "type": "rel_type_sys_id",
+            },
+        )
+        table_client.delete_record.assert_called_once()
+        assert result[0] is True
+
 
 class TestBuildPayload:
     def test_build_payload(self, create_module, table_client):
@@ -762,6 +805,161 @@ class TestEnsurePresent:
         ):
             configuration_item.ensure_present(module, table_client, attachment_client)
 
+    def test_ensure_present_create_new_with_id_column_set(
+        self, create_module, table_client, attachment_client
+    ):
+        module = create_module(
+            params=dict(
+                instance=dict(
+                    host="https://my.host.name", username="user", password="pass"
+                ),
+                state="present",
+                sys_id=None,
+                name=None,
+                short_description=None,
+                sys_class_name="cmdb_rel_ci",
+                assigned_to=None,
+                asset_tag=None,
+                install_status=None,
+                operational_status=None,
+                serial_number=None,
+                ip_address=None,
+                mac_address=None,
+                category=None,
+                environment=None,
+                id_column_set=["parent", "child", "type"],
+                other=dict(
+                    parent="parent_sys_id",
+                    child="child_sys_id",
+                    type="rel_type_sys_id",
+                ),
+                attachments=None,
+            ),
+        )
+        table_client.get_record.return_value = {}
+        table_client.create_record.return_value = dict(
+            sys_class_name="cmdb_rel_ci",
+            sys_id="new_rel_sys_id",
+            parent="parent_sys_id",
+            child="child_sys_id",
+            type="rel_type_sys_id",
+        )
+        attachment_client.upload_records.return_value = []
+
+        result = configuration_item.ensure_present(
+            module, table_client, attachment_client
+        )
+
+        table_client.get_record.assert_called_once_with(
+            "cmdb_rel_ci",
+            {
+                "parent": "parent_sys_id",
+                "child": "child_sys_id",
+                "type": "rel_type_sys_id",
+            },
+        )
+        table_client.create_record.assert_called_once()
+        assert result[0] is True
+
+    def test_ensure_present_update_with_id_column_set(
+        self, mocker, create_module, table_client, attachment_client
+    ):
+        module = create_module(
+            params=dict(
+                instance=dict(
+                    host="https://my.host.name", username="user", password="pass"
+                ),
+                state="present",
+                sys_id=None,
+                name=None,
+                short_description=None,
+                sys_class_name="cmdb_rel_ci",
+                assigned_to=None,
+                asset_tag=None,
+                install_status=None,
+                operational_status=None,
+                serial_number=None,
+                ip_address=None,
+                mac_address=None,
+                category=None,
+                environment=None,
+                id_column_set=["parent", "child", "type"],
+                other=dict(
+                    parent="parent_sys_id",
+                    child="child_sys_id",
+                    type="rel_type_sys_id",
+                ),
+                attachments=None,
+            ),
+        )
+        payload_mocker = mocker.patch.object(configuration_item, "build_payload")
+        payload_mocker.return_value = dict(
+            parent="parent_sys_id",
+            child="child_sys_id",
+            type="rel_type_sys_id",
+            sys_class_name="cmdb_rel_ci",
+        )
+        table_client.get_record.return_value = dict(
+            sys_id="existing_rel_sys_id",
+            sys_class_name="cmdb_rel_ci",
+            parent="parent_sys_id",
+            child="child_sys_id",
+            type="rel_type_sys_id",
+        )
+        table_client.update_record.return_value = dict(
+            sys_id="existing_rel_sys_id",
+            sys_class_name="cmdb_rel_ci",
+            parent="parent_sys_id",
+            child="child_sys_id",
+            type="rel_type_sys_id",
+        )
+        attachment_client.update_records.return_value = []
+        attachment_client.list_records.return_value = []
+
+        result = configuration_item.ensure_present(
+            module, table_client, attachment_client
+        )
+
+        table_client.get_record.assert_called()
+        assert result[0] is False
+
+    def test_ensure_present_id_column_set_missing_column(
+        self, create_module, table_client, attachment_client
+    ):
+        module = create_module(
+            params=dict(
+                instance=dict(
+                    host="https://my.host.name", username="user", password="pass"
+                ),
+                state="present",
+                sys_id=None,
+                name=None,
+                short_description=None,
+                sys_class_name="cmdb_rel_ci",
+                assigned_to=None,
+                asset_tag=None,
+                install_status=None,
+                operational_status=None,
+                serial_number=None,
+                ip_address=None,
+                mac_address=None,
+                category=None,
+                environment=None,
+                id_column_set=["parent", "child", "type"],
+                other=dict(
+                    parent="parent_sys_id",
+                    child="child_sys_id",
+                ),
+                attachments=None,
+            ),
+        )
+
+        with pytest.raises(
+            errors.ServiceNowError,
+            match="id_column_set column 'type' is not provided",
+        ):
+            configuration_item.ensure_present(module, table_client, attachment_client)
+
 
 class TestMain:
     def test_minimal_set_of_params_sys_id(self, run_main):
@@ -815,12 +1013,33 @@ class TestMain:
 
         assert success is True
 
+    def test_minimal_set_of_params_id_column_set(self, run_main):
+        params = dict(
+            instance=dict(
+                host="https://my.host.name", username="user", password="pass"
+            ),
+            id_column_set=["parent", "child", "type"],
+            sys_class_name="cmdb_rel_ci",
+            other=dict(
+                parent="parent_sys_id",
+                child="child_sys_id",
+                type="rel_type_sys_id",
+            ),
+        )
+        with set_module_args(args=params):
+            success, result = run_main(configuration_item, params)
+
+        assert success is True
+
     def test_fail(self, run_main):
         with set_module_args(args={}):
             success, result = run_main(configuration_item)
 
         assert success is False
-        assert "one of the following is required: sys_id, name" in result["msg"]
+        assert (
+            "one of the following is required: sys_id, name, id_column_set"
+            in result["msg"]
+        )
 
 
 class TestRun:


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/servicenow.itsm/issues/507

This change fixes a bug where configuration items were not able to be uniquely identified, depending on the table used.
The solution is to add a new parameter where the user can specify one or more fields that can be used to identify a record. This method is already implemented in other modules.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
configuration_item
