### PR TITLE
ensure custom headers are added to all requests

### DIFF
--- a/changelogs/fragments/556-add-custom-headers-to-all.yml
+++ b/changelogs/fragments/556-add-custom-headers-to-all.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - client - Ensures that any specified instance.custom_headers are added to all requests, not just some

--- a/plugins/module_utils/client.py
+++ b/plugins/module_utils/client.py
@@ -305,6 +305,8 @@ class Client:
             self._refresh_connection()
 
         self._log(f"ServiceNow: {method} {path}")
+        if self.custom_headers:
+            headers = dict(headers or {}, **self.custom_headers)
 
         request_kwargs = {
             "data": data,
@@ -380,8 +382,6 @@ class Client:
         if query:
             url = "{0}?{1}".format(url, urlencode(query))
         headers = dict(headers or DEFAULT_HEADERS, **self.auth_header)
-        if self.custom_headers:
-            headers = dict(headers, **self.custom_headers)
         if data is not None:
             data = json.dumps(data, separators=(",", ":"))
             headers["Content-type"] = "application/json"


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/servicenow.itsm/issues/556

The modules allow you to specify custom headers for API requests. This is useful for customer that use proxies or network filters. However, the current implementation only adds the headers to some requests. This change ensures that headers are added to all requests.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
client