### PR TITLE
docs(inventory): document sysparm_query for same-field AND filters

### DIFF
--- a/plugins/doc_fragments/query.py
+++ b/plugins/doc_fragments/query.py
@@ -17,12 +17,18 @@ options:
       - The data type of a field determines what operators are available for it.
         Refer to the ServiceNow Available Filters Queries documentation at
         U(https://docs.servicenow.com/bundle/tokyo-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html).
+      - Each field name can appear only once per list entry. To apply multiple conditions
+        to the same field (AND logic), use C(sysparm_query) with ServiceNow encoded query
+        syntax instead. Separate list entries under C(query) produce OR conditions.
       - Mutually exclusive with C(sysparm_query).
     type: list
     elements: dict
   sysparm_query:
     description:
       - An encoded query string used to filter the results as an alternative to C(query).
+      - Supports the full ServiceNow encoded query syntax including multiple conditions on
+        the same field (AND with C(^)), OR conditions (C(^OR) or C(^NQ)), and all operators
+        listed in the ServiceNow documentation.
       - Refer to the ServiceNow Available Filters Queries documentation at
         U(https://docs.servicenow.com/bundle/tokyo-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html).
       - If not set, the value of the C(SN_SYSPARM_QUERY) environment, if specified.

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -307,15 +307,10 @@ table: cmdb_ci_server
 query:
   - os: = Linux Red Hat   # match Linux Red Hat hosts
   - os: = Windows XP      # OR match Windows XP hosts
-
-# This approach is WRONG and will be neither AND nor OR. It will only maintain the last
-# instance of the duplicated key (`name` in this example)
----
-plugin: servicenow.itsm.now
-table: cmdb_ci_server
-query:
-  - name: STARTSWITH Database
-    name: ENDSWITH 1
+  # The following is WRONG and will be neither AND nor OR. It will only maintain the last
+  # instance of the duplicated key (`name` in this example)
+  # - name: STARTSWITH Database
+  #   name: ENDSWITH 1
 
 # Group hosts into named according to the specified criteria. Here, we created a group
 # of non-Windows production servers.

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -291,7 +291,6 @@ keyed_groups:
 #  |--@ungrouped:
 
 # Use sysparm_query for multiple AND conditions on the same field.
-# The query option only allows each field name once per entry (YAML drops duplicate keys).
 # sysparm_query uses ServiceNow encoded query syntax where ^ separates AND conditions.
 ---
 plugin: servicenow.itsm.now
@@ -301,21 +300,22 @@ columns:
   - name
   - ip_address
 
-# `ansible-inventory -i inventory.now.yaml --graph` output:
-# @all:
-#  |--@ungrouped:
-#  |  |--DatabaseServer1
+# the query param can do OR conditions, but cannot do AND
+---
+plugin: servicenow.itsm.now
+table: cmdb_ci_server
+query:
+  - os: = Linux Red Hat   # match Linux Red Hat hosts
+  - os: = Windows XP      # OR match Windows XP hosts
 
-
-# WARNING: duplicate keys in the same query entry do NOT work as expected.
-# YAML silently keeps only the last value, so only ENDSWITH is applied here:
-#
-# query:
-#   - name: STARTSWITH Database
-#     name: ENDSWITH 1          # <-- this overwrites the line above
-#
-# Use sysparm_query instead for same-field AND conditions (see example above).
-
+# This approach is WRONG and will be neither AND nor OR. It will only maintain the last
+# instance of the duplicated key (`name` in this example)
+---
+plugin: servicenow.itsm.now
+table: cmdb_ci_server
+query:
+  - name: STARTSWITH Database
+    name: ENDSWITH 1
 
 # Group hosts into named according to the specified criteria. Here, we created a group
 # of non-Windows production servers.

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -186,12 +186,18 @@ options:
       - The data type of a field determines what operators are available for it.
         Refer to the ServiceNow Available Filters Queries documentation at
         U(https://docs.servicenow.com/bundle/tokyo-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html).
+      - Each field name can appear only once per list entry. To apply multiple conditions
+        to the same field (AND logic), use C(sysparm_query) with ServiceNow encoded query
+        syntax instead. Separate list entries under C(query) produce OR conditions.
       - Mutually exclusive with C(sysparm_query).
     type: list
     elements: dict
   sysparm_query:
     description:
       - An encoded query string used to filter the results as an alternative to C(query).
+      - Supports the full ServiceNow encoded query syntax including multiple conditions on
+        the same field (AND with C(^)), OR conditions (C(^OR) or C(^NQ)), and all operators
+        listed in the ServiceNow documentation.
       - Refer to the ServiceNow Available Filters Queries documentation at
         U(https://docs.servicenow.com/bundle/tokyo-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html).
       - If not set, the value of the C(SN_SYSPARM_QUERY) environment, if specified.
@@ -283,6 +289,33 @@ keyed_groups:
 #  |  |--FileServerFloor2
 #  |  |--INSIGHT-NY-03
 #  |--@ungrouped:
+
+# Use sysparm_query for multiple AND conditions on the same field.
+# The query option only allows each field name once per entry (YAML drops duplicate keys).
+# sysparm_query uses ServiceNow encoded query syntax where ^ separates AND conditions.
+---
+plugin: servicenow.itsm.now
+table: cmdb_ci_server
+sysparm_query: "nameSTARTSWITHDatabase^nameENDSWITH1"
+columns:
+  - name
+  - ip_address
+
+# `ansible-inventory -i inventory.now.yaml --graph` output:
+# @all:
+#  |--@ungrouped:
+#  |  |--DatabaseServer1
+
+
+# WARNING: duplicate keys in the same query entry do NOT work as expected.
+# YAML silently keeps only the last value, so only ENDSWITH is applied here:
+#
+# query:
+#   - name: STARTSWITH Database
+#     name: ENDSWITH 1          # <-- this overwrites the line above
+#
+# Use sysparm_query instead for same-field AND conditions (see example above).
+
 
 # Group hosts into named according to the specified criteria. Here, we created a group
 # of non-Windows production servers.


### PR DESCRIPTION
## Summary

The `query` parameter silently drops duplicate YAML keys, so users cannot apply multiple AND conditions to the same field (e.g. `name STARTSWITH Database` AND `name ENDSWITH 1`). The `sysparm_query` parameter handles this correctly via ServiceNow encoded query syntax, but the inventory plugin docs had zero examples showing this.

- Added `sysparm_query` example demonstrating same-field AND filtering
- Added warning about duplicate YAML keys being silently dropped in `query` entries
- Documented the same-field limitation in `query` parameter descriptions
- Updated shared `doc_fragments/query.py` for consistency across all modules

## Verified Behavior

| User writes | Hosts returned | Result |
|---|---|---|
| `query` with duplicate `name:` keys | 12 | Only last key applied (wrong) |
| `sysparm_query: nameSTARTSWITHDatabase^nameENDSWITH1` | 1 | Both conditions applied (correct) |

Fixes: https://redhat.atlassian.net/browse/AAP-91763
Related upstream issue: https://github.com/ansible-collections/servicenow.itsm/issues/476