### PR TITLE
Add multi-hop relationship traversal to now inventory plugin

### DIFF
--- a/changelogs/fragments/inventory-multihop-enhancer-refactor.yml
+++ b/changelogs/fragments/inventory-multihop-enhancer-refactor.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - now inventory - Added multi-hop enhanced logic to group hosts based on distant relationships

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -115,6 +115,63 @@ options:
       - If this is unset, the value of the O(sysparm_limit) and its relevant defaults will be used.
     type: int
     version_added: 2.11.0
+  enhanced_multihop:
+    description:
+      - Enable multi-hop relationship traversal when building enhanced inventory groups.
+      - When enabled, the plugin walks the CMDB relationship graph beyond immediate (single-hop)
+        relationships to discover ancestor or descendant CIs and create groups for them.
+      - This is useful for CSDM / Tag-Based Application Service models where the automation target
+        (e.g. Application Service) is two or more hops above the server CI.
+      - Requires I(enhanced=true).
+      - Single-hop groups are always created; multi-hop groups are added on top.
+    type: bool
+    default: false
+    version_added: 2.16.0
+  enhanced_multihop_max_depth:
+    description:
+      - Maximum number of relationship hops to traverse when I(enhanced) is enabled.
+      - A value of 1 is equivalent to the default (single-hop) behavior.
+      - Higher values allow deeper graph traversal but may increase processing time or memory
+        usage for large CMDBs.
+      - Must be greater than 1.
+    type: int
+    default: 1
+    version_added: 2.16.0
+  enhanced_multihop_direction:
+    description:
+      - Direction to walk the relationship graph when I(enhanced_multihop) is enabled.
+      - V(up) follows parent edges (child to parent to grandparent). This is the typical
+        CSDM use case where servers need to be grouped by ancestor Application Services.
+      - V(down) follows child edges (parent to child to grandchild).
+      - V(both) walks in both directions.
+    type: str
+    choices: ['up', 'down', 'both']
+    default: up
+    version_added: 2.16.0
+  enhanced_multihop_target_classes:
+    description:
+      - When non-empty, only create multi-hop groups for CIs whose C(sys_class_name) matches one of
+        these values.
+      - Traversal continues through non-matching intermediate CIs so that ancestors beyond them
+        can still be reached.
+      - For example, setting this to V(["cmdb_ci_service_auto"]) would only create groups for
+        Application Service CIs, skipping intermediate Application CIs.
+      - When empty (the default), groups are created for all CIs found during traversal.
+    type: list
+    elements: str
+    default: []
+    version_added: 2.16.0
+  enhanced_multihop_relationship_types:
+    description:
+      - When non-empty, only follow relationship edges whose C(type.name) matches one of these values
+        during multi-hop traversal.
+      - This restricts which relationship types are walked, for example
+        V(["Contains::Contained by", "Depends on::Used by"]).
+      - When empty (the default), all relationship types are followed.
+    type: list
+    elements: str
+    default: []
+    version_added: 2.16.0
   aggregation:
     description:
       - Enable multiple variable values aggregations.
@@ -485,6 +542,46 @@ keyed_groups:
 # |  |--node2
 # |  |--node3
 # |  |--node1
