### PR TITLE
remove redundant test

### DIFF
--- a/plugins/modules/configuration_item.py
+++ b/plugins/modules/configuration_item.py
@@ -49,6 +49,8 @@ options:
     description:
       - The name of the configuration item.
       - Required if the configuration item does not yet exist.
+      - If both I(sys_id) and name are provided during C(absent) operations, the name is ignored since
+        sys_id is a unique identifier.
     type: str
   short_description:
     description:

--- a/tests/integration/targets/itsm_configuration_item/tasks/main.yml
+++ b/tests/integration/targets/itsm_configuration_item/tasks/main.yml
@@ -229,16 +229,6 @@
         that:
           - result.records | length == 1
 
-    - name: Delete configuration item using sys_id and wrong name
-      servicenow.itsm.configuration_item:
-        sys_id: "{{ base_ci.record.sys_id }}"
-        name: "wrong_name"
-        state: absent
-      register: result
-    - ansible.builtin.assert:
-        that:
-          - result is not changed
-
     - name: Delete configuration item using name and wrong sys_id
       servicenow.itsm.configuration_item:
         sys_id: "wrong_sys_id"


### PR DESCRIPTION
##### SUMMARY
Removing redundant test from configuration_item. It was missed due to test complexity that has since been removed

##### ISSUE TYPE
- Docs Pull Request

