### PR TITLE
add permission requirements to modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@ This collection is ideal for IT administrators, DevOps engineers, and automation
 - No additional Python libraries or external Ansible collections are required.
 - A ServiceNow instance and user credentials are required for module authentication.
 
+## ServiceNow permissions
+
+The account used to authenticate must be granted enough access on the ServiceNow
+side for the tables each module operates on. On a stock instance the `itil` role
+covers the common ITSM tables (incidents, problems, changes and their tasks),
+while configuration item modules require `itil` or `asset`. Because ServiceNow
+access is ultimately governed by per-instance ACLs, these out-of-the-box roles
+are guidance rather than a guarantee.
+
+See [ServiceNow permissions required by this collection](https://github.com/ansible-collections/servicenow.itsm/blob/main/docs/servicenow_permissions.md)
+for the full role matrix and setup recommendations. The required roles are also
+noted in each module's documentation.
+
 ## Installation
 
 Install the collection from Ansible Galaxy using:

--- a/changelogs/fragments/document_required_permissions.yml
+++ b/changelogs/fragments/document_required_permissions.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - Document the ServiceNow roles and permissions required to use the collection.
+    Added a ``docs/servicenow_permissions.md`` reference page with a per-module
+    role matrix, a note to every module's documentation, and a summary in the
+    README (https://github.com/ansible-collections/servicenow.itsm/issues/245).

--- a/docs/servicenow_permissions.md
+++ b/docs/servicenow_permissions.md
@@ -1,0 +1,99 @@
+# ServiceNow permissions required by this collection
+
+To use the modules and plugins in `servicenow.itsm`, the account that
+authenticates to your ServiceNow instance must be granted enough access on the
+ServiceNow side. This page documents the roles that are typically required.
+
+> **Important:** In ServiceNow, access is ultimately governed by
+> [Access Control Lists (ACLs)](https://www.servicenow.com/docs/bundle/zurich-platform-security/page/administer/contextual-security/concept/access-control-rules.html),
+> which every instance can customize. The roles listed here are the
+> **out-of-the-box (OOB) defaults** and should be treated as guidance, not a
+> guarantee. If a call authenticates successfully but returns empty results or a
+> `403`/`User Not Authorized` error, the cause is almost always an ACL that the
+> account does not satisfy. Use ServiceNow's *Debug Security* feature to see
+> exactly which ACL check fails.
+
+## The two layers of access
+
+A request from this collection must pass **two independent checks**:
+
+1. **REST API access.** The `snc_platform_rest_api_access` role controls whether
+   an account may call the platform REST APIs (Table, Attachment, Import Set,
+   Aggregate). The corresponding REST API ACLs are **inactive by default**, so on
+   a stock instance no extra role is needed. If your administrator has activated
+   the Table API ACL, the account additionally needs the
+   `snc_platform_rest_api_access` role (it replaced the older `rest_service`
+   role in the Kingston release).
+
+2. **Table / record access.** Even with REST access granted, the account still
+   needs a role (or a matching custom ACL) that permits read and/or write on the
+   specific table a module operates on. This is the layer described in the table
+   below.
+
+## Role requirements per module
+
+| Module(s) | ServiceNow table / API | Read | Create / Update / Delete |
+| --------- | ---------------------- | ---- | ------------------------ |
+| `incident`, `incident_info` | `incident` | `itil` | `itil` |
+| `problem`, `problem_info` | `problem` | `itil` | `itil` |
+| `problem_task`, `problem_task_info` | `problem_task` | `itil` | `itil` |
+| `change_request`, `change_request_info` | `change_request` | `itil` | `itil` (`change_manager` for change management) |
+| `change_request_task`, `change_request_task_info` | `change_task` | `itil` | `itil` |
+| `catalog_request`, `catalog_request_info` | `sc_request` | `sn_request_read`, `sn_request_write`, `catalog`, or `itil` | `sn_request_write` or `itil` |
+| `catalog_request_task`, `catalog_request_task_info` | `sc_task` | `sn_request_read`, `catalog`, or `itil` | `itil` (or a custom ACL) |
+| `configuration_item`, `configuration_item_batch` | `cmdb_ci` and subclasses | `itil` | `itil` **or** `asset` |
+| `configuration_item_info` | `cmdb_ci` and subclasses | `itil` | n/a (read only) |
+| `configuration_item_relations` | `cmdb_rel_ci` | `itil` | `itil` **or** `asset` |
+| `configuration_item_relations_info` | `cmdb_rel_ci` | `itil` | n/a (read only) |
+| `service_catalog`, `service_catalog_info` | Service Catalog API (`/api/sn_sc/servicecatalog`) | access to the catalog / item | access to order the catalog item |
+| `attachment_upload` | `sys_attachment` | — | write access on the **parent** record's table |
+| `attachment_info` | `sys_attachment` | read access on the **parent** record's table | — |
+| `api`, `api_info` | any table you target | depends on the target table | depends on the target table |
+
+### Notes on specific modules
+
+- **`itil` covers most ITSM tables.** Granting the `itil` role is the simplest
+  way to give an integration account read/write access to incidents, problems,
+  changes and their tasks. It is also the parent of the `sn_request_*` roles, so
+  `itil` users can access catalog requests as well.
+
+- **Catalog modules** (`catalog_request*`) can use the lower-privilege
+  `sn_request_read` / `sn_request_write` roles instead of `itil` when you want to
+  limit access to request tables only. Note that `sc_task` inherits field-level
+  ACLs from the parent `task` table, so writing to catalog tasks with a custom
+  role may require adding that role to those parent ACLs.
+
+- **Configuration items / CMDB** require `itil` or `asset` to create, update or
+  delete records in `cmdb_ci` and its subclasses. Be aware that, starting with
+  the Xanadu release (Patch 9), the `sn_cmdb_editor` and `sn_cmdb_admin` roles
+  **no longer** have create/update/delete access to `cmdb_ci`.
+
+- **Attachments** inherit their permissions from the parent record. To upload an
+  attachment to an incident, for example, the account needs write access to the
+  `incident` table.
+
+- **Service Catalog** (`service_catalog*`) uses a scripted REST API that mirrors
+  the catalog UI, so access is governed by whether the account can see and order
+  the relevant catalog items rather than by a dedicated table role.
+
+- **`api` / `api_info`** are generic and can target any table, so the required
+  role is whatever that table's ACLs demand.
+
+## Recommended setup for an integration account
+
+1. Create a dedicated ServiceNow user for automation and, on the user record,
+   select **Web service access only** so the account cannot log in to the UI.
+2. Grant the roles needed for the tables you automate — `itil` for broad ITSM
+   coverage, or a **custom role with targeted read/write ACLs** for least
+   privilege.
+3. Add `snc_platform_rest_api_access` **if** the platform REST API ACL is active
+   on your instance.
+4. If you loosen ACLs to give a non-`itil` account access, review the licensing
+   impact — widening record visibility can turn an account into a licensed user.
+
+## References
+
+- [Base system roles (Zurich)](https://www.servicenow.com/docs/bundle/zurich-platform-administration/page/administer/roles/reference/r_BaseSystemRoles.html)
+- [Service Catalog roles](https://www.servicenow.com/docs/r/roles-by-product/roles_servicecatalog.html)
+- [Service Catalog API reference](https://www.servicenow.com/docs/r/api-reference/rest-apis/c_ServiceCatalogAPI.html)
+- [Roles required to access the Service Catalog (KB0778265)](https://support.servicenow.com/kb?id=kb_article_view&sysparm_article=KB0778265)

--- a/plugins/doc_fragments/instance.py
+++ b/plugins/doc_fragments/instance.py
@@ -138,4 +138,13 @@ notes:
     U(https://www.servicenow.com/docs/r/platform-user-interface/t_EnableTinyURLSupport.html)."
   - If TinyURL support is not enabled and a query exceeds the URL length limit,
     the request will fail.
+  - "Permissions: the authenticating account must have a ServiceNow role that
+    grants access to the table(s) this module operates on. On a stock instance
+    the C(itil) role covers the common ITSM tables. If the platform REST API ACL
+    has been activated, the account additionally needs the
+    C(snc_platform_rest_api_access) role. Because access is ultimately governed
+    by per-instance ACLs, these out-of-the-box roles are guidance and not a
+    guarantee. See
+    U(https://github.com/ansible-collections/servicenow.itsm/blob/main/docs/servicenow_permissions.md)
+    for the full role matrix."
 """

--- a/plugins/modules/api.py
+++ b/plugins/modules/api.py
@@ -80,6 +80,9 @@ options:
         you have specified relative path to the file.
       - Template file needs to be present on the Ansible Controller's system. Otherwise, an error is raised.
     type: str
+notes:
+  - This module can target any ServiceNow table via the REST Table API, so the required
+    role depends on the table specified in I(resource).
 """
 
 

--- a/plugins/modules/api_info.py
+++ b/plugins/modules/api_info.py
@@ -88,6 +88,9 @@ options:
       - Default is set to C(false).
     type: bool
     default: False
+notes:
+  - This module can query any ServiceNow table via the REST Table API, so the required
+    role depends on the table specified in I(resource).
 """
 
 EXAMPLES = """

--- a/plugins/modules/attachment_info.py
+++ b/plugins/modules/attachment_info.py
@@ -40,6 +40,9 @@ options:
 
 notes:
   - Supports check_mode.
+  - This module reads from the ServiceNow C(sys_attachment) table. The
+    authenticating account needs read access to the parent record's table;
+    attachments inherit the parent record's permissions.
 """
 
 EXAMPLES = """

--- a/plugins/modules/attachment_upload.py
+++ b/plugins/modules/attachment_upload.py
@@ -40,6 +40,9 @@ options:
     required: true
 notes:
   - Supports check_mode.
+  - This module writes to the ServiceNow C(sys_attachment) table. The
+    authenticating account needs write access to the parent record's table
+    (I(table_name)); attachments inherit the parent record's permissions.
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/catalog_request.py
+++ b/plugins/modules/catalog_request.py
@@ -132,6 +132,9 @@ options:
       - For more information on optional parameters, refer to the ServiceNow
         catalog request documentation.
     type: dict
+notes:
+  - This module operates on the ServiceNow C(sc_request) table. Access is granted by the
+    C(itil) role or the lower-privilege C(sn_request_write)/C(sn_request_read) roles.
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/catalog_request_info.py
+++ b/plugins/modules/catalog_request_info.py
@@ -26,6 +26,9 @@ extends_documentation_fragment:
 seealso:
   - module: servicenow.itsm.catalog_request
   - module: servicenow.itsm.catalog_request_task_info
+notes:
+  - This module reads the ServiceNow C(sc_request) table. Access is granted by the
+    C(itil) role or the lower-privilege C(sn_request_read) role.
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/catalog_request_task.py
+++ b/plugins/modules/catalog_request_task.py
@@ -141,6 +141,10 @@ options:
       - For more information on optional parameters, refer to the ServiceNow
         catalog request task documentation.
     type: dict
+notes:
+  - This module operates on the ServiceNow C(sc_task) table, which the C(itil) role can
+    access by default. C(sc_task) inherits field-level ACLs from the parent C(task)
+    table.
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/catalog_request_task_info.py
+++ b/plugins/modules/catalog_request_task_info.py
@@ -26,6 +26,9 @@ extends_documentation_fragment:
 seealso:
   - module: servicenow.itsm.catalog_request
   - module: servicenow.itsm.catalog_request_task
+notes:
+  - This module reads the ServiceNow C(sc_task) table. Access is granted by the C(itil)
+    role or the lower-privilege C(sn_request_read) role.
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/change_request.py
+++ b/plugins/modules/change_request.py
@@ -150,6 +150,9 @@ options:
         change request documentation at
         U(https://docs.servicenow.com/bundle/tokyo-it-service-management/page/product/change-management/task/t_CreateAChange.html).
     type: dict
+notes:
+  - This module operates on the ServiceNow C(change_request) table, which the C(itil)
+    role can access by default.
 """
 
 EXAMPLES = """

--- a/plugins/modules/change_request_info.py
+++ b/plugins/modules/change_request_info.py
@@ -33,6 +33,9 @@ extends_documentation_fragment:
   - servicenow.itsm.sysparm_display_value
 seealso:
   - module: servicenow.itsm.change_request
+notes:
+  - This module reads the ServiceNow C(change_request) table, which the C(itil) role can
+    access by default.
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/change_request_task.py
+++ b/plugins/modules/change_request_task.py
@@ -137,6 +137,9 @@ options:
         change task documentation at
         U(https://docs.servicenow.com/bundle/tokyo-it-service-management/page/product/change-management/task/create-a-change-task.html).
     type: dict
+notes:
+  - This module operates on the ServiceNow C(change_task) table, which the C(itil) role
+    can access by default.
 """
 
 EXAMPLES = """

--- a/plugins/modules/change_request_task_info.py
+++ b/plugins/modules/change_request_task_info.py
@@ -31,6 +31,9 @@ extends_documentation_fragment:
   - servicenow.itsm.sysparm_display_value
 seealso:
   - module: servicenow.itsm.change_request_task
+notes:
+  - This module reads the ServiceNow C(change_task) table, which the C(itil) role can
+    access by default.
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/configuration_item.py
+++ b/plugins/modules/configuration_item.py
@@ -134,6 +134,10 @@ options:
       - For the attributes of configuration items specific to I(sys_class_name),
         please consult the relevant ServiceNow documentation.
     type: dict
+notes:
+  - This module operates on the ServiceNow C(cmdb_ci) table and its subclasses.
+    Creating, updating or deleting configuration items requires the C(itil) or C(asset)
+    role.
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/configuration_item_batch.py
+++ b/plugins/modules/configuration_item_batch.py
@@ -58,6 +58,9 @@ options:
       - Data is returned as string because ServiceNow API expect this
     required: true
     type: dict
+notes:
+  - This module operates on the ServiceNow C(cmdb_ci) table and its subclasses. Creating
+    or updating configuration items requires the C(itil) or C(asset) role.
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/configuration_item_info.py
+++ b/plugins/modules/configuration_item_info.py
@@ -62,6 +62,9 @@ options:
     elements: str
     required: false
     version_added: 2.4.0
+notes:
+  - This module reads the ServiceNow C(cmdb_ci) table and its subclasses, which the
+    C(itil) role can access by default.
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/configuration_item_relations.py
+++ b/plugins/modules/configuration_item_relations.py
@@ -75,6 +75,9 @@ options:
         type: str
         required: true
     required: true
+notes:
+  - This module manages CI relationships in the ServiceNow C(cmdb_rel_ci) table. Writing
+    requires the C(itil) or C(asset) role.
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/configuration_item_relations_info.py
+++ b/plugins/modules/configuration_item_relations_info.py
@@ -36,6 +36,9 @@ options:
 seealso:
   - module: servicenow.itsm.configuration_item_relations
 
+notes:
+  - This module reads CI relationships from the ServiceNow C(cmdb_rel_ci) table, which
+    the C(itil) role can access by default.
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/incident.py
+++ b/plugins/modules/incident.py
@@ -96,6 +96,9 @@ options:
         create incident documentation at
         U(https://docs.servicenow.com/bundle/tokyo-it-service-management/page/product/incident-management/task/create-an-incident.html).
     type: dict
+notes:
+  - This module operates on the ServiceNow C(incident) table, which the C(itil) role can
+    access by default.
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/incident_info.py
+++ b/plugins/modules/incident_info.py
@@ -32,6 +32,9 @@ extends_documentation_fragment:
   - servicenow.itsm.sysparm_display_value
 seealso:
   - module: servicenow.itsm.incident
+notes:
+  - This module reads the ServiceNow C(incident) table, which the C(itil) role can
+    access by default.
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/problem.py
+++ b/plugins/modules/problem.py
@@ -126,6 +126,9 @@ options:
     type: str
     default: /api/x_rhtpp_ansible/problem
     version_added: 2.0.0
+notes:
+  - This module operates on the ServiceNow C(problem) table, which the C(itil) role can
+    access by default.
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/problem_info.py
+++ b/plugins/modules/problem_info.py
@@ -33,6 +33,9 @@ seealso:
   - module: servicenow.itsm.problem
   - module: servicenow.itsm.problem_task
   - module: servicenow.itsm.problem_task_info
+notes:
+  - This module reads the ServiceNow C(problem) table, which the C(itil) role can access
+    by default.
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/problem_task.py
+++ b/plugins/modules/problem_task.py
@@ -106,6 +106,9 @@ options:
         create problem task documentation at
         U(https://docs.servicenow.com/bundle/tokyo-it-service-management/page/product/problem-management/task/create-problem-task.html).
     type: dict
+notes:
+  - This module operates on the ServiceNow C(problem_task) table, which the C(itil) role
+    can access by default.
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/problem_task_info.py
+++ b/plugins/modules/problem_task_info.py
@@ -32,6 +32,9 @@ seealso:
   - module: servicenow.itsm.problem_task
   - module: servicenow.itsm.problem
   - module: servicenow.itsm.problem_info
+notes:
+  - This module reads the ServiceNow C(problem_task) table, which the C(itil) role can
+    access by default.
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/service_catalog.py
+++ b/plugins/modules/service_catalog.py
@@ -62,6 +62,10 @@ options:
         description:
           - Name-value pairs of all mandatory cart item variables.
         type: dict
+notes:
+  - This module uses the ServiceNow Service Catalog API (C(/api/sn_sc/servicecatalog)).
+    Access depends on whether the authenticating account can see and order the relevant
+    catalog items rather than on a dedicated table role.
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/service_catalog_info.py
+++ b/plugins/modules/service_catalog_info.py
@@ -28,6 +28,9 @@ notes:
     pointer bug in a SNOW owned script included by the catalog, UIPolicyBuilder. If you need to
     gather full information about all catalogs in your instance, you should consider contacting
     SNOW support to discuss the best way to proceed in your environment.
+  - This module uses the ServiceNow Service Catalog API (C(/api/sn_sc/servicecatalog)).
+    Access depends on whether the authenticating account can see the relevant
+    catalog items rather than on a dedicated table role.
 
 version_added: 2.6.0
 


### PR DESCRIPTION
##### SUMMARY
Add permission requirements to each module notes section, as well as comprehensive perms doc.

Fixes https://github.com/ansible-collections/servicenow.itsm/issues/245

##### ISSUE TYPE
- Docs Pull Request