+
+# Multi-hop CMDB relationship traversal for CSDM / Tag-Based Application Services.
+# Groups servers by their Application Service (2 hops up: Server -> Application -> Service).
+# Only creates groups for Application Service CIs (cmdb_ci_service_auto), skipping
+# intermediate Application CIs during traversal.
+---
+plugin: servicenow.itsm.now
+table: cmdb_ci_server
+enhanced: true
+enhanced_multihop: true
+enhanced_multihop_max_depth: 3
+enhanced_multihop_direction: up
+enhanced_multihop_target_classes:
+  - cmdb_ci_service_auto
+columns:
+  - name
+  - ip_address
+
+# `ansible-inventory -i inventory.now.yaml --graph` output:
+# @all:
+#  |--@TAG_Finance_Core_Contains:
+#  |  |--srv-prod-chat-01
+#  |  |--srv-prod-chat-02
+#  |--@APP_Cisco_Chat_Used_by:
+#  |  |--srv-prod-chat-01
+#  |  |--srv-prod-chat-02
+#  |--@ungrouped:
+
+# Multi-hop traversal with relationship type filtering.
+# Only follows "Contains::Contained by" relationships during traversal.
+---
+plugin: servicenow.itsm.now
+table: cmdb_ci_server
+enhanced: true
+enhanced_multihop: true
+enhanced_multihop_relationship_types:
+  - "Contains::Contained by"
+columns:
+  - name
+  - ip_address
 """
 
 
@@ -508,6 +605,7 @@ from ..module_utils.relations import (
     REL_QUERY,
     REL_TABLE,
     enhance_records_with_rel_groups,
+    enhance_records_with_multihop_groups,
 )
 from ..module_utils.table import TableClient
 from ..module_utils.instance_config import merge_env_with_param_instance
@@ -816,9 +914,14 @@ class InventoryModule(BaseInventoryPlugin, ConstructableWithLookup, Cacheable):
     def __ingest_inventory_config(self, path, cache):
         self._read_config_data(path)
         self.cache_key = self.get_cache_key(path)
+        host = self._get_instance()["host"]
+        if not host:
+            raise AnsibleParserError(
+                "Instance parameter 'host' is required but is not set."
+            )
         self._cache_sub_key = "/".join(
             [
-                self._get_instance()["host"].rstrip("/"),
+                host.rstrip("/"),
                 "table",
                 self.get_option("table"),
                 self._construct_cache_suffix(),
@@ -888,6 +991,21 @@ class InventoryModule(BaseInventoryPlugin, ConstructableWithLookup, Cacheable):
             is_encoded_query=bool(enhanced_sysparm_query),
         )
         enhance_records_with_rel_groups(records, rel_records)
+
+        max_depth = self.get_option("enhanced_multihop_max_depth")
+        if max_depth < 1:
+            raise AnsibleParserError(
+                "Option 'enhanced_multihop_max_depth' must be greater than 0."
+            )
+        elif max_depth > 1:
+            enhance_records_with_multihop_groups(
+                records,
+                rel_records,
+                direction=self.get_option("enhanced_multihop_direction"),
+                max_depth=max_depth,
+                ci_classes=self.get_option("enhanced_multihop_target_classes"),
+                rel_types=self.get_option("enhanced_multihop_relationship_types"),
+            )
 
     def __create_table_client(self):
         try:

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -989,7 +989,9 @@ class InventoryModule(BaseInventoryPlugin, ConstructableWithLookup, Cacheable):
             relationship_records=rel_records,
             max_hop_depth=max_depth,
             multi_hop_direction=self.get_option("enhanced_multihop_direction"),
-            multi_hop_relationship_types=self.get_option("enhanced_multihop_relationship_types"),
+            multi_hop_relationship_types=self.get_option(
+                "enhanced_multihop_relationship_types"
+            ),
             multi_hop_ci_classes=self.get_option("enhanced_multihop_target_classes"),
         )
         record_enhancer.enhance_records_with_relationship_groups(records=records)

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -115,31 +115,22 @@ options:
       - If this is unset, the value of the O(sysparm_limit) and its relevant defaults will be used.
     type: int
     version_added: 2.11.0
-  enhanced_multihop:
-    description:
-      - Enable multi-hop relationship traversal when building enhanced inventory groups.
-      - When enabled, the plugin walks the CMDB relationship graph beyond immediate (single-hop)
-        relationships to discover ancestor or descendant CIs and create groups for them.
-      - This is useful for CSDM / Tag-Based Application Service models where the automation target
-        (e.g. Application Service) is two or more hops above the server CI.
-      - Requires I(enhanced=true).
-      - Single-hop groups are always created; multi-hop groups are added on top.
-    type: bool
-    default: false
-    version_added: 2.16.0
   enhanced_multihop_max_depth:
     description:
       - Maximum number of relationship hops to traverse when I(enhanced) is enabled.
-      - A value of 1 is equivalent to the default (single-hop) behavior.
+      - When greater than 1, the plugin walks the CMDB relationship graph beyond immediate (single-hop)
+        relationships to discover ancestor or descendant CIs and create groups for them.
+      - This is useful for CSDM / Tag-Based Application Service models where the automation target
+        (e.g. Application Service) is two or more hops above the server CI.
       - Higher values allow deeper graph traversal but may increase processing time or memory
         usage for large CMDBs.
-      - Must be greater than 1.
+      - Must be greater than 0.
     type: int
     default: 1
     version_added: 2.16.0
   enhanced_multihop_direction:
     description:
-      - Direction to walk the relationship graph when I(enhanced_multihop) is enabled.
+      - Direction to walk the relationship graph when I(enhanced_multihop_max_depth) is greater than 1.
       - V(up) follows parent edges (child to parent to grandparent). This is the typical
         CSDM use case where servers need to be grouped by ancestor Application Services.
       - V(down) follows child edges (parent to child to grandchild).
@@ -215,7 +206,6 @@ options:
     type: int
     default: 1000
     version_added: 2.5.0
-
 """
 
 EXAMPLES = r"""
@@ -551,7 +541,6 @@ keyed_groups:
 plugin: servicenow.itsm.now
 table: cmdb_ci_server
 enhanced: true
-enhanced_multihop: true
 enhanced_multihop_max_depth: 3
 enhanced_multihop_direction: up
 enhanced_multihop_target_classes:
@@ -576,7 +565,7 @@ columns:
 plugin: servicenow.itsm.now
 table: cmdb_ci_server
 enhanced: true
-enhanced_multihop: true
+enhanced_multihop_depth: 3
 enhanced_multihop_relationship_types:
   - "Contains::Contained by"
 columns:
@@ -604,8 +593,7 @@ from ..module_utils.relations import (
     REL_FIELDS,
     REL_QUERY,
     REL_TABLE,
-    enhance_records_with_rel_groups,
-    enhance_records_with_multihop_groups,
+    RecordRelationshipEnhancer,
 )
 from ..module_utils.table import TableClient
 from ..module_utils.instance_config import merge_env_with_param_instance
@@ -990,22 +978,21 @@ class InventoryModule(BaseInventoryPlugin, ConstructableWithLookup, Cacheable):
             ),
             is_encoded_query=bool(enhanced_sysparm_query),
         )
-        enhance_records_with_rel_groups(records, rel_records)
 
         max_depth = self.get_option("enhanced_multihop_max_depth")
         if max_depth < 1:
             raise AnsibleParserError(
                 "Option 'enhanced_multihop_max_depth' must be greater than 0."
             )
-        elif max_depth > 1:
-            enhance_records_with_multihop_groups(
-                records,
-                rel_records,
-                direction=self.get_option("enhanced_multihop_direction"),
-                max_depth=max_depth,
-                ci_classes=self.get_option("enhanced_multihop_target_classes"),
-                rel_types=self.get_option("enhanced_multihop_relationship_types"),
-            )
+
+        record_enhancer = RecordRelationshipEnhancer(
+            relationship_records=rel_records,
+            max_hop_depth=max_depth,
+            multi_hop_direction=self.get_option("enhanced_multihop_direction"),
+            multi_hop_relationship_types=self.get_option("enhanced_multihop_relationship_types"),
+            multi_hop_ci_classes=self.get_option("enhanced_multihop_target_classes"),
+        )
+        record_enhancer.enhance_records_with_relationship_groups(records=records)
 
     def __create_table_client(self):
         try:

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -1131,7 +1131,9 @@ class InventoryModule(BaseInventoryPlugin, ConstructableWithLookup, Cacheable):
             relationship_records=rel_records,
             max_hop_depth=max_depth,
             multi_hop_direction=self.get_option("enhanced_multihop_direction"),
-            multi_hop_relationship_types=self.get_option("enhanced_multihop_relationship_types"),
+            multi_hop_relationship_types=self.get_option(
+                "enhanced_multihop_relationship_types"
+            ),
             multi_hop_ci_classes=self.get_option("enhanced_multihop_target_classes"),
         )
         record_enhancer.enhance_records_with_relationship_groups(records=records)

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -565,7 +565,7 @@ columns:
 plugin: servicenow.itsm.now
 table: cmdb_ci_server
 enhanced: true
-enhanced_multihop_depth: 3
+enhanced_multihop_max_depth: 3
 enhanced_multihop_relationship_types:
   - "Contains::Contained by"
 columns:

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -210,31 +210,22 @@ options:
       - If this is unset, the value of the O(sysparm_limit) and its relevant defaults will be used.
     type: int
     version_added: 2.11.0
-  enhanced_multihop:
-    description:
-      - Enable multi-hop relationship traversal when building enhanced inventory groups.
-      - When enabled, the plugin walks the CMDB relationship graph beyond immediate (single-hop)
-        relationships to discover ancestor or descendant CIs and create groups for them.
-      - This is useful for CSDM / Tag-Based Application Service models where the automation target
-        (e.g. Application Service) is two or more hops above the server CI.
-      - Requires I(enhanced=true).
-      - Single-hop groups are always created; multi-hop groups are added on top.
-    type: bool
-    default: false
-    version_added: 2.16.0
   enhanced_multihop_max_depth:
     description:
       - Maximum number of relationship hops to traverse when I(enhanced) is enabled.
-      - A value of 1 is equivalent to the default (single-hop) behavior.
+      - When greater than 1, the plugin walks the CMDB relationship graph beyond immediate (single-hop)
+        relationships to discover ancestor or descendant CIs and create groups for them.
+      - This is useful for CSDM / Tag-Based Application Service models where the automation target
+        (e.g. Application Service) is two or more hops above the server CI.
       - Higher values allow deeper graph traversal but may increase processing time or memory
         usage for large CMDBs.
-      - Must be greater than 1.
+      - Must be greater than 0.
     type: int
     default: 1
     version_added: 2.16.0
   enhanced_multihop_direction:
     description:
-      - Direction to walk the relationship graph when I(enhanced_multihop) is enabled.
+      - Direction to walk the relationship graph when I(enhanced_multihop_max_depth) is greater than 1.
       - V(up) follows parent edges (child to parent to grandparent). This is the typical
         CSDM use case where servers need to be grouped by ancestor Application Services.
       - V(down) follows child edges (parent to child to grandchild).
@@ -310,7 +301,6 @@ options:
     type: int
     default: 1000
     version_added: 2.5.0
-
 """
 
 EXAMPLES = r"""
@@ -646,7 +636,6 @@ keyed_groups:
 plugin: servicenow.itsm.now
 table: cmdb_ci_server
 enhanced: true
-enhanced_multihop: true
 enhanced_multihop_max_depth: 3
 enhanced_multihop_direction: up
 enhanced_multihop_target_classes:
@@ -671,7 +660,7 @@ columns:
 plugin: servicenow.itsm.now
 table: cmdb_ci_server
 enhanced: true
-enhanced_multihop: true
+enhanced_multihop_depth: 3
 enhanced_multihop_relationship_types:
   - "Contains::Contained by"
 columns:
@@ -700,8 +689,7 @@ from ..module_utils.relations import (
     REL_FIELDS,
     REL_QUERY,
     REL_TABLE,
-    enhance_records_with_rel_groups,
-    enhance_records_with_multihop_groups,
+    RecordRelationshipEnhancer,
 )
 from ..module_utils.table import TableClient
 
@@ -1132,22 +1120,21 @@ class InventoryModule(BaseInventoryPlugin, ConstructableWithLookup, Cacheable):
             ),
             is_encoded_query=bool(enhanced_sysparm_query),
         )
-        enhance_records_with_rel_groups(records, rel_records)
 
         max_depth = self.get_option("enhanced_multihop_max_depth")
         if max_depth < 1:
             raise AnsibleParserError(
                 "Option 'enhanced_multihop_max_depth' must be greater than 0."
             )
-        elif max_depth > 1:
-            enhance_records_with_multihop_groups(
-                records,
-                rel_records,
-                direction=self.get_option("enhanced_multihop_direction"),
-                max_depth=max_depth,
-                ci_classes=self.get_option("enhanced_multihop_target_classes"),
-                rel_types=self.get_option("enhanced_multihop_relationship_types"),
-            )
+
+        record_enhancer = RecordRelationshipEnhancer(
+            relationship_records=rel_records,
+            max_hop_depth=max_depth,
+            multi_hop_direction=self.get_option("enhanced_multihop_direction"),
+            multi_hop_relationship_types=self.get_option("enhanced_multihop_relationship_types"),
+            multi_hop_ci_classes=self.get_option("enhanced_multihop_target_classes"),
+        )
+        record_enhancer.enhance_records_with_relationship_groups(records=records)
 
     def __create_table_client(self):
         try:

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -210,6 +210,63 @@ options:
       - If this is unset, the value of the O(sysparm_limit) and its relevant defaults will be used.
     type: int
     version_added: 2.11.0
+  enhanced_multihop:
+    description:
+      - Enable multi-hop relationship traversal when building enhanced inventory groups.
+      - When enabled, the plugin walks the CMDB relationship graph beyond immediate (single-hop)
+        relationships to discover ancestor or descendant CIs and create groups for them.
+      - This is useful for CSDM / Tag-Based Application Service models where the automation target
+        (e.g. Application Service) is two or more hops above the server CI.
+      - Requires I(enhanced=true).
+      - Single-hop groups are always created; multi-hop groups are added on top.
+    type: bool
+    default: false
+    version_added: 2.16.0
+  enhanced_multihop_max_depth:
+    description:
+      - Maximum number of relationship hops to traverse when I(enhanced) is enabled.
+      - A value of 1 is equivalent to the default (single-hop) behavior.
+      - Higher values allow deeper graph traversal but may increase processing time or memory
+        usage for large CMDBs.
+      - Must be greater than 1.
+    type: int
+    default: 1
+    version_added: 2.16.0
+  enhanced_multihop_direction:
+    description:
+      - Direction to walk the relationship graph when I(enhanced_multihop) is enabled.
+      - V(up) follows parent edges (child to parent to grandparent). This is the typical
+        CSDM use case where servers need to be grouped by ancestor Application Services.
+      - V(down) follows child edges (parent to child to grandchild).
+      - V(both) walks in both directions.
+    type: str
+    choices: ['up', 'down', 'both']
+    default: up
+    version_added: 2.16.0
+  enhanced_multihop_target_classes:
+    description:
+      - When non-empty, only create multi-hop groups for CIs whose C(sys_class_name) matches one of
+        these values.
+      - Traversal continues through non-matching intermediate CIs so that ancestors beyond them
+        can still be reached.
+      - For example, setting this to V(["cmdb_ci_service_auto"]) would only create groups for
+        Application Service CIs, skipping intermediate Application CIs.
+      - When empty (the default), groups are created for all CIs found during traversal.
+    type: list
+    elements: str
+    default: []
+    version_added: 2.16.0
+  enhanced_multihop_relationship_types:
+    description:
+      - When non-empty, only follow relationship edges whose C(type.name) matches one of these values
+        during multi-hop traversal.
+      - This restricts which relationship types are walked, for example
+        V(["Contains::Contained by", "Depends on::Used by"]).
+      - When empty (the default), all relationship types are followed.
+    type: list
+    elements: str
+    default: []
+    version_added: 2.16.0
   aggregation:
     description:
       - Enable multiple variable values aggregations.
@@ -580,6 +637,46 @@ keyed_groups:
 # |  |--node2
 # |  |--node3
 # |  |--node1
+
+# Multi-hop CMDB relationship traversal for CSDM / Tag-Based Application Services.
+# Groups servers by their Application Service (2 hops up: Server -> Application -> Service).
+# Only creates groups for Application Service CIs (cmdb_ci_service_auto), skipping
+# intermediate Application CIs during traversal.
+---
+plugin: servicenow.itsm.now
+table: cmdb_ci_server
+enhanced: true
+enhanced_multihop: true
+enhanced_multihop_max_depth: 3
+enhanced_multihop_direction: up
+enhanced_multihop_target_classes:
+  - cmdb_ci_service_auto
+columns:
+  - name
+  - ip_address
+
+# `ansible-inventory -i inventory.now.yaml --graph` output:
+# @all:
+#  |--@TAG_Finance_Core_Contains:
+#  |  |--srv-prod-chat-01
+#  |  |--srv-prod-chat-02
+#  |--@APP_Cisco_Chat_Used_by:
+#  |  |--srv-prod-chat-01
+#  |  |--srv-prod-chat-02
+#  |--@ungrouped:
+
+# Multi-hop traversal with relationship type filtering.
+# Only follows "Contains::Contained by" relationships during traversal.
+---
+plugin: servicenow.itsm.now
+table: cmdb_ci_server
+enhanced: true
+enhanced_multihop: true
+enhanced_multihop_relationship_types:
+  - "Contains::Contained by"
+columns:
+  - name
+  - ip_address
 """
 
 
@@ -604,6 +701,7 @@ from ..module_utils.relations import (
     REL_QUERY,
     REL_TABLE,
     enhance_records_with_rel_groups,
+    enhance_records_with_multihop_groups,
 )
 from ..module_utils.table import TableClient
 
@@ -958,9 +1056,14 @@ class InventoryModule(BaseInventoryPlugin, ConstructableWithLookup, Cacheable):
     def __ingest_inventory_config(self, path, cache):
         self._read_config_data(path)
         self.cache_key = self.get_cache_key(path)
+        host = self._get_instance()["host"]
+        if not host:
+            raise AnsibleParserError(
+                "Instance parameter 'host' is required but is not set."
+            )
         self._cache_sub_key = "/".join(
             [
-                self._get_instance()["host"].rstrip("/"),
+                host.rstrip("/"),
                 "table",
                 self.get_option("table"),
                 self._construct_cache_suffix(),
@@ -1030,6 +1133,21 @@ class InventoryModule(BaseInventoryPlugin, ConstructableWithLookup, Cacheable):
             is_encoded_query=bool(enhanced_sysparm_query),
         )
         enhance_records_with_rel_groups(records, rel_records)
+
+        max_depth = self.get_option("enhanced_multihop_max_depth")
+        if max_depth < 1:
+            raise AnsibleParserError(
+                "Option 'enhanced_multihop_max_depth' must be greater than 0."
+            )
+        elif max_depth > 1:
+            enhance_records_with_multihop_groups(
+                records,
+                rel_records,
+                direction=self.get_option("enhanced_multihop_direction"),
+                max_depth=max_depth,
+                ci_classes=self.get_option("enhanced_multihop_target_classes"),
+                rel_types=self.get_option("enhanced_multihop_relationship_types"),
+            )
 
     def __create_table_client(self):
         try:

--- a/plugins/module_utils/relations.py
+++ b/plugins/module_utils/relations.py
@@ -102,7 +102,9 @@ class RecordRelationshipEnhancer:
         self.multi_hop_relationship_types = (
             set(multi_hop_relationship_types) if multi_hop_relationship_types else None
         )
-        self.multi_hop_ci_classes = set(multi_hop_ci_classes) if multi_hop_ci_classes else None
+        self.multi_hop_ci_classes = (
+            set(multi_hop_ci_classes) if multi_hop_ci_classes else None
+        )
         self.max_hop_depth = max_hop_depth
         self.multi_hop_direction = multi_hop_direction
 
@@ -187,7 +189,10 @@ class RecordRelationshipEnhancer:
             return
 
         type_name = relationship.get(RelationshipFields.TYPE_NAME.value, "")
-        if self.multi_hop_relationship_types and type_name not in self.multi_hop_relationship_types:
+        if (
+            self.multi_hop_relationship_types
+            and type_name not in self.multi_hop_relationship_types
+        ):
             return
 
         if self.multi_hop_direction in ("up", "both"):
@@ -236,7 +241,10 @@ class RecordRelationshipEnhancer:
                 if not all([neighbor_name, rel_type, neighbor_class]):
                     continue
 
-                if self.multi_hop_ci_classes and neighbor_class not in self.multi_hop_ci_classes:
+                if (
+                    self.multi_hop_ci_classes
+                    and neighbor_class not in self.multi_hop_ci_classes
+                ):
                     continue
 
                 groups.add(_format_group_name(neighbor_name, rel_type))

--- a/plugins/module_utils/relations.py
+++ b/plugins/module_utils/relations.py
@@ -271,7 +271,7 @@ class RecordRelationshipEnhancer:
         visited = {starting_sys_id}
         ids_at_current_depth = [starting_sys_id]
 
-        for _ in range(self.max_hop_depth):
+        for _ in range(self.max_hop_depth):  # pylint: disable=disallowed-name
             if not ids_at_current_depth:
                 break
             ids_at_current_depth, new_groups = self._process_ids_at_depth(

--- a/plugins/module_utils/relations.py
+++ b/plugins/module_utils/relations.py
@@ -33,16 +33,6 @@ REL_FIELDS = set([r.value for r in RelationshipFields])
 REL_QUERY = None
 
 
-def _extend_records_with_groups(records, groups):
-    for record in records:
-        sys_id = record.get("sys_id")
-        sys_id_groups = groups.get(sys_id, set())
-        existing = record.get("relationship_groups", set())
-        record["relationship_groups"] = existing.union(sys_id_groups)
-
-    return records
-
-
 def _extract_ci_rel_type(type_name):
     # type_name is of form "Parent description::Child description".
     # Return the value of form (Parent_description, Child_description).
@@ -78,265 +68,207 @@ def _format_group_name(ci_name: str, rel_type: str) -> str:
     return "{0}_{1}".format(ci_name, rel_type)
 
 
-def _relations_to_groups(rel_records):
-    groups = dict()
+class RecordRelationshipEnhancer:
+    """Enrich inventory records with CMDB relationship group names.
 
-    extract_relation = dict(
-        parent=_extract_parent_relation, child=_extract_child_relation
-    )
-
-    for rel_record in rel_records or list():
-        for target in ("child", "parent"):
-            t_extr_rel = extract_relation[target]
-            sys_id, ci_name, ci_class, ci_rel_type = t_extr_rel(rel_record)
-
-            if sys_id and ci_name and ci_rel_type and ci_class:
-                rel_group = _format_group_name(ci_name, ci_rel_type)
-
-                items = groups.setdefault(sys_id, set())
-                items.add(rel_group)
-
-    return groups
-
-
-def enhance_records_with_rel_groups(records, rel_records):
-    groups = _relations_to_groups(rel_records)
-    records = _extend_records_with_groups(records, groups)
-
-    return records
-
-
-def _build_relationship_adjacency_maps(
-    relationship_records: list, relationship_types=None
-) -> tuple:
-    """Build parent/child adjacency lists from cmdb_rel_ci relationship records.
+    Parses cmdb_rel_ci relationship records into single-hop groups and,
+    when max_hop_depth > 1, builds an adjacency map for BFS traversal to
+    discover multi-hop relationship groups.
 
     Args:
-        relationship_records: List of relationship records from the cmdb_rel_ci table,
-            each containing dot-walked fields (parent.sys_id, child.sys_id,
-            type.name, etc.).
-        relationship_types: Optional list of relationship type names (e.g.
-            "Runs on::Runs") to include. When None, all types are included.
-
-    Returns:
-        A tuple of (child_to_parent, parent_to_child) dicts. Each maps a CI
-        sys_id to a list of (neighbor_sys_id, neighbor_name,
-        neighbor_sys_class_name, rel_type) tuples representing its adjacent
-        nodes in that direction.
+        relationship_records: Raw cmdb_rel_ci records with dot-walked fields
+            (parent.sys_id, child.sys_id, type.name, etc.).
+        max_hop_depth: Maximum number of hops to traverse. 1 means single-hop only.
+        multi_hop_direction: Traversal direction for multi-hop — "up" follows
+            child-to-parent edges, "down" follows parent-to-child, "both"
+            follows both.
+        multi_hop_relationship_types: Optional list of relationship type names (e.g.
+            "Runs on::Runs") to include in multi-hop traversal. When None,
+            all types are followed.
+        multi_hop_ci_classes: Optional list of CMDB CI class names (e.g.
+            "cmdb_ci_service_auto") to collect during multi-hop traversal.
+            When None, all classes are collected.
     """
-    relationship_types_set = set(relationship_types) if relationship_types else None
-    child_to_parent = {}
-    parent_to_child = {}
 
-    for rel_record in relationship_records or []:
-        type_name = rel_record.get(RelationshipFields.TYPE_NAME.value, "")
+    def __init__(
+        self,
+        relationship_records: list = None,
+        max_hop_depth: int = 1,
+        multi_hop_direction: str = "both",
+        multi_hop_relationship_types: list = None,
+        multi_hop_ci_classes: list = None,
+    ):
+        self.relationships = relationship_records or list()
+        self.multi_hop_relationship_types = (
+            set(multi_hop_relationship_types) if multi_hop_relationship_types else None
+        )
+        self.multi_hop_ci_classes = set(multi_hop_ci_classes) if multi_hop_ci_classes else None
+        self.max_hop_depth = max_hop_depth
+        self.multi_hop_direction = multi_hop_direction
 
-        # check if this relationship is one that the user actually cares about
-        if relationship_types_set and type_name not in relationship_types_set:
-            continue
+        self._adjacent_relationships_map = (
+            {}
+        )  # type: dict[str, list[tuple[str, str, str, str]]]
+        self._single_hop_groups = {}  # type: dict[str, set[str]]
 
-        parent_rel_type, child_rel_type = _extract_ci_rel_type(type_name)
-        parent_sys_id = rel_record.get(RelationshipFields.PARENT_SYS_ID.value, "")
-        child_sys_id = rel_record.get(RelationshipFields.CHILD_SYS_ID.value, "")
+        self._parse_relationships()
+
+    def enhance_records_with_relationship_groups(self, records: list) -> list:
+        """Add a ``relationship_groups`` set to each inventory record.
+
+        Merges single-hop groups (always present) with multi-hop groups
+        (computed via BFS when max_hop_depth > 1) for each record's sys_id.
+
+        Args:
+            records: Inventory records to enrich. Each must contain a
+                "sys_id" key.
+
+        Returns:
+            The input records list with "relationship_groups" added to
+            each record.
+        """
+        for record in records:
+            sys_id = record.get("sys_id")
+            if not sys_id:
+                continue
+            single_hop = self._single_hop_groups.get(sys_id, set())
+            multi_hop = set()
+            if self.max_hop_depth > 1:
+                multi_hop = self._transform_adjacent_relationships_into_groups(
+                    starting_sys_id=sys_id,
+                )
+            record["relationship_groups"] = single_hop | multi_hop
+
+        return records
+
+    def _parse_relationships(self) -> None:
+        """Parse relationship records into single-hop groups and adjacency maps.
+
+        Iterates over all relationship records once. Single-hop groups are
+        always built. The adjacency map is only built when max_hop_depth > 1.
+        """
+        for rel_record in self.relationships:
+            self._parse_single_hop_groups(rel_record)
+            if self.max_hop_depth > 1:
+                self._map_relationship_adjacency(relationship=rel_record)
+
+    def _parse_single_hop_groups(self, rel_record: dict) -> None:
+        """Extract single-hop group names from a relationship record.
+
+        For each relationship, both the parent and child CI sys_ids receive
+        a group name derived from the opposite end's name and relationship
+        type.
+        """
+        extract_func = dict(
+            parent=_extract_parent_relation, child=_extract_child_relation
+        )
+        for target in ("child", "parent"):
+            sys_id, ci_name, ci_class, ci_rel_type = extract_func[target](rel_record)
+            if sys_id and ci_name and ci_rel_type and ci_class:
+                self._single_hop_groups.setdefault(sys_id, set()).add(
+                    _format_group_name(ci_name, ci_rel_type)
+                )
+
+    def _map_relationship_adjacency(self, relationship: dict) -> None:
+        """Add a relationship record's edges to the adjacency map.
+
+        Edges are filtered by multi_hop_relationship_types and added in the
+        direction(s) specified by self.multi_hop_direction. Records missing either
+        parent or child sys_id are skipped.
+        """
+        parent_sys_id, child_name, child_class, child_rel_type = (
+            _extract_parent_relation(relationship)
+        )
+        child_sys_id, parent_name, parent_class, parent_rel_type = (
+            _extract_child_relation(relationship)
+        )
 
         if not (child_sys_id and parent_sys_id):
-            continue
+            return
 
-        child_to_parent.setdefault(child_sys_id, []).append(
-            (
-                parent_sys_id,
-                rel_record.get(RelationshipFields.PARENT_NAME.value, ""),
-                rel_record.get(RelationshipFields.PARENT_SYS_CLASS_NAME.value, ""),
-                parent_rel_type,
+        type_name = relationship.get(RelationshipFields.TYPE_NAME.value, "")
+        if self.multi_hop_relationship_types and type_name not in self.multi_hop_relationship_types:
+            return
+
+        if self.multi_hop_direction in ("up", "both"):
+            self._adjacent_relationships_map.setdefault(child_sys_id, []).append(
+                (parent_sys_id, parent_name, parent_class, parent_rel_type)
             )
-        )
-        parent_to_child.setdefault(parent_sys_id, []).append(
-            (
-                child_sys_id,
-                rel_record.get(RelationshipFields.CHILD_NAME.value, ""),
-                rel_record.get(RelationshipFields.CHILD_SYS_CLASS_NAME.value, ""),
-                child_rel_type,
+
+        if self.multi_hop_direction in ("down", "both"):
+            self._adjacent_relationships_map.setdefault(parent_sys_id, []).append(
+                (child_sys_id, child_name, child_class, child_rel_type)
             )
-        )
 
-    return child_to_parent, parent_to_child
+    def _process_ids_at_depth(
+        self,
+        ids_at_current_depth: list,
+        visited: set,
+    ) -> tuple:
+        """Process one BFS depth level and return the next level's IDs and any matching groups.
 
+        All unvisited neighbors are added to the next depth for traversal.
+        Only neighbors with valid name/class/rel_type that pass the
+        multi_hop_ci_classes filter produce group names.
 
-def get_relationship_adjancency_map(
-    direction: str, relationship_records: list, relationship_types: list = None
-) -> dict:
-    """Return a single adjacency map for the requested traversal direction.
+        Args:
+            ids_at_current_depth: CI sys_ids to expand at this depth.
+            visited: Mutable set of already-seen sys_ids; updated in place.
 
-    Builds the full parent/child adjacency maps via
-    _build_relationship_adjacency_maps, then returns only the map matching
-    the requested direction.
+        Returns:
+            A tuple of (ids_at_next_depth, groups) where ids_at_next_depth
+            is a list of newly discovered sys_ids and groups is a set of
+            formatted group name strings.
+        """
+        ids_at_next_depth = []
+        groups = set()
 
-    Args:
-        direction: Traversal direction. "up" returns child-to-parent edges,
-            "down" returns parent-to-child edges, any other value merges both
-            directions into one map.
-        relationship_records: Raw cmdb_rel_ci records with dot-walked fields.
-        relationship_types: Optional list of relationship type names to
-            include. When None, all types are included.
+        for current_id in ids_at_current_depth:
+            for neighbor in self._adjacent_relationships_map.get(current_id, []):
+                neighbor_id, neighbor_name, neighbor_class, rel_type = neighbor
 
-    Returns:
-        A dict mapping each CI sys_id to a list of
-        (neighbor_sys_id, neighbor_name, neighbor_sys_class_name, rel_type)
-        tuples for its neighbors in the requested direction.
-    """
-    child_to_parent, parent_to_child = _build_relationship_adjacency_maps(
-        relationship_records=relationship_records, relationship_types=relationship_types
-    )
-    if direction == "up":
-        return child_to_parent
-    elif direction == "down":
-        return parent_to_child
+                if neighbor_id in visited:
+                    continue
 
-    # combine both up and down
-    adjacency = {}
-    for sys_id in set(list(child_to_parent.keys()) + list(parent_to_child.keys())):
-        adjacency[sys_id] = child_to_parent.get(sys_id, []) + parent_to_child.get(
-            sys_id, []
-        )
-    return adjacency
+                visited.add(neighbor_id)
+                ids_at_next_depth.append(neighbor_id)
 
+                if not all([neighbor_name, rel_type, neighbor_class]):
+                    continue
 
-def _process_ids_at_depth(
-    adjacent_relationships: dict,
-    ids_at_current_depth: list,
-    visited: set,
-    ci_classes_set: set,
-) -> tuple:
-    """Process one BFS (breadth-first search) depth level and return the next level's IDs and any matching groups.
+                if self.multi_hop_ci_classes and neighbor_class not in self.multi_hop_ci_classes:
+                    continue
 
-    All unvisited neighbors are added to the next depth for traversal. Only
-    neighbors with valid name/class/rel_type that pass the ci_classes filter
-    produce group names.
+                groups.add(_format_group_name(neighbor_name, rel_type))
 
-    Args:
-        adjacent_relationships: Adjacency map from get_relationship_adjancency_map.
-        ids_at_current_depth: CI sys_ids to expand at this depth.
-        visited: Mutable set of already-seen sys_ids; updated in place.
-        ci_classes_set: Optional set of CMDB CI class names to collect.
-            When None, all classes are collected.
+        return ids_at_next_depth, groups
 
-    Returns:
-        A tuple of (ids_at_next_depth, groups) where ids_at_next_depth is a
-        list of newly discovered sys_ids and groups is a set of formatted
-        group name strings.
-    """
-    ids_at_next_depth = []
-    groups = set()
+    def _transform_adjacent_relationships_into_groups(
+        self,
+        starting_sys_id: str,
+    ) -> set:
+        """BFS from a single CI, returning group names for matching neighbors.
 
-    for current_id in ids_at_current_depth:
-        for neighbor in adjacent_relationships.get(current_id, []):
-            neighbor_id, neighbor_name, neighbor_class, rel_type = neighbor
+        Traverses the adjacency map up to max_hop_depth hops from
+        starting_sys_id. All reachable nodes are walked, but only those
+        whose CI class passes the multi_hop_ci_classes filter produce group names.
 
-            if neighbor_id in visited:
-                continue
+        Args:
+            starting_sys_id: The sys_id of the CI to traverse from.
 
-            visited.add(neighbor_id)
-            ids_at_next_depth.append(neighbor_id)
+        Returns:
+            A set of formatted group name strings for matching neighbors.
+        """
+        groups = set()
+        visited = {starting_sys_id}
+        ids_at_current_depth = [starting_sys_id]
 
-            if not all([neighbor_name, rel_type, neighbor_class]):
-                continue
-
-            if ci_classes_set and neighbor_class not in ci_classes_set:
-                continue
-
-            groups.add(_format_group_name(neighbor_name, rel_type))
-
-    return ids_at_next_depth, groups
-
-
-def _transform_adjacent_relationships_into_groups(
-    adjacent_relationships: dict,
-    starting_sys_id: str,
-    max_depth: int,
-    ci_classes: list,
-) -> set:
-    """Perform a BFS (breadth-first search) from a single CI and return group names for matching neighbors.
-
-    Traverses the adjacency map up to max_depth hops from starting_sys_id.
-    All reachable nodes are walked through, but only those whose CI class
-    passes the ci_classes filter produce group names in the result.
-
-    Args:
-        adjacent_relationships: Adjacency map from get_relationship_adjancency_map.
-        starting_sys_id: The sys_id of the CI to traverse from.
-        max_depth: Maximum number of hops to traverse.
-        ci_classes: Optional list of CMDB CI class names to collect.
-            When None, all classes are collected.
-
-    Returns:
-        A set of formatted group name strings for matching neighbors.
-    """
-    ci_classes_set = set(ci_classes) if ci_classes else None
-    groups = set()
-    visited = {starting_sys_id}
-    ids_at_current_depth = [starting_sys_id]
-
-    for _ in range(max_depth):
-        if not ids_at_current_depth:
-            break
-        ids_at_current_depth, new_groups = _process_ids_at_depth(
-            adjacent_relationships, ids_at_current_depth, visited, ci_classes_set
-        )
-        groups.update(new_groups)
-
-    return groups
-
-
-def enhance_records_with_multihop_groups(
-    records: list,
-    relationship_records: list,
-    direction: str,
-    max_depth: int,
-    ci_classes: list,
-    relationship_types: list,
-) -> list:
-    """Enrich inventory records with relationship groups discovered via multi-hop BFS (breadth-first search).
-
-    Builds an adjacency map from the raw cmdb_rel_ci relationship records,
-    then performs a breadth-first traversal up to max_depth hops from each
-    record. Discovered neighbors are added as relationship_groups on each
-    record (e.g. "myserver_Runs_on").
-
-    Args:
-        records: Inventory records to enrich. Each must contain a "sys_id" key.
-        relationship_records: Raw cmdb_rel_ci records with dot-walked fields.
-        direction: Traversal direction — "up" follows child-to-parent edges,
-            "down" follows parent-to-child, any other value follows both.
-        max_depth: Maximum number of hops to traverse from each source record.
-        ci_classes: Optional list of CMDB CI class names (e.g.
-            "cmdb_ci_server") to collect. When None, all classes are collected.
-        relationship_types: Optional list of relationship type names to
-            traverse. When None, all types are traversed.
-
-    Returns:
-        The input records list, with a "relationship_groups" set added or
-        extended on each record.
-    """
-    adjacent_relationships = get_relationship_adjancency_map(
-        direction=direction,
-        relationship_records=relationship_records,
-        relationship_types=relationship_types,
-    )
-    record_relationship_group_map = {}
-    for record in records:
-        record_sys_id = record.get("sys_id")
-        if not record_sys_id:
-            continue
-
-        record_relationship_group_map[record_sys_id] = (
-            _transform_adjacent_relationships_into_groups(
-                adjacent_relationships=adjacent_relationships,
-                starting_sys_id=record_sys_id,
-                max_depth=max_depth,
-                ci_classes=ci_classes,
+        for _ in range(self.max_hop_depth):
+            if not ids_at_current_depth:
+                break
+            ids_at_current_depth, new_groups = self._process_ids_at_depth(
+                ids_at_current_depth, visited
             )
-        )
+            groups.update(new_groups)
 
-    records = _extend_records_with_groups(records, record_relationship_group_map)
-
-    return records
+        return groups

--- a/plugins/module_utils/relations.py
+++ b/plugins/module_utils/relations.py
@@ -8,23 +8,26 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import re
+from enum import Enum
 
 REL_TABLE = "cmdb_rel_ci"
+
+
 # sysparm_fields to be used when querying REL_TABLE. Uses dot-walking
 # notation to extract fields from linked tables in a single REST API call.
 # https://docs.servicenow.com/bundle/tokyo-application-development/page/integrate/inbound-rest/concept/c_RESTAPI.html
-REL_FIELDS = set(
-    (
-        "sys_id",
-        "type.name",
-        "parent.sys_id",
-        "parent.name",
-        "parent.sys_class_name",
-        "child.sys_id",
-        "child.name",
-        "child.sys_class_name",
-    )
-)
+class RelationshipFields(Enum):
+    SYS_ID = "sys_id"
+    TYPE_NAME = "type.name"
+    PARENT_SYS_ID = "parent.sys_id"
+    PARENT_NAME = "parent.name"
+    PARENT_SYS_CLASS_NAME = "parent.sys_class_name"
+    CHILD_SYS_ID = "child.sys_id"
+    CHILD_NAME = "child.name"
+    CHILD_SYS_CLASS_NAME = "child.sys_class_name"
+
+
+REL_FIELDS = set([r.value for r in RelationshipFields])
 
 # Similar as above but for sysparm_query
 REL_QUERY = None
@@ -34,7 +37,8 @@ def _extend_records_with_groups(records, groups):
     for record in records:
         sys_id = record.get("sys_id")
         sys_id_groups = groups.get(sys_id, set())
-        record["relationship_groups"] = sys_id_groups
+        existing = record.get("relationship_groups", set())
+        record["relationship_groups"] = existing.union(sys_id_groups)
 
     return records
 
@@ -50,23 +54,28 @@ def _extract_ci_rel_type(type_name):
 
 
 def _extract_parent_relation(rel_record):
-    sys_id = rel_record.get("parent.sys_id", "")
-    ci_name = rel_record.get("child.name", "")
-    ci_class = rel_record.get("child.sys_class_name", "")
-    type_name = rel_record.get("type.name", "")
+    sys_id = rel_record.get(RelationshipFields.PARENT_SYS_ID.value, "")
+    ci_name = rel_record.get(RelationshipFields.CHILD_NAME.value, "")
+    ci_class = rel_record.get(RelationshipFields.CHILD_SYS_CLASS_NAME.value, "")
+    type_name = rel_record.get(RelationshipFields.TYPE_NAME.value, "")
     ci_rel_type = _extract_ci_rel_type(type_name)[1]
 
     return sys_id, ci_name, ci_class, ci_rel_type
 
 
 def _extract_child_relation(rel_record):
-    sys_id = rel_record.get("child.sys_id", "")
-    ci_name = rel_record.get("parent.name", "")
-    ci_class = rel_record.get("parent.sys_class_name", "")
-    type_name = rel_record.get("type.name", "")
+    sys_id = rel_record.get(RelationshipFields.CHILD_SYS_ID.value, "")
+    ci_name = rel_record.get(RelationshipFields.PARENT_NAME.value, "")
+    ci_class = rel_record.get(RelationshipFields.PARENT_SYS_CLASS_NAME.value, "")
+    type_name = rel_record.get(RelationshipFields.TYPE_NAME.value, "")
     ci_rel_type = _extract_ci_rel_type(type_name)[0]
 
     return sys_id, ci_name, ci_class, ci_rel_type
+
+
+def _format_group_name(ci_name: str, rel_type: str) -> str:
+    """Format a CI name and relationship type into an Ansible group name."""
+    return "{0}_{1}".format(ci_name, rel_type)
 
 
 def _relations_to_groups(rel_records):
@@ -82,7 +91,7 @@ def _relations_to_groups(rel_records):
             sys_id, ci_name, ci_class, ci_rel_type = t_extr_rel(rel_record)
 
             if sys_id and ci_name and ci_rel_type and ci_class:
-                rel_group = "{0}_{1}".format(ci_name, ci_rel_type)
+                rel_group = _format_group_name(ci_name, ci_rel_type)
 
                 items = groups.setdefault(sys_id, set())
                 items.add(rel_group)
@@ -93,5 +102,241 @@ def _relations_to_groups(rel_records):
 def enhance_records_with_rel_groups(records, rel_records):
     groups = _relations_to_groups(rel_records)
     records = _extend_records_with_groups(records, groups)
+
+    return records
+
+
+def _build_relationship_adjacency_maps(
+    relationship_records: list, relationship_types=None
+) -> tuple:
+    """Build parent/child adjacency lists from cmdb_rel_ci relationship records.
+
+    Args:
+        relationship_records: List of relationship records from the cmdb_rel_ci table,
+            each containing dot-walked fields (parent.sys_id, child.sys_id,
+            type.name, etc.).
+        relationship_types: Optional list of relationship type names (e.g.
+            "Runs on::Runs") to include. When None, all types are included.
+
+    Returns:
+        A tuple of (child_to_parent, parent_to_child) dicts. Each maps a CI
+        sys_id to a list of (neighbor_sys_id, neighbor_name,
+        neighbor_sys_class_name, rel_type) tuples representing its adjacent
+        nodes in that direction.
+    """
+    relationship_types_set = set(relationship_types) if relationship_types else None
+    child_to_parent = {}
+    parent_to_child = {}
+
+    for rel_record in relationship_records or []:
+        type_name = rel_record.get(RelationshipFields.TYPE_NAME.value, "")
+
+        # check if this relationship is one that the user actually cares about
+        if relationship_types_set and type_name not in relationship_types_set:
+            continue
+
+        parent_rel_type, child_rel_type = _extract_ci_rel_type(type_name)
+        parent_sys_id = rel_record.get(RelationshipFields.PARENT_SYS_ID.value, "")
+        child_sys_id = rel_record.get(RelationshipFields.CHILD_SYS_ID.value, "")
+
+        if not (child_sys_id and parent_sys_id):
+            continue
+
+        child_to_parent.setdefault(child_sys_id, []).append(
+            (
+                parent_sys_id,
+                rel_record.get(RelationshipFields.PARENT_NAME.value, ""),
+                rel_record.get(RelationshipFields.PARENT_SYS_CLASS_NAME.value, ""),
+                parent_rel_type,
+            )
+        )
+        parent_to_child.setdefault(parent_sys_id, []).append(
+            (
+                child_sys_id,
+                rel_record.get(RelationshipFields.CHILD_NAME.value, ""),
+                rel_record.get(RelationshipFields.CHILD_SYS_CLASS_NAME.value, ""),
+                child_rel_type,
+            )
+        )
+
+    return child_to_parent, parent_to_child
+
+
+def get_relationship_adjancency_map(
+    direction: str, relationship_records: list, relationship_types: list = None
+) -> dict:
+    """Return a single adjacency map for the requested traversal direction.
+
+    Builds the full parent/child adjacency maps via
+    _build_relationship_adjacency_maps, then returns only the map matching
+    the requested direction.
+
+    Args:
+        direction: Traversal direction. "up" returns child-to-parent edges,
+            "down" returns parent-to-child edges, any other value merges both
+            directions into one map.
+        relationship_records: Raw cmdb_rel_ci records with dot-walked fields.
+        relationship_types: Optional list of relationship type names to
+            include. When None, all types are included.
+
+    Returns:
+        A dict mapping each CI sys_id to a list of
+        (neighbor_sys_id, neighbor_name, neighbor_sys_class_name, rel_type)
+        tuples for its neighbors in the requested direction.
+    """
+    child_to_parent, parent_to_child = _build_relationship_adjacency_maps(
+        relationship_records=relationship_records, relationship_types=relationship_types
+    )
+    if direction == "up":
+        return child_to_parent
+    elif direction == "down":
+        return parent_to_child
+
+    # combine both up and down
+    adjacency = {}
+    for sys_id in set(list(child_to_parent.keys()) + list(parent_to_child.keys())):
+        adjacency[sys_id] = child_to_parent.get(sys_id, []) + parent_to_child.get(
+            sys_id, []
+        )
+    return adjacency
+
+
+def _process_ids_at_depth(
+    adjacent_relationships: dict,
+    ids_at_current_depth: list,
+    visited: set,
+    ci_classes_set: set,
+) -> tuple:
+    """Process one BFS (breadth-first search) depth level and return the next level's IDs and any matching groups.
+
+    All unvisited neighbors are added to the next depth for traversal. Only
+    neighbors with valid name/class/rel_type that pass the ci_classes filter
+    produce group names.
+
+    Args:
+        adjacent_relationships: Adjacency map from get_relationship_adjancency_map.
+        ids_at_current_depth: CI sys_ids to expand at this depth.
+        visited: Mutable set of already-seen sys_ids; updated in place.
+        ci_classes_set: Optional set of CMDB CI class names to collect.
+            When None, all classes are collected.
+
+    Returns:
+        A tuple of (ids_at_next_depth, groups) where ids_at_next_depth is a
+        list of newly discovered sys_ids and groups is a set of formatted
+        group name strings.
+    """
+    ids_at_next_depth = []
+    groups = set()
+
+    for current_id in ids_at_current_depth:
+        for neighbor in adjacent_relationships.get(current_id, []):
+            neighbor_id, neighbor_name, neighbor_class, rel_type = neighbor
+
+            if neighbor_id in visited:
+                continue
+
+            visited.add(neighbor_id)
+            ids_at_next_depth.append(neighbor_id)
+
+            if not all([neighbor_name, rel_type, neighbor_class]):
+                continue
+
+            if ci_classes_set and neighbor_class not in ci_classes_set:
+                continue
+
+            groups.add(_format_group_name(neighbor_name, rel_type))
+
+    return ids_at_next_depth, groups
+
+
+def _transform_adjacent_relationships_into_groups(
+    adjacent_relationships: dict,
+    starting_sys_id: str,
+    max_depth: int,
+    ci_classes: list,
+) -> set:
+    """Perform a BFS (breadth-first search) from a single CI and return group names for matching neighbors.
+
+    Traverses the adjacency map up to max_depth hops from starting_sys_id.
+    All reachable nodes are walked through, but only those whose CI class
+    passes the ci_classes filter produce group names in the result.
+
+    Args:
+        adjacent_relationships: Adjacency map from get_relationship_adjancency_map.
+        starting_sys_id: The sys_id of the CI to traverse from.
+        max_depth: Maximum number of hops to traverse.
+        ci_classes: Optional list of CMDB CI class names to collect.
+            When None, all classes are collected.
+
+    Returns:
+        A set of formatted group name strings for matching neighbors.
+    """
+    ci_classes_set = set(ci_classes) if ci_classes else None
+    groups = set()
+    visited = {starting_sys_id}
+    ids_at_current_depth = [starting_sys_id]
+
+    for _ in range(max_depth):
+        if not ids_at_current_depth:
+            break
+        ids_at_current_depth, new_groups = _process_ids_at_depth(
+            adjacent_relationships, ids_at_current_depth, visited, ci_classes_set
+        )
+        groups.update(new_groups)
+
+    return groups
+
+
+def enhance_records_with_multihop_groups(
+    records: list,
+    relationship_records: list,
+    direction: str,
+    max_depth: int,
+    ci_classes: list,
+    relationship_types: list,
+) -> list:
+    """Enrich inventory records with relationship groups discovered via multi-hop BFS (breadth-first search).
+
+    Builds an adjacency map from the raw cmdb_rel_ci relationship records,
+    then performs a breadth-first traversal up to max_depth hops from each
+    record. Discovered neighbors are added as relationship_groups on each
+    record (e.g. "myserver_Runs_on").
+
+    Args:
+        records: Inventory records to enrich. Each must contain a "sys_id" key.
+        relationship_records: Raw cmdb_rel_ci records with dot-walked fields.
+        direction: Traversal direction — "up" follows child-to-parent edges,
+            "down" follows parent-to-child, any other value follows both.
+        max_depth: Maximum number of hops to traverse from each source record.
+        ci_classes: Optional list of CMDB CI class names (e.g.
+            "cmdb_ci_server") to collect. When None, all classes are collected.
+        relationship_types: Optional list of relationship type names to
+            traverse. When None, all types are traversed.
+
+    Returns:
+        The input records list, with a "relationship_groups" set added or
+        extended on each record.
+    """
+    adjacent_relationships = get_relationship_adjancency_map(
+        direction=direction,
+        relationship_records=relationship_records,
+        relationship_types=relationship_types,
+    )
+    record_relationship_group_map = {}
+    for record in records:
+        record_sys_id = record.get("sys_id")
+        if not record_sys_id:
+            continue
+
+        record_relationship_group_map[record_sys_id] = (
+            _transform_adjacent_relationships_into_groups(
+                adjacent_relationships=adjacent_relationships,
+                starting_sys_id=record_sys_id,
+                max_depth=max_depth,
+                ci_classes=ci_classes,
+            )
+        )
+
+    records = _extend_records_with_groups(records, record_relationship_group_map)
 
     return records

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -9,6 +9,7 @@ plugins/module_utils/errors.py import-2.7
 plugins/module_utils/generic.py import-2.7
 plugins/module_utils/instance_config.py import-2.7
 plugins/module_utils/relations.py import-2.7
+plugins/module_utils/relations.py compile-2.7
 plugins/module_utils/service_catalog.py import-2.7
 plugins/module_utils/snow.py import-2.7
 plugins/module_utils/table.py import-2.7

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -8,6 +8,7 @@ plugins/module_utils/errors.py import-2.7
 plugins/module_utils/generic.py import-2.7
 plugins/module_utils/instance_config.py import-2.7
 plugins/module_utils/relations.py import-2.7
+plugins/module_utils/relations.py compile-2.7
 plugins/module_utils/service_catalog.py import-2.7
 plugins/module_utils/snow.py import-2.7
 plugins/module_utils/table.py import-2.7

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -6,7 +6,6 @@ plugins/module_utils/attachment.py import-2.7
 plugins/module_utils/client.py import-2.7
 plugins/module_utils/errors.py import-2.7
 plugins/module_utils/generic.py import-2.7
-plugins/module_utils/instance_config.py import-2.7
 plugins/module_utils/relations.py import-2.7
 plugins/module_utils/relations.py compile-2.7
 plugins/module_utils/service_catalog.py import-2.7

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -8,6 +8,7 @@ plugins/module_utils/client.py import-2.7
 plugins/module_utils/errors.py import-2.7
 plugins/module_utils/generic.py import-2.7
 plugins/module_utils/instance_config.py import-2.7
+plugins/module_utils/relations.py import-2.7
 plugins/module_utils/service_catalog.py import-2.7
 plugins/module_utils/snow.py import-2.7
 plugins/module_utils/table.py import-2.7

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -6,6 +6,8 @@ plugins/module_utils/attachment.py import-2.7
 plugins/module_utils/client.py import-2.7
 plugins/module_utils/errors.py import-2.7
 plugins/module_utils/generic.py import-2.7
+plugins/module_utils/instance_config.py import-2.7
+plugins/module_utils/relations.py import-2.7
 plugins/module_utils/service_catalog.py import-2.7
 plugins/module_utils/snow.py import-2.7
 plugins/module_utils/table.py import-2.7

--- a/tests/unit/plugins/inventory/test_now.py
+++ b/tests/unit/plugins/inventory/test_now.py
@@ -1075,10 +1075,16 @@ class TestConstructCacheSuffix:
 
 class TestInventoryModuleEnhancedQueryFeatures:
     def setup_get_option_side_effect(self, **options):
+        defaults = dict(
+            enhanced_multihop_max_depth=1,
+        )
+
         def get_option(option_name):
             if option_name == "enhanced":
                 return options.get("enhanced", True)
-            return options.get(option_name, None)
+            if option_name in options:
+                return options[option_name]
+            return defaults.get(option_name)
 
         return get_option
 
@@ -1088,8 +1094,8 @@ class TestInventoryModuleEnhancedQueryFeatures:
         )
         self.mock_fetch_records.return_value = []
 
-        self.mock_enhance_records_with_rel_groups = mocker.patch(
-            "ansible_collections.servicenow.itsm.plugins.inventory.now.enhance_records_with_rel_groups"
+        self.mock_enhancer_class = mocker.patch(
+            "ansible_collections.servicenow.itsm.plugins.inventory.now.RecordRelationshipEnhancer"
         )
 
         self.mock_table_client = mocker.Mock()
@@ -1132,9 +1138,15 @@ class TestInventoryModuleEnhancedQueryFeatures:
             is_encoded_query=False,
         )
 
-        # Verify enhance_records_with_rel_groups was called
-        self.mock_enhance_records_with_rel_groups.assert_called_once_with(
-            self.mock_records, []
+        self.mock_enhancer_class.assert_called_once_with(
+            relationship_records=[],
+            max_hop_depth=1,
+            multi_hop_direction=None,
+            multi_hop_relationship_types=None,
+            multi_hop_ci_classes=None,
+        )
+        self.mock_enhancer_class.return_value.enhance_records_with_relationship_groups.assert_called_once_with(
+            records=self.mock_records
         )
 
     def test_populate_enhanced_records_with_enhanced_sysparm_query(
@@ -1164,9 +1176,15 @@ class TestInventoryModuleEnhancedQueryFeatures:
             is_encoded_query=True,
         )
 
-        # Verify enhance_records_with_rel_groups was called
-        self.mock_enhance_records_with_rel_groups.assert_called_once_with(
-            self.mock_records, []
+        self.mock_enhancer_class.assert_called_once_with(
+            relationship_records=[],
+            max_hop_depth=1,
+            multi_hop_direction=None,
+            multi_hop_relationship_types=None,
+            multi_hop_ci_classes=None,
+        )
+        self.mock_enhancer_class.return_value.enhance_records_with_relationship_groups.assert_called_once_with(
+            records=self.mock_records
         )
 
     def test_populate_enhanced_records_with_default_query(
@@ -1218,6 +1236,38 @@ class TestInventoryModuleEnhancedQueryFeatures:
             inventory_plugin._InventoryModule__populate_enhanced_records_from_remote(
                 self.mock_table_client, self.mock_records
             )
+
+    def test_populate_enhanced_records_uses_multihop_for_depth_gt_1(
+        self, inventory_plugin, mocker
+    ):
+        """Test that max_depth > 1 passes multihop params to RecordRelationshipEnhancer"""
+        mocker.patch.object(
+            inventory_plugin,
+            "get_option",
+            side_effect=self.setup_get_option_side_effect(
+                enhanced_additional_columns=[],
+                enhanced_multihop_max_depth=3,
+                enhanced_multihop_direction="up",
+                enhanced_multihop_target_classes=["cmdb_ci_server"],
+                enhanced_multihop_relationship_types=["Runs on::Runs"],
+            ),
+        )
+        self.setup_mocks(mocker)
+
+        inventory_plugin._InventoryModule__populate_enhanced_records_from_remote(
+            self.mock_table_client, self.mock_records
+        )
+
+        self.mock_enhancer_class.assert_called_once_with(
+            relationship_records=[],
+            max_hop_depth=3,
+            multi_hop_direction="up",
+            multi_hop_relationship_types=["Runs on::Runs"],
+            multi_hop_ci_classes=["cmdb_ci_server"],
+        )
+        self.mock_enhancer_class.return_value.enhance_records_with_relationship_groups.assert_called_once_with(
+            records=self.mock_records
+        )
 
     def test_get_query_columns_with_enhanced(self, inventory_plugin, mocker):
         """Test __get_query_columns includes REL_FIELDS when enhanced is enabled"""

--- a/tests/unit/plugins/inventory/test_now.py
+++ b/tests/unit/plugins/inventory/test_now.py
@@ -991,10 +991,16 @@ class TestConstructCacheSuffix:
 
 class TestInventoryModuleEnhancedQueryFeatures:
     def setup_get_option_side_effect(self, **options):
+        defaults = dict(
+            enhanced_multihop_max_depth=1,
+        )
+
         def get_option(option_name):
             if option_name == "enhanced":
                 return options.get("enhanced", True)
-            return options.get(option_name, None)
+            if option_name in options:
+                return options[option_name]
+            return defaults.get(option_name)
 
         return get_option
 
@@ -1004,8 +1010,8 @@ class TestInventoryModuleEnhancedQueryFeatures:
         )
         self.mock_fetch_records.return_value = []
 
-        self.mock_enhance_records_with_rel_groups = mocker.patch(
-            "ansible_collections.servicenow.itsm.plugins.inventory.now.enhance_records_with_rel_groups"
+        self.mock_enhancer_class = mocker.patch(
+            "ansible_collections.servicenow.itsm.plugins.inventory.now.RecordRelationshipEnhancer"
         )
 
         self.mock_table_client = mocker.Mock()
@@ -1048,9 +1054,15 @@ class TestInventoryModuleEnhancedQueryFeatures:
             is_encoded_query=False,
         )
 
-        # Verify enhance_records_with_rel_groups was called
-        self.mock_enhance_records_with_rel_groups.assert_called_once_with(
-            self.mock_records, []
+        self.mock_enhancer_class.assert_called_once_with(
+            relationship_records=[],
+            max_hop_depth=1,
+            multi_hop_direction=None,
+            multi_hop_relationship_types=None,
+            multi_hop_ci_classes=None,
+        )
+        self.mock_enhancer_class.return_value.enhance_records_with_relationship_groups.assert_called_once_with(
+            records=self.mock_records
         )
 
     def test_populate_enhanced_records_with_enhanced_sysparm_query(
@@ -1080,9 +1092,15 @@ class TestInventoryModuleEnhancedQueryFeatures:
             is_encoded_query=True,
         )
 
-        # Verify enhance_records_with_rel_groups was called
-        self.mock_enhance_records_with_rel_groups.assert_called_once_with(
-            self.mock_records, []
+        self.mock_enhancer_class.assert_called_once_with(
+            relationship_records=[],
+            max_hop_depth=1,
+            multi_hop_direction=None,
+            multi_hop_relationship_types=None,
+            multi_hop_ci_classes=None,
+        )
+        self.mock_enhancer_class.return_value.enhance_records_with_relationship_groups.assert_called_once_with(
+            records=self.mock_records
         )
 
     def test_populate_enhanced_records_with_default_query(
@@ -1134,6 +1152,38 @@ class TestInventoryModuleEnhancedQueryFeatures:
             inventory_plugin._InventoryModule__populate_enhanced_records_from_remote(
                 self.mock_table_client, self.mock_records
             )
+
+    def test_populate_enhanced_records_uses_multihop_for_depth_gt_1(
+        self, inventory_plugin, mocker
+    ):
+        """Test that max_depth > 1 passes multihop params to RecordRelationshipEnhancer"""
+        mocker.patch.object(
+            inventory_plugin,
+            "get_option",
+            side_effect=self.setup_get_option_side_effect(
+                enhanced_additional_columns=[],
+                enhanced_multihop_max_depth=3,
+                enhanced_multihop_direction="up",
+                enhanced_multihop_target_classes=["cmdb_ci_server"],
+                enhanced_multihop_relationship_types=["Runs on::Runs"],
+            ),
+        )
+        self.setup_mocks(mocker)
+
+        inventory_plugin._InventoryModule__populate_enhanced_records_from_remote(
+            self.mock_table_client, self.mock_records
+        )
+
+        self.mock_enhancer_class.assert_called_once_with(
+            relationship_records=[],
+            max_hop_depth=3,
+            multi_hop_direction="up",
+            multi_hop_relationship_types=["Runs on::Runs"],
+            multi_hop_ci_classes=["cmdb_ci_server"],
+        )
+        self.mock_enhancer_class.return_value.enhance_records_with_relationship_groups.assert_called_once_with(
+            records=self.mock_records
+        )
 
     def test_get_query_columns_with_enhanced(self, inventory_plugin, mocker):
         """Test __get_query_columns includes REL_FIELDS when enhanced is enabled"""

--- a/tests/unit/plugins/module_utils/test_relations.py
+++ b/tests/unit/plugins/module_utils/test_relations.py
@@ -11,75 +11,13 @@ import sys
 
 import pytest
 from ansible_collections.servicenow.itsm.plugins.module_utils import relations
+from ansible_collections.servicenow.itsm.plugins.module_utils.relations import (
+    RecordRelationshipEnhancer,
+)
 
 pytestmark = pytest.mark.skipif(
     sys.version_info < (2, 7), reason="requires python2.7 or higher"
 )
-
-
-class TestAddRelationsToRecords:
-    def test_add_empty_relations_to_records(self):
-        records = [dict(sys_id="s1", name="abc")]
-        rels = dict()
-
-        relations._extend_records_with_groups(records, rels)
-
-        assert records == [dict(sys_id="s1", name="abc", relationship_groups=set())]
-
-    def test_add_relations_to_empty_records(self):
-        records = []
-        rels = dict()
-
-        relations._extend_records_with_groups(records, rels)
-
-        assert records == []
-
-    def test_add_relations_to_records(self):
-        records = [dict(sys_id="s1", name="abc")]
-        rels = dict(s1=set(("g1", "g2")), s2=set(("g3",)))
-
-        relations._extend_records_with_groups(records, rels)
-
-        assert records == [
-            dict(sys_id="s1", name="abc", relationship_groups=set(("g1", "g2")))
-        ]
-
-
-class TestGroupRelations:
-    def test_group_empty_relations(self):
-        records = []
-        rels = relations._relations_to_groups(records)
-        assert rels == dict()
-
-    def test_group_relations(self):
-        records = [
-            {
-                "parent.sys_id": "p1",
-                "child.name": "cn1",
-                "child.sys_class_name": "cscn1",
-                "child.sys_id": "c1",
-                "parent.name": "pn1",
-                "parent.sys_class_name": "pscn1",
-                "type.name": "parent1::child1",
-            },
-            {
-                "parent.sys_id": "p1",
-                "child.name": "cn2",
-                "child.sys_class_name": "cscn2",
-                "child.sys_id": "c2",
-                "parent.name": "pn1",
-                "parent.sys_class_name": "pscn1",
-                "type.name": "parent1::child2",
-            },
-        ]
-
-        actual = relations._relations_to_groups(records)
-
-        assert actual == dict(
-            p1=set(("cn1_child1", "cn2_child2")),
-            c1=set(("pn1_parent1",)),
-            c2=set(("pn1_parent1",)),
-        )
 
 
 class TestExtractRelation:
@@ -150,44 +88,180 @@ class TestGetRelationType:
         assert actual == expected
 
 
-class TestEnhanceRecordsWithRelationGroups:
-    def test_enhance_empty_records_with_empty_rel_groups(self):
+class TestRecordRelationshipEnhancer:
+    REL_RECORDS = [
+        {
+            "parent.sys_id": "p1",
+            "child.name": "cn1",
+            "child.sys_class_name": "cscn1",
+            "child.sys_id": "c1",
+            "parent.name": "pn1",
+            "parent.sys_class_name": "pscn1",
+            "type.name": "parent1::child1",
+        },
+        {
+            "parent.sys_id": "p1",
+            "child.name": "cn2",
+            "child.sys_class_name": "cscn2",
+            "child.sys_id": "c2",
+            "parent.name": "pn1",
+            "parent.sys_class_name": "pscn1",
+            "type.name": "parent1::child2",
+        },
+    ]
+
+    MULTIHOP_REL_RECORDS = [
+        {
+            "parent.sys_id": "p1",
+            "child.name": "cn1",
+            "child.sys_class_name": "cmdb_ci_server",
+            "child.sys_id": "c1",
+            "parent.name": "pn1",
+            "parent.sys_class_name": "cmdb_ci_app",
+            "type.name": "Runs on::Runs",
+        },
+        {
+            "parent.sys_id": "c1",
+            "child.name": "cn2",
+            "child.sys_class_name": "cmdb_ci_db",
+            "child.sys_id": "c2",
+            "parent.name": "cn1",
+            "parent.sys_class_name": "cmdb_ci_server",
+            "type.name": "Runs on::Runs",
+        },
+    ]
+
+    def test_empty_inputs(self):
+        enhancer = RecordRelationshipEnhancer(relationship_records=[], max_hop_depth=1)
         records = []
-        rel_records = []
+        result = enhancer.enhance_records_with_relationship_groups(records=records)
+        assert result == []
 
-        relations.enhance_records_with_rel_groups(records, rel_records)
+    def test_single_hop_groups(self):
+        enhancer = RecordRelationshipEnhancer(
+            relationship_records=self.REL_RECORDS, max_hop_depth=1
+        )
+        records = [dict(sys_id="p1"), dict(sys_id="c1"), dict(sys_id="c2")]
+        enhancer.enhance_records_with_relationship_groups(records=records)
 
-        assert records == []
+        assert records[0]["relationship_groups"] == {"cn1_child1", "cn2_child2"}
+        assert records[1]["relationship_groups"] == {"pn1_parent1"}
+        assert records[2]["relationship_groups"] == {"pn1_parent1"}
 
-    def test_enhance_empty_records_with_rel_groups(self):
-        records = []
+    def test_record_without_matching_sys_id(self):
+        enhancer = RecordRelationshipEnhancer(
+            relationship_records=self.REL_RECORDS, max_hop_depth=1
+        )
+        records = [dict(sys_id="unknown")]
+        enhancer.enhance_records_with_relationship_groups(records=records)
+
+        assert records[0]["relationship_groups"] == set()
+
+    def test_record_without_sys_id_skipped(self):
+        enhancer = RecordRelationshipEnhancer(
+            relationship_records=self.REL_RECORDS, max_hop_depth=1
+        )
+        records = [dict(name="no_sys_id")]
+        enhancer.enhance_records_with_relationship_groups(records=records)
+
+        assert "relationship_groups" not in records[0]
+
+    def test_multihop_direction_up(self):
+        enhancer = RecordRelationshipEnhancer(
+            relationship_records=self.MULTIHOP_REL_RECORDS,
+            max_hop_depth=3,
+            multi_hop_direction="up",
+        )
+        records = [dict(sys_id="c2")]
+        enhancer.enhance_records_with_relationship_groups(records=records)
+
+        groups = records[0]["relationship_groups"]
+        assert "cn1_Runs_on" in groups
+        assert "pn1_Runs_on" in groups
+
+    def test_multihop_direction_down(self):
+        enhancer = RecordRelationshipEnhancer(
+            relationship_records=self.MULTIHOP_REL_RECORDS,
+            max_hop_depth=3,
+            multi_hop_direction="down",
+        )
+        records = [dict(sys_id="p1")]
+        enhancer.enhance_records_with_relationship_groups(records=records)
+
+        groups = records[0]["relationship_groups"]
+        assert "cn1_Runs" in groups
+        assert "cn2_Runs" in groups
+
+    def test_multihop_direction_both(self):
+        enhancer = RecordRelationshipEnhancer(
+            relationship_records=self.MULTIHOP_REL_RECORDS,
+            max_hop_depth=3,
+            multi_hop_direction="both",
+        )
+        records = [dict(sys_id="c1")]
+        enhancer.enhance_records_with_relationship_groups(records=records)
+
+        groups = records[0]["relationship_groups"]
+        assert "pn1_Runs_on" in groups
+        assert "cn2_Runs" in groups
+
+    def test_multihop_relationship_types_filter(self):
+        mixed_rel_records = self.MULTIHOP_REL_RECORDS + [
+            {
+                "parent.sys_id": "c1",
+                "child.name": "cn3",
+                "child.sys_class_name": "cmdb_ci_net",
+                "child.sys_id": "c3",
+                "parent.name": "cn1",
+                "parent.sys_class_name": "cmdb_ci_server",
+                "type.name": "Contains::Contained by",
+            },
+        ]
+
+        enhancer = RecordRelationshipEnhancer(
+            relationship_records=mixed_rel_records,
+            max_hop_depth=3,
+            multi_hop_direction="down",
+            multi_hop_relationship_types=["Runs on::Runs"],
+        )
+        records = [dict(sys_id="p1")]
+        enhancer.enhance_records_with_relationship_groups(records=records)
+
+        groups = records[0]["relationship_groups"]
+        assert "cn1_Runs" in groups
+        assert "cn2_Runs" in groups
+        assert "cn3_Contained_by" not in groups
+
+    def test_multihop_ci_classes_filter(self):
+        enhancer = RecordRelationshipEnhancer(
+            relationship_records=self.MULTIHOP_REL_RECORDS,
+            max_hop_depth=3,
+            multi_hop_direction="up",
+            multi_hop_ci_classes=["cmdb_ci_app"],
+        )
+        records = [dict(sys_id="c2")]
+        enhancer.enhance_records_with_relationship_groups(records=records)
+
+        groups = records[0]["relationship_groups"]
+        assert "pn1_Runs_on" in groups
+        assert "cn1_Runs_on" in groups
+
+    def test_one_sided_sys_id_produces_single_hop_group(self):
         rel_records = [
             {
-                "parent.sys_id": "s1",
-                "child.name": "child_name",
-                "child.sys_class_name": "child_sys_class_name",
-                "type.name": "Parent desc::Child desc",
-            }
+                "parent.sys_id": "p1",
+                "child.name": "cn1",
+                "child.sys_class_name": "cscn1",
+                "child.sys_id": "",
+                "parent.name": "pn1",
+                "parent.sys_class_name": "pscn1",
+                "type.name": "parent1::child1",
+            },
         ]
+        enhancer = RecordRelationshipEnhancer(
+            relationship_records=rel_records, max_hop_depth=2
+        )
+        records = [dict(sys_id="p1")]
+        enhancer.enhance_records_with_relationship_groups(records=records)
 
-        relations.enhance_records_with_rel_groups(records, rel_records)
-
-        assert records == []
-
-    def test_enhance_records_with_rel_groups(self):
-        records = [dict(sys_id="s1"), dict(sys_id="s2")]
-        rel_records = [
-            {
-                "parent.sys_id": "s1",
-                "child.name": "child_name",
-                "child.sys_class_name": "child_sys_class_name",
-                "type.name": "Parent desc::Child desc",
-            }
-        ]
-
-        relations.enhance_records_with_rel_groups(records, rel_records)
-
-        assert records == [
-            dict(sys_id="s1", relationship_groups=set(("child_name_Child_desc",))),
-            dict(sys_id="s2", relationship_groups=set()),
-        ]
+        assert "cn1_child1" in records[0]["relationship_groups"]


### PR DESCRIPTION
##### SUMMARY

Adds multi-hop relationship traversal to the `now` inventory plugin, allowing hosts to be grouped
based on distant CMDB relationships beyond immediate (single-hop) neighbors.

Refactors the standalone single-hop and multi-hop relationship functions into a unified
`RecordRelationshipEnhancer` class that parses relationship records once and uses BFS to
discover multi-hop groups up to a configurable depth.

New inventory options:
- `enhanced_multihop_max_depth` — maximum number of hops to traverse (default: 1, single-hop only)
- `enhanced_multihop_direction` — traversal direction: `up`, `down`, or `both`
- `enhanced_multihop_relationship_types` — optional filter for which relationship types to follow
- `enhanced_multihop_target_classes` — optional filter for which CI classes produce group names

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
now inventory plugin, relations module_utils

##### ADDITIONAL INFORMATION

The `RecordRelationshipEnhancer` class replaces the previous standalone functions
(`enhance_records_with_rel_groups`, `enhance_records_with_multihop_groups`, etc.)
with a single-pass parser that builds both single-hop groups and an adjacency map for
BFS traversal. Single-hop groups are always computed; multi-hop BFS only runs when
`enhanced_multihop_max_depth > 1`.

Example inventory configuration:
```yaml
plugin: servicenow.itsm.now
table: cmdb_ci_server
enhanced: true
enhanced_multihop_max_depth: 3
enhanced_multihop_direction: up
enhanced_multihop_relationship_types:
  - "Runs on::Runs"
enhanced_multihop_target_classes:
  - cmdb_ci_service_auto
```